### PR TITLE
Add more keyboard shortcuts

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1700,6 +1700,7 @@
 "key_hint_select" = "Select";
 "key_hint_deselect" = "Deselect";
 "key_hint_goback" = "Go Back";
+"key_hint_recenter_map" = "Recenter Map"
 
 "wiki_buy_description" = "To read full articles - buy Wikipedia plugin and download Wikipedia data of %@";
 "wiki_download_description" = "To read full articles - download Wikipedia data of %@";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1700,7 +1700,7 @@
 "key_hint_select" = "Select";
 "key_hint_deselect" = "Deselect";
 "key_hint_goback" = "Go Back";
-"key_hint_recenter_map" = "Recenter Map"
+"key_hint_recenter_map" = "Recenter Map";
 
 "wiki_buy_description" = "To read full articles - buy Wikipedia plugin and download Wikipedia data of %@";
 "wiki_download_description" = "To read full articles - download Wikipedia data of %@";

--- a/Sources/Controllers/OARootViewController.m
+++ b/Sources/Controllers/OARootViewController.m
@@ -831,7 +831,7 @@ typedef enum : NSUInteger {
              [UIKeyCommand keyCommandWithInput:@"+" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn) discoverabilityTitle:OALocalizedString(@"key_hint_zoom_in")],
              [UIKeyCommand keyCommandWithInput:@"=" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn)],
              [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(goBack) discoverabilityTitle:OALocalizedString(@"key_hint_goback")],
-             [UIKeyCommand keyCommandWithInput:@"0" modifierFlags:UIKeyModifierCommand action:@selector(recenterMap) discoverabilityTitle:OALocalizedString(@"sett_arr_map")]];
+             [UIKeyCommand keyCommandWithInput:@"0" modifierFlags:UIKeyModifierCommand action:@selector(recenterMap) discoverabilityTitle:OALocalizedString(@"key_hint_recenter_map")]];
 }
 
 - (void) zoomOut

--- a/Sources/Controllers/OARootViewController.m
+++ b/Sources/Controllers/OARootViewController.m
@@ -831,7 +831,7 @@ typedef enum : NSUInteger {
              [UIKeyCommand keyCommandWithInput:@"+" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn) discoverabilityTitle:OALocalizedString(@"key_hint_zoom_in")],
              [UIKeyCommand keyCommandWithInput:@"=" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn)],
              [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(goBack) discoverabilityTitle:OALocalizedString(@"key_hint_goback")],
-             [UIKeyCommand keyCommandWithInput:@"0" modifierFlags:UIKeyModifierCommand action:@selector(recenterMap) discoverabilityTitle:@"Recenter the map"]];
+             [UIKeyCommand keyCommandWithInput:@"0" modifierFlags:UIKeyModifierCommand action:@selector(recenterMap) discoverabilityTitle:OALocalizedString(@"sett_arr_map")]];
 }
 
 - (void) zoomOut

--- a/Sources/Controllers/OARootViewController.m
+++ b/Sources/Controllers/OARootViewController.m
@@ -17,6 +17,7 @@
 #import <Reachability.h>
 
 #import "OAAppDelegate.h"
+#import "OAMapViewTrackingUtilities.h"
 #import "OAMenuOriginViewControllerProtocol.h"
 #import "OAMenuViewControllerProtocol.h"
 #import "OAFavoriteImportViewController.h"
@@ -824,9 +825,13 @@ typedef enum : NSUInteger {
 
 - (NSArray *) keyCommands
 {
-    return @[[UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow modifierFlags:0 action:@selector(zoomOut) discoverabilityTitle:OALocalizedString(@"key_hint_zoom_out")],
-             [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow modifierFlags:0 action:@selector(zoomIn) discoverabilityTitle:OALocalizedString(@"key_hint_zoom_in")],
-             [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(goBack) discoverabilityTitle:OALocalizedString(@"key_hint_goback")]];
+    return @[[UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow modifierFlags:0 action:@selector(zoomOut)],
+             [UIKeyCommand keyCommandWithInput:@"-" modifierFlags:UIKeyModifierCommand action:@selector(zoomOut) discoverabilityTitle:OALocalizedString(@"key_hint_zoom_out")],
+             [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow modifierFlags:0 action:@selector(zoomIn)],
+             [UIKeyCommand keyCommandWithInput:@"+" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn) discoverabilityTitle:OALocalizedString(@"key_hint_zoom_in")],
+             [UIKeyCommand keyCommandWithInput:@"=" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn)],
+             [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(goBack) discoverabilityTitle:OALocalizedString(@"key_hint_goback")],
+             [UIKeyCommand keyCommandWithInput:@"0" modifierFlags:UIKeyModifierCommand action:@selector(recenterMap) discoverabilityTitle:@"Recenter the map"]];
 }
 
 - (void) zoomOut
@@ -854,6 +859,13 @@ typedef enum : NSUInteger {
         if (canOpenURL)
             [[UIApplication sharedApplication] openURL:[NSURL URLWithString:wunderlinqAppURL] options:@{} completionHandler:nil];
     }
+}
+
+- (void) recenterMap
+{
+    if ([[OAAppSettings sharedManager].settingExternalInputDevice get] != NO_EXTERNAL_DEVICE)
+        [[OAMapViewTrackingUtilities instance] backToLocationImpl];
+    
 }
 
 #pragma mark SFSafariViewControllerDelegate


### PR DESCRIPTION
## Why?:
Lots of apps seem to implement their own shortcuts which creates confusion for the end-user. Zooming on an Apple Mac or iOS app has always used `CMD +` and `CMD -`. Resetting the zoom level normally is `CMD 0`.

So to be more in line with Apple's default shortcuts from apps like Apple Maps which use `CMD +` and `CMD -`. I have added these as defaults.

A dedicated re-center button (`CMD 0`) is useful when the map was moved or zoomed, to quickly get back to the current location.

## Added:

`CMD +` for Zoom In (With a hidden alternative of CMD = to also make it work on non numeric keyboards without much confusion.
`CMD -` for Zoom Out
`CMD 0` for recentering the map.

## Changed:
The **original zoom in and zoom out** on the arrow keys are still active but not shown in the help popup when holding down CMD for backwards compatibility. We might want to re-use these keys to move the map around sometime in the future.

## Notes:
Someone else added the check for an external input device a while back. I left it in there because am not sure if this is needed. But there is no way to use keyboard shortcuts in iOS without a hardware keyboard so IMHO that could maybe be removed.