### PR TITLE
Storing "Show Opacity Slider" switch state

### DIFF
--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		1586E120242209BC00DA5625 /* OAPointHeaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1586E11E242209BB00DA5625 /* OAPointHeaderCell.xib */; };
 		1586E123242209F300DA5625 /* OAPointHeaderTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1586E121242209F200DA5625 /* OAPointHeaderTableViewCell.m */; };
 		1586E124242209F300DA5625 /* OAPointHeaderTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1586E121242209F200DA5625 /* OAPointHeaderTableViewCell.m */; };
+		33DBD3292494DA1F006F8F66 /* OAMapOpacitySliderToggler.m in Sources */ = {isa = PBXBuildFile; fileRef = 33DBD3252494D9C4006F8F66 /* OAMapOpacitySliderToggler.m */; };
+		33DBD32A2494DA21006F8F66 /* OAMapOpacitySliderToggler.m in Sources */ = {isa = PBXBuildFile; fileRef = 33DBD3252494D9C4006F8F66 /* OAMapOpacitySliderToggler.m */; };
 		3A02BFB71A31F2FA0019377F /* OAGPXListViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3A02BFB31A31F2FA0019377F /* OAGPXListViewController.mm */; };
 		3A02BFBF1A31FA820019377F /* icon_gpx_fill@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3A02BFBB1A31FA820019377F /* icon_gpx_fill@2x.png */; };
 		3A02BFC21A31FA820019377F /* icon_star@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3A02BFBC1A31FA820019377F /* icon_star@2x.png */; };
@@ -5780,6 +5782,8 @@
 		1586E121242209F200DA5625 /* OAPointHeaderTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OAPointHeaderTableViewCell.m; path = Controllers/Cells/OAPointHeaderTableViewCell.m; sourceTree = "<group>"; };
 		1586E122242209F300DA5625 /* OAPointHeaderTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OAPointHeaderTableViewCell.h; path = Controllers/Cells/OAPointHeaderTableViewCell.h; sourceTree = "<group>"; };
 		2CFA9B52B7169930B7654453 /* Pods-OsmAnd Maps.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OsmAnd Maps.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OsmAnd Maps/Pods-OsmAnd Maps.debug.xcconfig"; sourceTree = "<group>"; };
+		33DBD3242494D997006F8F66 /* OAMapOpacitySliderToggler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OAMapOpacitySliderToggler.h; path = Controllers/Panels/OAMapOpacitySliderToggler.h; sourceTree = "<group>"; };
+		33DBD3252494D9C4006F8F66 /* OAMapOpacitySliderToggler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OAMapOpacitySliderToggler.m; path = Controllers/Panels/OAMapOpacitySliderToggler.m; sourceTree = "<group>"; };
 		3A02BFB21A31F2FA0019377F /* OAGPXListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OAGPXListViewController.h; path = Sources/Controllers/2.0/OAGPXListViewController.h; sourceTree = "<group>"; };
 		3A02BFB31A31F2FA0019377F /* OAGPXListViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = OAGPXListViewController.mm; path = Sources/Controllers/2.0/OAGPXListViewController.mm; sourceTree = "<group>"; };
 		3A02BFBB1A31FA820019377F /* icon_gpx_fill@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "icon_gpx_fill@2x.png"; path = "Resources/Icons/icon_gpx_fill@2x.png"; sourceTree = "<group>"; };
@@ -13441,6 +13445,8 @@
 				BBA3AF031975016F0039D991 /* OAMapPanelViewController.mm */,
 				3A9173981A09203D000B22C5 /* OAOptionsPanelBlackViewController.h */,
 				3A9173991A09203D000B22C5 /* OAOptionsPanelBlackViewController.m */,
+				33DBD3242494D997006F8F66 /* OAMapOpacitySliderToggler.h */,
+				33DBD3252494D9C4006F8F66 /* OAMapOpacitySliderToggler.m */,
 			);
 			name = Panels;
 			sourceTree = "<group>";
@@ -19431,6 +19437,7 @@
 				DA7235282164C33400FE18D1 /* OAMoreOptionsBottomSheetViewController.mm in Sources */,
 				847A1D551DF94E9B003C1246 /* OADestinationViewController.mm in Sources */,
 				DA68629122CCB25F00C32E32 /* OATableViewCustomFooterView.m in Sources */,
+				33DBD32A2494DA21006F8F66 /* OAMapOpacitySliderToggler.m in Sources */,
 				DA5AA2DC2351C97300DF0B7B /* OAHomeWorkCollectionViewCell.mm in Sources */,
 				DAE47428231E66CC00E5292D /* GpxUIHelper.swift in Sources */,
 				DA9C6248221D41380087E140 /* OAOsmEditingViewController.mm in Sources */,
@@ -19825,6 +19832,7 @@
 				DAF820D62369D136007003FA /* OARouteProgressBarCell.mm in Sources */,
 				DA23E1ED23361A2B0056F4A8 /* OAAppModeView.m in Sources */,
 				BBA3AFF819854D8F0039D991 /* OAResourcesInstaller.mm in Sources */,
+				33DBD3292494DA1F006F8F66 /* OAMapOpacitySliderToggler.m in Sources */,
 				BBA3AF51197FC4BB0039D991 /* OAMapPanelViewController.mm in Sources */,
 				845AFB3F1E261A4900170026 /* OAObjectType.m in Sources */,
 				84C86A1B1FB988DA00AA7C1B /* OATopTextView.mm in Sources */,

--- a/OsmAnd.xcworkspace/contents.xcworkspacedata
+++ b/OsmAnd.xcworkspace/contents.xcworkspacedata
@@ -1,1 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:OsmAnd.xcodeproj'/><FileRef location='group:../baked/fat-ios-clang.xcode/OsmAnd_projects.xcodeproj'/><FileRef location='group:Pods/Pods.xcodeproj'/></Workspace>
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:OsmAnd.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:../baked/fat-ios-clang.xcode/OsmAnd_projects.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/OsmAnd.xcworkspace/contents.xcworkspacedata
+++ b/OsmAnd.xcworkspace/contents.xcworkspacedata
@@ -1,13 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "group:OsmAnd.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:../baked/fat-ios-clang.xcode/OsmAnd_projects.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Pods/Pods.xcodeproj">
-   </FileRef>
-</Workspace>
+<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:OsmAnd.xcodeproj'/><FileRef location='group:../baked/fat-ios-clang.xcode/OsmAnd_projects.xcodeproj'/><FileRef location='group:Pods/Pods.xcodeproj'/></Workspace>

--- a/Sources/Controllers/2.0/OAMapSettingsMainScreen.mm
+++ b/Sources/Controllers/2.0/OAMapSettingsMainScreen.mm
@@ -25,6 +25,7 @@
 #import "OAPOIUIFilter.h"
 #import "OAMapSettingsOverlayUnderlayScreen.h"
 #import "Reachability.h"
+#import "OAMapOpacitySliderToggler.h"
 
 #include <OsmAndCore.h>
 #include <OsmAndCore/Utilities.h>
@@ -44,6 +45,7 @@
     OsmAndAppInstance _app;
     OAAppSettings *_settings;
     OAIAPHelper *_iapHelper;
+    OAMapOpacitySliderToggler *_opacitySliderToggler;
     
     OAMapStyleSettings *styleSettings;
     NSArray *_filteredTopLevelParams;
@@ -70,6 +72,7 @@
         _app = [OsmAndApp instance];
         _settings = [OAAppSettings sharedManager];
         _iapHelper = [OAIAPHelper sharedInstance];
+        _opacitySliderToggler = [OAMapOpacitySliderToggler sharedInstance];
         
         title = OALocalizedString(@"map_settings_map");
 
@@ -566,6 +569,8 @@
                 OAMapSettingsViewController *mapSettingsViewController = [[OAMapSettingsViewController alloc] initWithSettingsScreen:EMapSettingsScreenOverlay];
                 [mapSettingsViewController show:vwController.parentViewController parentViewController:vwController animated:YES];
             }
+            
+            [_opacitySliderToggler showOpacitySlider];
         }
         else
             _app.data.overlayMapSource = nil;
@@ -608,6 +613,8 @@
                 OAMapSettingsViewController *mapSettingsViewController = [[OAMapSettingsViewController alloc] initWithSettingsScreen:EMapSettingsScreenUnderlay];
                 [mapSettingsViewController show:vwController.parentViewController parentViewController:vwController animated:YES];
             }
+            
+            [_opacitySliderToggler showOpacitySlider];
         }
         else
         {

--- a/Sources/Controllers/2.0/OAMapSettingsOverlayUnderlayScreen.mm
+++ b/Sources/Controllers/2.0/OAMapSettingsOverlayUnderlayScreen.mm
@@ -25,6 +25,7 @@
 #import "OAOnlineTilesEditingViewController.h"
 #import "OAMapCreatorHelper.h"
 #import "OAAutoObserverProxy.h"
+#import "OAMapOpacitySliderToggler.h"
 
 #include <QSet>
 
@@ -97,6 +98,7 @@ static NSInteger kButtonsSection;
     OAMapStyleSettings *_styleSettings;
     OAMapStyleParameter *_hidePolygonsParameter;
     OAAutoObserverProxy *_sqlitedbResourcesChangedObserver;
+    OAMapOpacitySliderToggler *_opacitySliderToggler;
 }
 
 @synthesize settingsScreen, tableData, vwController, tblView, title, isOnlineMapSource;
@@ -109,6 +111,7 @@ static NSInteger kButtonsSection;
     {
         _app = [OsmAndApp instance];
         _settings = [OAAppSettings sharedManager];
+        _opacitySliderToggler = [OAMapOpacitySliderToggler sharedInstance];
         
         if ([param isEqualToString:@"overlay"]) {
             _mapSettingType = EMapSettingOverlay;
@@ -469,7 +472,16 @@ static NSInteger kButtonsSection;
             [cell.switchView removeTarget:self action:NULL forControlEvents:UIControlEventValueChanged];
             if (indexPath.section == kMapVisibilitySection)
             {
-                [cell.switchView setOn: [[OARootViewController instance].mapPanel isOverlayUnderlayViewVisible]];
+                
+                if ([item[@"title"] isEqualToString:OALocalizedString(@"map_settings_show_slider_map")])
+                {
+                    [cell.switchView setOn: [_opacitySliderToggler isOpacitySliderEnabled]];
+                }
+                else
+                {
+                    [cell.switchView setOn: [[OARootViewController instance].mapPanel isOverlayUnderlayViewVisible]];
+                }
+                
                 [cell.switchView addTarget:self action:@selector(onShowSwitchChanged:) forControlEvents:UIControlEventValueChanged];
             }
             else
@@ -594,6 +606,8 @@ static NSInteger kButtonsSection;
             [tblView insertSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, _data.count - 1)] withRowAnimation:UITableViewRowAnimationFade];
             [tblView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:0 inSection:0]] withRowAnimation:UITableViewRowAnimationAutomatic];
             [tblView endUpdates];
+            
+            [_opacitySliderToggler showOpacitySlider];
         }
         else
         {
@@ -625,7 +639,10 @@ static NSInteger kButtonsSection;
 {
     UISwitch *switchView = (UISwitch*)sender;
     if (switchView)
+    {
+        [_opacitySliderToggler setIsOpacitySliderEnabled: switchView.isOn];
         [[OARootViewController instance].mapPanel updateOverlayUnderlayView:switchView.isOn];
+    }
 }
 
 - (void) hidePolygons:(BOOL)hide

--- a/Sources/Controllers/Panels/OAMapOpacitySliderToggler.h
+++ b/Sources/Controllers/Panels/OAMapOpacitySliderToggler.h
@@ -1,0 +1,16 @@
+//
+//  OAMapOpacitySliderToggler.h
+//  OsmAnd
+//
+//  Created by nnngrach on 12.06.2020.
+//  Copyright © 2020 OsmAnd. All rights reserved.
+//
+
+@interface OAMapOpacitySliderToggler : NSObject
+
++ (OAMapOpacitySliderToggler *) sharedInstance;
+- (BOOL)isOpacitySliderEnabled;
+- (void)setIsOpacitySliderEnabled: (BOOL)isEnabled;
+- (void)showOpacitySlider;
+
+@end

--- a/Sources/Controllers/Panels/OAMapOpacitySliderToggler.m
+++ b/Sources/Controllers/Panels/OAMapOpacitySliderToggler.m
@@ -1,0 +1,57 @@
+//
+//  OAMapOpacitySliderToggler.m
+//  OsmAnd Maps
+//
+//  Created by nnngrach on 12.06.2020.
+//  Copyright © 2020 OsmAnd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "OAMapOpacitySliderToggler.h"
+#import "OARootViewController.h"
+#import "OAAppSettings.h"
+
+@implementation OAMapOpacitySliderToggler
+{
+     OAAppSettings *_settings;
+}
+
+
+static OAMapOpacitySliderToggler *sharedSingleton_ = nil;
+
++ (OAMapOpacitySliderToggler *) sharedInstance
+{
+    if (sharedSingleton_ == nil)
+    {
+        sharedSingleton_ = [[OAMapOpacitySliderToggler alloc] init];
+        [sharedSingleton_ initParameters];
+    }
+    return sharedSingleton_;
+}
+
+
+- (void) initParameters
+{
+    _settings = [OAAppSettings sharedManager];
+}
+
+
+
+- (BOOL)isOpacitySliderEnabled
+{
+    return [_settings mapSettingShowOpacitySlider];
+}
+
+- (void)setIsOpacitySliderEnabled: (BOOL)isEnabled
+{
+    [_settings setMapSettingShowOpacitySlider:isEnabled];
+}
+
+
+- (void)showOpacitySlider
+{
+    [[OARootViewController instance].mapPanel updateOverlayUnderlayView:[self isOpacitySliderEnabled]];
+}
+
+@end

--- a/Sources/Helpers/OAAppSettings.h
+++ b/Sources/Helpers/OAAppSettings.h
@@ -356,6 +356,7 @@ typedef NS_ENUM(NSInteger, EOARulerWidgetMode)
 @property (assign, nonatomic) BOOL mapSettingShowFavorites;
 @property (assign, nonatomic) BOOL mapSettingShowOfflineEdits;
 @property (assign, nonatomic) BOOL mapSettingShowOnlineNotes;
+@property (assign, nonatomic) BOOL mapSettingShowOpacitySlider;
 @property (nonatomic) NSArray *mapSettingVisibleGpx;
 
 @property (nonatomic) NSString *billingUserId;

--- a/Sources/Helpers/OAAppSettings.m
+++ b/Sources/Helpers/OAAppSettings.m
@@ -31,6 +31,7 @@
 #define mapSettingShowFavoritesKey @"mapSettingShowFavoritesKey"
 #define mapSettingShowOfflineEditsKey @"mapSettingShowOfflineEditsKey"
 #define mapSettingShowOnlineNotesKey @"mapSettingShowOnlineNotesKey"
+#define mapSettingShowOpacitySliderKey @"mapSettingShowOpacitySliderKey"
 #define mapSettingVisibleGpxKey @"mapSettingVisibleGpxKey"
 
 #define billingUserIdKey @"billingUserIdKey"
@@ -1226,6 +1227,7 @@
 @synthesize mapSettingShowFavorites=_mapSettingShowFavorites, mapSettingShowOfflineEdits=_mapSettingShowOfflineEdits;
 @synthesize mapSettingShowOnlineNotes=_mapSettingShowOnlineNotes, settingPrefMapLanguage=_settingPrefMapLanguage;
 @synthesize settingMapLanguageShowLocal=_settingMapLanguageShowLocal, settingMapLanguageTranslit=_settingMapLanguageTranslit;
+@synthesize mapSettingShowOpacitySlider=_mapSettingShowOpacitySlider;
 
 + (OAAppSettings*) sharedManager
 {
@@ -1306,6 +1308,7 @@
         _mapSettingShowFavorites = [[NSUserDefaults standardUserDefaults] objectForKey:mapSettingShowFavoritesKey] ? [[NSUserDefaults standardUserDefaults] boolForKey:mapSettingShowFavoritesKey] : NO;
         _mapSettingShowOfflineEdits = [[NSUserDefaults standardUserDefaults] objectForKey:mapSettingShowOfflineEditsKey] ? [[NSUserDefaults standardUserDefaults] boolForKey:mapSettingShowOfflineEditsKey] : YES;
         _mapSettingShowOnlineNotes = [[NSUserDefaults standardUserDefaults] objectForKey:mapSettingShowOnlineNotesKey] ? [[NSUserDefaults standardUserDefaults] boolForKey:mapSettingShowOnlineNotesKey] : NO;
+        _mapSettingShowOpacitySlider = [[NSUserDefaults standardUserDefaults] objectForKey:mapSettingShowOpacitySliderKey] ? [[NSUserDefaults standardUserDefaults] boolForKey:mapSettingShowOpacitySliderKey] : NO;
         _mapSettingVisibleGpx = [[NSUserDefaults standardUserDefaults] objectForKey:mapSettingVisibleGpxKey] ? [[NSUserDefaults standardUserDefaults] objectForKey:mapSettingVisibleGpxKey] : @[];
 
         _mapSettingTrackRecording = [[NSUserDefaults standardUserDefaults] objectForKey:mapSettingTrackRecordingKey] ? [[NSUserDefaults standardUserDefaults] boolForKey:mapSettingTrackRecordingKey] : NO;
@@ -1836,6 +1839,12 @@
                                            Visibility:NO];
         }
     }
+}
+
+- (void) setMapSettingShowOpacitySlider:(BOOL)mapSettingShowOpacitySlider
+{
+    _mapSettingShowOpacitySlider = mapSettingShowOpacitySlider;
+    [[NSUserDefaults standardUserDefaults] setBool:_mapSettingShowOpacitySlider forKey:mapSettingShowOpacitySliderKey];
 }
 
 - (void) setMapSettingTrackRecording:(BOOL)mapSettingTrackRecording

--- a/Sources/QuickAction/Actions/OAMapOverlayAction.mm
+++ b/Sources/QuickAction/Actions/OAMapOverlayAction.mm
@@ -13,6 +13,7 @@
 #import "Localization.h"
 #import "OAQuickActionSelectionBottomSheetViewController.h"
 #import "OAQuickActionType.h"
+#import "OAMapOpacitySliderToggler.h"
 
 #define KEY_OVERLAYS @"overlays"
 #define KEY_NO_OVERLAY @"no_overlay"
@@ -21,11 +22,16 @@ static OAQuickActionType *TYPE;
 
 @implementation OAMapOverlayAction
 
+{
+    OAMapOpacitySliderToggler *_opacitySliderToggler;
+}
+
 - (instancetype) init
 {
     self = [super initWithActionType:self.class.TYPE];
     if (self)
     {
+        _opacitySliderToggler = [OAMapOpacitySliderToggler sharedInstance];
         [super commonInit];
     }
     return self;
@@ -65,6 +71,8 @@ static OAQuickActionType *TYPE;
             nextSource = sources[index + 1];
         
         [self executeWithParams:nextSource];
+        
+        [_opacitySliderToggler showOpacitySlider];
     }
 }
 

--- a/Sources/QuickAction/Actions/OAMapUnderlayAction.mm
+++ b/Sources/QuickAction/Actions/OAMapUnderlayAction.mm
@@ -14,6 +14,7 @@
 #import "OAQuickActionSelectionBottomSheetViewController.h"
 #import "OAMapStyleSettings.h"
 #import "OAQuickActionType.h"
+#import "OAMapOpacitySliderToggler.h"
 
 #define KEY_UNDERLAYS @"underlays"
 #define KEY_NO_UNDERLAY @"no_underlay"
@@ -24,6 +25,7 @@ static OAQuickActionType *TYPE;
 {
     OAMapStyleSettings *_styleSettings;
     OAMapStyleParameter *_hidePolygonsParameter;
+    OAMapOpacitySliderToggler *_opacitySliderToggler;
 }
 
 - (instancetype) init
@@ -33,7 +35,7 @@ static OAQuickActionType *TYPE;
     {
         _styleSettings = [OAMapStyleSettings sharedInstance];
         _hidePolygonsParameter = [_styleSettings getParameter:@"noPolygons"];
-
+        _opacitySliderToggler = [OAMapOpacitySliderToggler sharedInstance];
         [super commonInit];
     }
     return self;
@@ -73,6 +75,8 @@ static OAQuickActionType *TYPE;
             nextSource = sources[index + 1];
         
         [self executeWithParams:nextSource];
+        
+        [_opacitySliderToggler showOpacitySlider];
     }
 }
 

--- a/Sources/QuickAction/OAQuickActionRegistry.m
+++ b/Sources/QuickAction/OAQuickActionRegistry.m
@@ -34,6 +34,8 @@
 #import "OANavAutoZoomMapAction.h"
 #import "OANavStartStopAction.h"
 #import "OANavResumePauseAction.h"
+#import "OAMapOverlayAction.h"
+#import "OAMapUnderlayAction.h"
 //#import "OASwitchProfileAction.h"
 
 #define kType @"type"
@@ -118,6 +120,8 @@ static OAQuickActionType *TYPE_NAVIGATION;
     [quickActionTypes addObject:OAShowHidePoiAction.TYPE];
     [quickActionTypes addObject:OAMapStyleAction.TYPE];
     [quickActionTypes addObject:OADayNightModeAction.TYPE];
+    [quickActionTypes addObject:OAMapOverlayAction.TYPE];
+    [quickActionTypes addObject:OAMapUnderlayAction.TYPE];
     //        [quickActionTypes addObject:OAShowHideTransportLinesAction.TYPE];
     // navigation
     [quickActionTypes addObject:OANavVoiceAction.TYPE];


### PR DESCRIPTION
Implemented saving of the ShowOpacitySlider switch state. This state will be loaded when you turn on the overlay/underlay layer from the map settings menu, overlay/underlay settings menu, quick actions menu. If the stored state is on, the transparency slider will automatically appear on the screen.

![screenshot](https://drive.google.com/uc?export=download&id=12fofEZY97QHQvGVkzz3w1tG1yi3higyv)