### PR TITLE
Added in support for enhanced voices

### DIFF
--- a/Sources/Voice/OATTSCommandPlayerImpl.mm
+++ b/Sources/Voice/OATTSCommandPlayerImpl.mm
@@ -69,9 +69,22 @@
         [toSpeak appendString:utterance];
     }
     AVSpeechUtterance *utterance = [AVSpeechUtterance speechUtteranceWithString:toSpeak];
-    utterance.voice = [AVSpeechSynthesisVoice voiceWithLanguage:voiceProvider];
+    utterance.voice = [self voiceToUse];
     [utterance setRate:0.5f];
     [synthesizer speakUtterance:utterance];
+}
+
+- (AVSpeechSynthesisVoice *)voiceToUse {
+    NSArray<AVSpeechSynthesisVoice *> *allVoices = [AVSpeechSynthesisVoice speechVoices];
+    NSMutableArray<AVSpeechSynthesisVoice *> *allEnhancedVoicesForLanguage = [[NSMutableArray alloc] init];
+
+    for (AVSpeechSynthesisVoice *voice in allVoices) {
+        if (voice.quality == AVSpeechSynthesisVoiceQualityEnhanced && [voice.language hasPrefix:voiceProvider]) {
+            [allEnhancedVoicesForLanguage insertObject:voice atIndex:0];
+        }
+    }
+
+    return allEnhancedVoicesForLanguage.firstObject ? : [AVSpeechSynthesisVoice voiceWithLanguage:voiceProvider];
 }
 
 - (OACommandBuilder *)newCommandBuilder {


### PR DESCRIPTION
This PR tries to use the Apple provided enhanced voices (these have to be manually downloaded by a user in devices settings [Settings -> Accessibility -> Voice Over -> Speech -> Voice])

This change will make the app search for enhanced voices that are available for the chosen language first before defaulting to the previously chosen voices.

Let me know if there's any changes I should make to improve this PR or if there's a guide I've missed to adhere to standards e.t.c.