### PR TITLE
Support generic GPX Uniform Type Identifier

### DIFF
--- a/OsmAnd Maps copy-Info.plist
+++ b/OsmAnd Maps copy-Info.plist
@@ -12,12 +12,12 @@
 			<key>CFBundleTypeIconFiles</key>
 			<array/>
 			<key>CFBundleTypeName</key>
-			<string>GPS eXchange format</string>
+			<string>GPS Exchange Format (GPX)</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>net.osmand.gpx</string>
+				<string>com.topografix.gpx</string>
 			</array>
 		</dict>
 		<dict>
@@ -139,9 +139,11 @@
 				<string>public.xml</string>
 			</array>
 			<key>UTTypeDescription</key>
-			<string>GPX eXchange format</string>
+			<string>GPS Exchange Format (GPX)</string>
 			<key>UTTypeIdentifier</key>
-			<string>net.osmand.gpx</string>
+			<string>com.topografix.gpx</string>
+			<key>UTTypeReferenceURL</key>
+			<string>http://www.topografix.com/GPX/1/</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -150,7 +152,9 @@
 					<string>GPX</string>
 				</array>
 				<key>public.mime-type</key>
-				<string>application/gpx+xml</string>
+				<array>
+					<string>application/gpx+xml</string>
+				</array>
 			</dict>
 		</dict>
 		<dict>
@@ -185,9 +189,11 @@
 				<string>public.xml</string>
 			</array>
 			<key>UTTypeDescription</key>
-			<string>GPS eXchange format</string>
+			<string>GPS Exchange Format (GPX)</string>
 			<key>UTTypeIdentifier</key>
-			<string>net.osmand.gpx</string>
+			<string>com.topografix.gpx</string>
+			<key>UTTypeReferenceURL</key>
+			<string>http://www.topografix.com/GPX/1/</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -196,7 +202,9 @@
 					<string>GPX</string>
 				</array>
 				<key>public.mime-type</key>
-				<string>application/gpx+xml</string>
+				<array>
+					<string>application/gpx+xml</string>
+				</array>
 			</dict>
 		</dict>
 		<dict>

--- a/Resources/OsmAnd-Info.plist
+++ b/Resources/OsmAnd-Info.plist
@@ -40,14 +40,14 @@
 			<key>CFBundleTypeIconFiles</key>
 			<array/>
 			<key>CFBundleTypeName</key>
-			<string>GPS eXchange format</string>
+			<string>GPS Exchange Format (GPX)</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>net.osmand.gpx</string>
+				<string>com.topografix.gpx</string>
 			</array>
 		</dict>
 		<dict>
@@ -262,9 +262,11 @@
 				<string>public.xml</string>
 			</array>
 			<key>UTTypeDescription</key>
-			<string>GPX eXchange format</string>
+			<string>GPS Exchange Format (GPX)</string>
 			<key>UTTypeIdentifier</key>
-			<string>net.osmand.gpx</string>
+			<string>com.topografix.gpx</string>
+			<key>UTTypeReferenceURL</key>
+			<string>http://www.topografix.com/GPX/1/</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -273,7 +275,9 @@
 					<string>GPX</string>
 				</array>
 				<key>public.mime-type</key>
-				<string>application/gpx+xml</string>
+				<array>
+					<string>application/gpx+xml</string>
+				</array>
 			</dict>
 		</dict>
 		<dict>
@@ -397,9 +401,11 @@
 				<string>public.xml</string>
 			</array>
 			<key>UTTypeDescription</key>
-			<string>GPS eXchange format</string>
+			<string>GPS Exchange Format (GPX)</string>
 			<key>UTTypeIdentifier</key>
-			<string>net.osmand.gpx</string>
+			<string>com.topografix.gpx</string>
+			<key>UTTypeReferenceURL</key>
+			<string>http://www.topografix.com/GPX/1/</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -408,7 +414,9 @@
 					<string>GPX</string>
 				</array>
 				<key>public.mime-type</key>
-				<string>application/gpx+xml</string>
+				<array>
+					<string>application/gpx+xml</string>
+				</array>
 			</dict>
 		</dict>
 		<dict>

--- a/Sources/Controllers/2.0/OAFavoriteListViewController.mm
+++ b/Sources/Controllers/2.0/OAFavoriteListViewController.mm
@@ -58,7 +58,7 @@ typedef enum
 @end
 
 @interface OAFavoriteListViewController () <OAMultiselectableHeaderDelegate>{
-    
+
     BOOL isDecelerating;
 }
     @property (strong, nonatomic) NSArray*  menuItems;
@@ -88,9 +88,9 @@ static UIViewController *parentController;
 {
     if (!parentController)
         return NO;
-    
+
     [OAFavoriteListViewController doPop];
-    
+
     return YES;
 }
 
@@ -101,27 +101,27 @@ static UIViewController *parentController;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     isDecelerating = NO;
     self.sortingType = 0;
     _favAction = kFavoriteActionNone;
     self.view.backgroundColor = [UIColor groupTableViewBackgroundColor];
-    
+
     _sortedHeaderView = [[OAMultiselectableHeaderView alloc] initWithFrame:CGRectMake(0.0, 1.0, 100.0, 44.0)];
     _sortedHeaderView.delegate = self;
     [_sortedHeaderView setTitleText:OALocalizedString(@"favorites")];
-    
+
     _menuHeaderView = [[OAMultiselectableHeaderView alloc] initWithFrame:CGRectMake(0.0, 1.0, 100.0, 44.0)];
     _menuHeaderView.editable = NO;
     [_menuHeaderView setTitleText:OALocalizedString(@"import_export")];
-    
+
     _editToolbarView.hidden = YES;
 
     _horizontalLine = [CALayer layer];
     _horizontalLine.backgroundColor = [UIColorFromRGB(kBottomToolbarTopLineColor) CGColor];
     self.editToolbarView.backgroundColor = UIColorFromRGB(kBottomToolbarBackgroundColor);
     [self.editToolbarView.layer addSublayer:_horizontalLine];
-    
+
     _selectedItems = [[NSMutableArray alloc] init];
 }
 
@@ -161,41 +161,41 @@ static UIViewController *parentController;
     dispatch_async(dispatch_get_main_queue(), ^{
         if ([self.favoriteTableView isEditing])
             return;
-        
+
         if ([[NSDate date] timeIntervalSince1970] - self.lastUpdate < 0.3 && !forceUpdate)
             return;
         self.lastUpdate = [[NSDate date] timeIntervalSince1970];
-        
+
         OsmAndAppInstance app = [OsmAndApp instance];
         // Obtain fresh location and heading
         CLLocation* newLocation = app.locationServices.lastKnownLocation;
         if (!newLocation)
             return;
-        
+
         CLLocationDirection newHeading = app.locationServices.lastKnownHeading;
         CLLocationDirection newDirection =
         (newLocation.speed >= 1 /* 3.7 km/h */ && newLocation.course >= 0.0f)
         ? newLocation.course
         : newHeading;
-        
+
         [self.sortedFavoriteItems enumerateObjectsUsingBlock:^(OAFavoriteItem* itemData, NSUInteger idx, BOOL *stop) {
             const auto& favoritePosition31 = itemData.favorite->getPosition31();
             const auto favoriteLon = OsmAnd::Utilities::get31LongitudeX(favoritePosition31.x);
             const auto favoriteLat = OsmAnd::Utilities::get31LatitudeY(favoritePosition31.y);
-                
+
             const auto distance = OsmAnd::Utilities::distance(newLocation.coordinate.longitude,
                                                                 newLocation.coordinate.latitude,
                                                                 favoriteLon, favoriteLat);
-            
 
-            
+
+
             itemData.distance = [app getFormattedDistance:distance];
             itemData.distanceMeters = distance;
             CGFloat itemDirection = [app.locationServices radiusFromBearingToLocation:[[CLLocation alloc] initWithLatitude:favoriteLat longitude:favoriteLon]];
             itemData.direction = OsmAnd::Utilities::normalizedAngleDegrees(itemDirection - newDirection) * (M_PI / 180);
-            
+
          }];
-        
+
         if (self.sortingType == 1 && [self.sortedFavoriteItems count] > 0) {
             NSArray *sortedArray = [self.sortedFavoriteItems sortedArrayUsingComparator:^NSComparisonResult(OAFavoriteItem* obj1, OAFavoriteItem* obj2) {
                 return obj1.distanceMeters > obj2.distanceMeters ? NSOrderedDescending : obj1.distanceMeters < obj2.distanceMeters ? NSOrderedAscending : NSOrderedSame;
@@ -205,7 +205,7 @@ static UIViewController *parentController;
 
         if (isDecelerating)
             return;
-        
+
         [self refreshVisibleRows];
     });
 }
@@ -214,9 +214,9 @@ static UIViewController *parentController;
 {
     if ([self.favoriteTableView isEditing])
         return;
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
-        
+
         [self.favoriteTableView beginUpdates];
         NSArray *visibleIndexPaths = [self.favoriteTableView indexPathsForVisibleRows];
         for (NSIndexPath *i in visibleIndexPaths)
@@ -247,7 +247,7 @@ static UIViewController *parentController;
 
                     [c.titleView setText:[item getDisplayName]];
                     c = [self setupPoiIconForCell:c withFavaoriteItem:item];
-                    
+
                     [c.distanceView setText:item.distance];
                     c.directionImageView.transform = CGAffineTransformMakeRotation(item.direction);
                 }
@@ -257,27 +257,27 @@ static UIViewController *parentController;
 
         //NSArray *visibleIndexPaths = [self.favoriteTableView indexPathsForVisibleRows];
         //[self.favoriteTableView reloadRowsAtIndexPaths:visibleIndexPaths withRowAnimation:UITableViewRowAnimationNone];
-        
+
     });
 }
 
 -(void)viewWillAppear:(BOOL)animated {
-    
+
     if (_favAction == kFavoriteActionChangeColor)
         [self setupColor];
     else if (_favAction == kFavoriteActionChangeGroup)
         [self setupGroup];
     else
         [self setupView];
-    
+
     if (_favAction != kFavoriteActionNone) {
         return;
     }
-    
+
     [self generateData];
     [self setupView];
     [self updateDistanceAndDirection:YES];
-    
+
     OsmAndAppInstance app = [OsmAndApp instance];
     self.locationServicesUpdateObserver = [[OAAutoObserverProxy alloc] initWith:self
                                                                     withHandler:@selector(updateDistanceAndDirection)
@@ -289,7 +289,7 @@ static UIViewController *parentController;
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    
+
     if (_favAction != kFavoriteActionNone) {
         _favAction = kFavoriteActionNone;
         return;
@@ -299,7 +299,7 @@ static UIViewController *parentController;
 -(void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    
+
     if (_favAction != kFavoriteActionNone)
         return;
 
@@ -315,36 +315,36 @@ static UIViewController *parentController;
     NSMutableArray *allGroups = [[NSMutableArray alloc] init];
     self.menuItems = [[NSArray alloc] init];
     self.sortedFavoriteItems = [[NSMutableArray alloc] init];
-    
+
     NSMutableArray *headerViews = [NSMutableArray array];
     NSMutableArray *tableData = [NSMutableArray array];
-    
+
     if (![OAFavoritesHelper isFavoritesLoaded])
         [OAFavoritesHelper loadFavorites];
-    
+
     NSArray *favorites = [NSMutableArray arrayWithArray:[OAFavoritesHelper getFavoriteGroups]];
 
     for (OAFavoriteGroup *group in favorites)
     {
         FavoriteTableGroup* itemData = [[FavoriteTableGroup alloc] init];
         itemData.favoriteGroup = group;
-        
+
         // Sort items
         NSArray *sortedArrayItems = [itemData.favoriteGroup.points sortedArrayUsingComparator:^NSComparisonResult(OAFavoriteItem* obj1, OAFavoriteItem* obj2) {
             return [[[obj1 getDisplayName] lowercaseString] compare:[[obj2 getDisplayName] lowercaseString]];
         }];
         [itemData.favoriteGroup.points setArray:sortedArrayItems];
-        
+
         for (OAFavoriteItem *item in group.points)
             [self.sortedFavoriteItems addObject:item];
         [allGroups addObject:itemData];
     }
-    
+
     NSArray *sortedArray = [self.sortedFavoriteItems sortedArrayUsingComparator:^NSComparisonResult(OAFavoriteItem* obj1, OAFavoriteItem* obj2) {
         return obj1.distanceMeters > obj2.distanceMeters ? NSOrderedDescending : obj1.distanceMeters < obj2.distanceMeters ? NSOrderedAscending : NSOrderedSame;
     }];
     [self.sortedFavoriteItems setArray:sortedArray];
-    
+
     for (FavoriteTableGroup *group in allGroups) {
         NSMutableArray *groupData = [NSMutableArray array];
         [groupData addObject:@{
@@ -353,7 +353,7 @@ static UIViewController *parentController;
         }];
         [tableData addObject:groupData];
     }
-    
+
     for (int i = 0; i < tableData.count;)
     {
         OAMultiselectableHeaderView *headerView = [[OAMultiselectableHeaderView alloc] initWithFrame:CGRectMake(0.0, 1.0, 100.0, 44.0)];
@@ -362,7 +362,7 @@ static UIViewController *parentController;
         headerView.delegate = self;
         [headerViews addObject:headerView];
     }
-    
+
     // Generate menu items
     self.menuItems = @[@{@"type" : @"actionItem",
                          @"text": OALocalizedString(@"fav_import_title"),
@@ -373,16 +373,16 @@ static UIViewController *parentController;
                          @"icon": @"favorite_export_icon.png",
                          @"action": @"onExportClicked"}];
     [tableData addObject:self.menuItems];
-    
+
     OAMultiselectableHeaderView *headerView = [[OAMultiselectableHeaderView alloc] initWithFrame:CGRectMake(0.0, 1.0, 100.0, 44.0)];
     [headerView setTitleText:OALocalizedString(@"import_export")];
     headerView.editable = NO;
     [headerViews addObject:headerView];
-    
+
     _data = [NSMutableArray arrayWithArray:tableData];
-    
+
     [self.favoriteTableView reloadData];
-    
+
     _unsortedHeaderViews = [NSArray arrayWithArray:headerViews];
 }
 
@@ -434,10 +434,10 @@ static UIViewController *parentController;
 
         [alert addAction:defaultAction];
         [self presentViewController:alert animated:YES completion:nil];
-        
+
         return;
     }
-    
+
     UIAlertController *alert = [UIAlertController
                                 alertControllerWithTitle:nil
                                 message:OALocalizedString(@"fav_remove_q")
@@ -456,7 +456,7 @@ static UIViewController *parentController;
     [alert addAction:yesButton];
     [alert addAction:cancelButton];
     [self presentViewController:alert animated:YES completion:nil];
- 
+
 }
 
 - (IBAction) favoriteChangeColorClicked:(id)sender
@@ -470,7 +470,7 @@ static UIViewController *parentController;
 
         [alert addAction:defaultAction];
         [self presentViewController:alert animated:YES completion:nil];
-       
+
         return;
     }
 
@@ -490,7 +490,7 @@ static UIViewController *parentController;
 
         [alert addAction:defaultAction];
         [self presentViewController:alert animated:YES completion:nil];
-        
+
         return;
     }
 
@@ -503,7 +503,7 @@ static UIViewController *parentController;
         if (groupName.length > 0 && group.name.length != 0)
             [groupNames addObject:groupName];
     }
-        
+
     _groupController = [[OAEditGroupViewController alloc] initWithGroupName:nil groups:groupNames];
     [self.navigationController pushViewController:_groupController animated:YES];
 }
@@ -539,11 +539,11 @@ static UIViewController *parentController;
                         tableGroup.favoriteGroup.color = favCol.color;
                 }
             }
-            
+
             if (item)
             {
                 [item setColor:favCol.color];
-                
+
                 if (indexPath.row == 1)
                 {
                     OAFavoriteGroup *group = [OAFavoritesHelper getGroupByName:[item getCategory]];
@@ -551,7 +551,7 @@ static UIViewController *parentController;
                 }
             }
         }
-        
+
         [app saveFavoritesToPermamentStorage];
     }
     [self finishEditing];
@@ -562,7 +562,7 @@ static UIViewController *parentController;
 {
     if ([_selectedItems count] == 0)
         return;
-    
+
     if (_groupController.saveChanges)
     {
         OsmAndAppInstance app = [OsmAndApp instance];
@@ -572,7 +572,7 @@ static UIViewController *parentController;
             NSNumber *row2 = [NSNumber numberWithInteger:obj2.row];
             return [row2 compare:row1];
         }];
-        
+
         for (NSIndexPath *indexPath in sortedSelectedItems)
         {
             OAFavoriteItem* item;
@@ -594,13 +594,13 @@ static UIViewController *parentController;
                     }
                 }
             }
-            
+
             if (item)
             {
                 [OAFavoritesHelper editFavoriteName:item newName:[item getDisplayName] group:_groupController.groupName descr:[item getDescription] address:[item getAddress]];
             }
         }
-        
+
         [app saveFavoritesToPermamentStorage];
     }
     [self finishEditing];
@@ -639,7 +639,7 @@ static UIViewController *parentController;
         [self.tabBarController.tabBar setHidden:YES];
         [self applySafeAreaMargins];
     }];
-    
+
     [self.editButton setImage:[UIImage imageNamed:@"icon_edit_active"] forState:UIControlStateNormal];
     [self.backButton setHidden:YES];
     [self.directionButton setHidden:YES];
@@ -693,7 +693,7 @@ static UIViewController *parentController;
 
         [alert addAction:defaultAction];
         [self presentViewController:alert animated:YES completion:nil];
-       
+
         return;
     }
 
@@ -705,15 +705,15 @@ static UIViewController *parentController;
 
     if (exportCollection->getFavoriteLocationsCount() == 0)
         return;
-        
+
     NSString* filename = [@"Exported favorites" stringByAppendingString:@".gpx"];
     NSString* fullFilename = [NSTemporaryDirectory() stringByAppendingString:filename];
     if (!exportCollection->saveTo(QString::fromNSString(fullFilename)))
         return;
-        
+
     NSURL* favoritesUrl = [NSURL fileURLWithPath:fullFilename];
     _exportController = [UIDocumentInteractionController interactionControllerWithURL:favoritesUrl];
-    _exportController.UTI = @"net.osmand.gpx";
+    _exportController.UTI = @"com.topografix.gpx";
     _exportController.delegate = self;
     _exportController.name = filename;
     [_exportController presentOptionsMenuFromRect:_exportButton.frame
@@ -741,15 +741,15 @@ static UIViewController *parentController;
 
 -(void)onExportClicked
 {
-    
+
     if (self.sortedFavoriteItems.count == 0)
         return;
-    
+
     OsmAndAppInstance app = [OsmAndApp instance];
     // Share all favorites
     NSURL* favoritesUrl = [NSURL fileURLWithPath:app.favoritesStorageFilename];
     _exportController = [UIDocumentInteractionController interactionControllerWithURL:favoritesUrl];
-    _exportController.UTI = @"net.osmand.gpx";
+    _exportController.UTI = @"com.topografix.gpx";
     _exportController.delegate = self;
     _exportController.name = @"OsmAnd favourites.gpx";
     [_exportController presentOptionsMenuFromRect:CGRectZero
@@ -850,13 +850,13 @@ static UIViewController *parentController;
             NSArray *nib = [[NSBundle mainBundle] loadNibNamed:[OAPointTableViewCell getCellIdentifier] owner:self options:nil];
             cell = (OAPointTableViewCell *)[nib objectAtIndex:0];
         }
-        
+
         if (cell)
         {
             OAFavoriteItem* item = [self.sortedFavoriteItems objectAtIndex:indexPath.row];
             [cell.titleView setText:[item getDisplayName]];
             cell = [self setupPoiIconForCell:cell withFavaoriteItem:item];
-            
+
             [cell.distanceView setText:item.distance];
             cell.directionImageView.image = [UIImage templateImageNamed:@"ic_small_direction"];
             cell.directionImageView.tintColor = UIColorFromRGB(color_elevation_chart);
@@ -864,7 +864,7 @@ static UIViewController *parentController;
         }
 
         return cell;
-        
+
     }
     else
     {
@@ -875,7 +875,7 @@ static UIViewController *parentController;
             NSArray *nib = [[NSBundle mainBundle] loadNibNamed:[OAIconTextTableViewCell getCellIdentifier] owner:self options:nil];
             cell = (OAIconTextTableViewCell *)[nib objectAtIndex:0];
         }
-        
+
         if (cell) {
             NSDictionary* item = [self.menuItems objectAtIndex:indexPath.row];
             [cell.textView setText:[item objectForKey:@"text"]];
@@ -903,7 +903,7 @@ static UIViewController *parentController;
 {
     NSDictionary *item = _data[indexPath.section][0];
     FavoriteTableGroup* groupData = item[@"group"];
-    
+
     OAPointHeaderTableViewCell* cell;
     cell = (OAPointHeaderTableViewCell *)[self.favoriteTableView dequeueReusableCellWithIdentifier:[OAPointHeaderTableViewCell getCellIdentifier]];
     if (cell == nil)
@@ -917,7 +917,7 @@ static UIViewController *parentController;
         OAFavoriteGroup* group = groupData.favoriteGroup;
         [cell.groupTitle setText:[OAFavoriteGroup getDisplayName:group.name]];
         cell.folderIcon.tintColor = groupData.favoriteGroup.color;
-        
+
         cell.openCloseGroupButton.tag = indexPath.section << 10 | indexPath.row;
         [cell.openCloseGroupButton removeTarget:nil action:NULL forControlEvents:UIControlEventTouchUpInside];
         [cell.openCloseGroupButton addTarget:self action:@selector(openCloseGroupButtonAction:) forControlEvents:UIControlEventTouchUpInside];
@@ -925,7 +925,7 @@ static UIViewController *parentController;
             [cell.openCloseGroupButton setHidden:NO];
         else
             [cell.openCloseGroupButton setHidden:YES];
-        
+
         if (groupData.isOpen)
         {
             cell.arrowImage.image = [UIImage templateImageNamed:@"ic_custom_arrow_down"];
@@ -945,7 +945,7 @@ static UIViewController *parentController;
 {
     NSDictionary *item = _data[indexPath.section][0];
     FavoriteTableGroup* groupData = item[@"group"];
-    
+
     NSInteger dataIndex = indexPath.row - 1;
     OAPointTableViewCell* cell;
     cell = (OAPointTableViewCell *)[self.favoriteTableView dequeueReusableCellWithIdentifier:[OAPointTableViewCell getCellIdentifier]];
@@ -962,7 +962,7 @@ static UIViewController *parentController;
         cell = [self setupPoiIconForCell:cell withFavaoriteItem:item];
 
         [cell.distanceView setText:item.distance];
-        
+
         cell.directionImageView.tintColor = UIColorFromRGB(color_elevation_chart);
         cell.directionImageView.transform = CGAffineTransformMakeRotation(item.direction);
     }
@@ -985,7 +985,7 @@ static UIViewController *parentController;
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:[OAIconTextTableViewCell getCellIdentifier] owner:self options:nil];
         cell = (OAIconTextTableViewCell *)[nib objectAtIndex:0];
     }
-    
+
     if (cell)
     {
         [cell.textView setText:[item objectForKey:@"text"]];
@@ -1012,14 +1012,14 @@ static UIViewController *parentController;
         }
     }
     return indexPath;
-    
+
 }
 
 - (BOOL) tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if (self.directionButton.tag == 1)
         return [self canEditSortedRowAtIndexPath:indexPath];
-    
+
     return [self canEditUnsortedRowAtIndexPath:indexPath];
 }
 
@@ -1049,7 +1049,7 @@ static UIViewController *parentController;
 {
     OsmAndAppInstance app = [OsmAndApp instance];
     OAFavoriteItem* item = [self.sortedFavoriteItems objectAtIndex:indexPath.row];
-    
+
     [self.favoriteTableView beginUpdates];
     [OAFavoritesHelper deleteFavoriteGroups:nil andFavoritesItems:@[item]];
     [self.sortedFavoriteItems removeObjectAtIndex:indexPath.row];
@@ -1062,11 +1062,11 @@ static UIViewController *parentController;
 {
     OsmAndAppInstance app = [OsmAndApp instance];
     NSInteger dataIndex = indexPath.row - 1;
-    
+
     NSDictionary *groupData = _data[indexPath.section][0];
     FavoriteTableGroup* group = groupData[@"group"];
     OAFavoriteItem* item = [group.favoriteGroup.points objectAtIndex:dataIndex];
-    
+
     [self.favoriteTableView beginUpdates];
     [OAFavoritesHelper deleteFavoriteGroups:nil andFavoritesItems:@[item]];
     [group.favoriteGroup.points removeObjectAtIndex:indexPath.row - 1];
@@ -1085,7 +1085,7 @@ static UIViewController *parentController;
     for (NSIndexPath *selectedItem in sortedArray)
     {
         NSInteger dataIndex = selectedItem.row;
-        
+
         OAFavoriteItem* item = [self.sortedFavoriteItems objectAtIndex:dataIndex];
         toDelete.push_back(item.favorite);
         [self.favoriteTableView beginUpdates];
@@ -1098,19 +1098,19 @@ static UIViewController *parentController;
 }
 
 - (void)removeGroupHeader:(NSIndexPath *)indexPath{
-    
+
     NSInteger numberOfRows = [self.favoriteTableView numberOfRowsInSection:[indexPath section]];
-    
+
     if (numberOfRows == 1)
     {
         [self.favoriteTableView beginUpdates];
-        
+
         NSDictionary *groupData = _data[indexPath.section][0];
         FavoriteTableGroup* group = groupData[@"group"];
         [OAFavoritesHelper deleteFavoriteGroups:@[group.favoriteGroup] andFavoritesItems:nil];
-        
+
         [_data removeObjectAtIndex:indexPath.section];
-        
+
         [self.favoriteTableView deleteSections:[NSIndexSet indexSetWithIndex:indexPath.section]
                               withRowAnimation:UITableViewRowAnimationFade];
         [self.favoriteTableView endUpdates];
@@ -1123,7 +1123,7 @@ static UIViewController *parentController;
     NSSortDescriptor *sectionDescriptor = [[NSSortDescriptor alloc] initWithKey:@"section" ascending:NO];
     NSArray<NSIndexPath *> *sortedArray = [_selectedItems sortedArrayUsingDescriptors:@[sectionDescriptor, rowDescriptor]];
     OsmAndAppInstance app = [OsmAndApp instance];
-    
+
     for (NSIndexPath *selectedItem in sortedArray)
     {
         if (selectedItem.row == 0)
@@ -1135,7 +1135,7 @@ static UIViewController *parentController;
             FavoriteTableGroup* group = groupData[@"group"];
             OAFavoriteItem* item = [group.favoriteGroup.points objectAtIndex:dataIndex];
             [OAFavoritesHelper deleteFavoriteGroups:nil andFavoritesItems:@[item]];
-            
+
             if (group.isOpen)
             {
                 [self.favoriteTableView beginUpdates];
@@ -1165,7 +1165,7 @@ static UIViewController *parentController;
 }
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
-    
+
     if (editingStyle == UITableViewCellEditingStyleDelete)
     {
         UIAlertController *alert = [UIAlertController
@@ -1230,7 +1230,7 @@ static UIViewController *parentController;
 {
     UIButton *button = (UIButton *)sender;
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:button.tag & 0x3FF inSection:button.tag >> 10];
-    
+
     [self openCloseFavoriteGroup:indexPath];
 }
 
@@ -1270,7 +1270,7 @@ static UIViewController *parentController;
     BOOL isGroupHeaderSelected = [self.favoriteTableView.indexPathsForSelectedRows containsObject:[NSIndexPath indexPathForRow:0 inSection:indexPath.section]];
     NSDictionary *item = _data[indexPath.section][0];
     FavoriteTableGroup* groupData = item[@"group"];
-    
+
     if (groupData.isOpen)
     {
         NSArray *selectedRows = [self.favoriteTableView indexPathsForSelectedRows];
@@ -1312,7 +1312,7 @@ static UIViewController *parentController;
         [self.favoriteTableView beginUpdates];
         [self.favoriteTableView reloadSections:[[NSIndexSet alloc] initWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
         [self.favoriteTableView endUpdates];
-        
+
         [self selectPreselectedCells:indexPath];
     }
 }
@@ -1366,7 +1366,7 @@ static UIViewController *parentController;
         [self addIndexPathToSelectedCellsArray:indexPath];
         return;
     }
-    
+
     if (indexPath.section == 0) {
         OAFavoriteItem* item = [self.sortedFavoriteItems objectAtIndex:indexPath.row];
         [self doPush];
@@ -1402,7 +1402,7 @@ static UIViewController *parentController;
                 numberOfSelectedRowsInSection++;
         }
         [self removeIndexPathFromSelectedCellsArray:indexPath];
-        
+
         if (indexPath.row == 0)
         {
             [self removeIndexPathFromSelectedCellsArray:[NSIndexPath indexPathForRow:0 inSection:indexPath.section]];
@@ -1451,7 +1451,7 @@ static UIViewController *parentController;
         OAFavoriteItem* item = [groupData.favoriteGroup.points objectAtIndex:indexPath.row - 1];
         [self doPush];
         [[OARootViewController instance].mapPanel openTargetViewWithFavorite:item pushed:YES];
-        
+
     }
     else
     {
@@ -1466,7 +1466,7 @@ static UIViewController *parentController;
 - (void)doPush
 {
     parentController = self.parentViewController;
-    
+
     CATransition* transition = [CATransition animation];
     transition.duration = 0.4;
     transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
@@ -1485,7 +1485,7 @@ static UIViewController *parentController;
     transition.subtype = kCATransitionFromLeft; //kCATransitionFromLeft, kCATransitionFromRight, kCATransitionFromTop, kCATransitionFromBottom
     [[OARootViewController instance].navigationController.view.layer addAnimation:transition forKey:nil];
     [[OARootViewController instance].navigationController pushViewController:parentController animated:NO];
-    
+
     parentController = nil;
 }
 
@@ -1510,7 +1510,7 @@ static UIViewController *parentController;
     OAMultiselectableHeaderView *headerView = (OAMultiselectableHeaderView *)sender;
     NSInteger section = headerView.section;
     NSInteger rowsCount = [self.favoriteTableView numberOfRowsInSection:section];
-    
+
     [self.favoriteTableView beginUpdates];
     if (value)
     {

--- a/Sources/Controllers/2.0/OAGPXItemViewController.mm
+++ b/Sources/Controllers/2.0/OAGPXItemViewController.mm
@@ -48,11 +48,11 @@
 
     OsmAndAppInstance _app;
     NSDateFormatter *dateTimeFormatter;
-    
+
     OAMapViewController *_mapViewController;
-    
+
     BOOL _startEndTimeExists;
-    
+
     OAGpxSegmentType _segmentType;
     EPointsSortingType _sortingType;
     CGFloat _scrollPos;
@@ -70,29 +70,29 @@
     OASavingTrackHelper *_savingHelper;
     OAGPXWptListViewController *_waypointsController;
     BOOL _wasOpenedWaypointsView;
-    
+
     NSInteger _sectionsCount;
     NSInteger _controlsSectionIndex;
     NSInteger _speedSectionIndex;
     NSInteger _timeSectionIndex;
     NSInteger _uphillsSectionIndex;
-    
+
     NSString *_exportFileName;
     NSString *_exportFilePath;
 
     NSArray* _groups;
-    
+
     OAEditGroupViewController *_groupController;
     OAEditColorViewController *_colorController;
-    
+
     OAEditGPXColorViewController *_trackColorController;
     OAGPXTrackColorCollection *_gpxColorCollection;
-    
+
     UIView *_badge;
     CALayer *_horizontalLine;
-    
+
     UIView *_headerView;
-    
+
     UIFont *_upDownFont;
     NSTextAttachment *_arrowUp;
     NSTextAttachment *_arrowDown;
@@ -142,9 +142,9 @@
         _app = [OsmAndApp instance];
         _segmentType = kSegmentStatistics;
         _savingHelper = [OASavingTrackHelper sharedInstance];
-        
+
         [self updateCurrentGPXData];
-        
+
         _showCurrentTrack = YES;
     }
     return self;
@@ -156,15 +156,15 @@
     if (self)
     {
         _app = [OsmAndApp instance];
-        
+
         _segmentType = ctrlState.segmentType;
         _sortingType = ctrlState.sortType;
         _scrollPos = ctrlState.scrollPos;
 
         _savingHelper = [OASavingTrackHelper sharedInstance];
-        
+
         [self updateCurrentGPXData];
-        
+
         _showCurrentTrack = YES;
     }
     return self;
@@ -179,7 +179,7 @@
 {
     NSMutableAttributedString *string = [[NSMutableAttributedString alloc] init];
     UIFont *font = [UIFont systemFontOfSize:12 weight:UIFontWeightSemibold];
-    
+
     if (item.newGpx && item.wptPoints == 0)
     {
         [string appendAttributedString:[[NSAttributedString alloc] initWithString:OALocalizedString(@"select_wpt_on_map")]];
@@ -192,7 +192,7 @@
         NSString *waypointsStr = [NSString stringWithFormat:@"%d", item.wptPoints];
         NSString *timeMovingStr = [[OsmAndApp instance] getFormattedTimeInterval:item.timeMoving shortFormat:NO];
         NSString *avgSpeedStr = [[OsmAndApp instance] getFormattedSpeed:item.avgSpeed];
-        
+
         NSMutableAttributedString *stringDistance = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"\u00a0\u00a0%@", [distanceStr stringByReplacingOccurrencesOfString:@" " withString:@"\u00a0"]]];
         NSMutableAttributedString *stringWaypoints = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"  \u00a0\u00a0%@", [waypointsStr stringByReplacingOccurrencesOfString:@" " withString:@"\u00a0"]]];
         NSMutableAttributedString *stringTimeMoving;
@@ -201,13 +201,13 @@
         NSMutableAttributedString *stringAvgSpeed;
         if (item.avgSpeed > 0)
             stringAvgSpeed =[[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"  \u00a0\u00a0%@", [avgSpeedStr stringByReplacingOccurrencesOfString:@" " withString:@"\u00a0"]]];
-        
+
         NSTextAttachment *distanceAttachment = [[NSTextAttachment alloc] init];
         distanceAttachment.image = [UIImage imageNamed:@"ic_gpx_distance.png"];
-        
+
         NSTextAttachment *waypointsAttachment = [[NSTextAttachment alloc] init];
         waypointsAttachment.image = [UIImage imageNamed:@"ic_gpx_points.png"];
-        
+
         NSTextAttachment *timeMovingAttachment;
         if (item.timeMoving > 0)
         {
@@ -220,7 +220,7 @@
             avgSpeedAttachment = [[NSTextAttachment alloc] init];
             avgSpeedAttachment.image = [UIImage imageNamed:@"ic_average_speed.png"];
         }
-        
+
         NSAttributedString *distanceStringWithImage = [NSAttributedString attributedStringWithAttachment:distanceAttachment];
         NSAttributedString *waypointsStringWithImage = [NSAttributedString attributedStringWithAttachment:waypointsAttachment];
         NSAttributedString *timeMovingStringWithImage;
@@ -229,7 +229,7 @@
         NSAttributedString *avgSpeedStringWithImage;
         if (item.avgSpeed > 0)
             avgSpeedStringWithImage = [NSAttributedString attributedStringWithAttachment:avgSpeedAttachment];
-        
+
         [stringDistance replaceCharactersInRange:NSMakeRange(0, 1) withAttributedString:distanceStringWithImage];
         [stringDistance addAttribute:NSBaselineOffsetAttributeName value:[NSNumber numberWithFloat:-2.0] range:NSMakeRange(0, 1)];
         [stringWaypoints replaceCharactersInRange:NSMakeRange(2, 1) withAttributedString:waypointsStringWithImage];
@@ -244,7 +244,7 @@
             [stringAvgSpeed replaceCharactersInRange:NSMakeRange(2, 1) withAttributedString:avgSpeedStringWithImage];
             [stringAvgSpeed addAttribute:NSBaselineOffsetAttributeName value:[NSNumber numberWithFloat:-2.0] range:NSMakeRange(2, 1)];
         }
-        
+
         [string appendAttributedString:stringDistance];
         [string appendAttributedString:stringWaypoints];
         if (stringTimeMoving)
@@ -252,9 +252,9 @@
         if (stringAvgSpeed)
             [string appendAttributedString:stringAvgSpeed];
     }
-    
+
     [string addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, string.length)];
-    
+
     return string;
 }
 
@@ -268,7 +268,7 @@
 {
     OAGPX* item = [_savingHelper getCurrentGPX];
     item.gpxTitle = OALocalizedString(@"track_recording_name");
-    
+
     self.gpx = item;
     self.doc = (OAGPXDocument*)_savingHelper.currentTrack;
 }
@@ -278,7 +278,7 @@
     OAGPXRouter *gpxRouter = [OAGPXRouter sharedInstance];
     if (gpxRouter.gpx && [gpxRouter.gpx.gpxFilePath isEqualToString:self.gpx.gpxFilePath])
         [gpxRouter cancelRoute];
-    
+
     NSString *path = [_app.gpxPath stringByAppendingPathComponent:self.gpx.gpxFilePath];
     self.doc = [[OAGPXDocument alloc] initWithGpxFile:path];
 }
@@ -286,7 +286,7 @@
 - (void)cancelPressed
 {
     _cancelPressed = YES;
-    
+
     [_mapViewController hideTempGpxTrack];
 
     if (self.delegate)
@@ -299,7 +299,7 @@
 {
     if (self.delegate)
         [self.delegate btnOkPressed];
-    
+
     [self closePointsController];
 }
 
@@ -377,15 +377,15 @@
     dateTimeFormatter = [[NSDateFormatter alloc] init];
     dateTimeFormatter.dateStyle = NSDateFormatterShortStyle;
     dateTimeFormatter.timeStyle = NSDateFormatterMediumStyle;
-    
+
     self.titleView.text = [self.gpx getNiceTitle];
     _startEndTimeExists = self.gpx.startTime > 0 && self.gpx.endTime > 0;
-    
+
     BOOL uphillsDataExists = (self.gpx.avgElevation != 0.0 || self.gpx.minElevation != 0.0 || self.gpx.maxElevation != 0.0 || self.gpx.diffElevationDown != 0.0 || self.gpx.diffElevationUp != 0.0);
-    
+
     _controlsSectionIndex = _showCurrentTrack ? -1 : 0;
     NSInteger nextSectionIndex = _showCurrentTrack ? 0 : 1;
-    
+
     if (_startEndTimeExists)
     {
         _speedSectionIndex = (self.gpx.avgSpeed > 0 && self.gpx.maxSpeed > 0 ? nextSectionIndex++ : -1);
@@ -412,10 +412,10 @@
         [_headerView addSubview:headerLabel];
         [_tableView setTableHeaderView:_headerView];
     }
-    
+
     self.buttonUpdate.frame = self.buttonSort.frame;
     self.buttonEdit.frame = self.buttonMore.frame;
-    
+
     _tableView.dataSource = self;
     _tableView.delegate = self;
     _tableView.estimatedRowHeight = kEstimatedRowHeight;
@@ -440,21 +440,21 @@
             [_mapViewController showTempGpxTrack:self.gpx.gpxFilePath];
         });
     }
-    
+
     self.editToolbarView.hidden = YES;
-    
+
     _horizontalLine = [CALayer layer];
     _horizontalLine.backgroundColor = [UIColorFromRGB(kBottomToolbarTopLineColor) CGColor];
     self.editToolbarView.backgroundColor = UIColorFromRGB(kBottomToolbarBackgroundColor);
     [self.editToolbarView.layer addSublayer:_horizontalLine];
     _horizontalLine.frame = CGRectMake(0.0, 0.0, self.contentView.bounds.size.width, 0.5);
-    
+
     _upDownFont = [UIFont systemFontOfSize:17.];
-    
+
     _arrowUp = [[NSTextAttachment alloc] init];
     _arrowUp.image = [UIImage imageNamed:@"ic_arrow_up"];
     [_arrowUp setBounds:CGRectMake(0, roundf(_upDownFont.capHeight - 16.)/ 2., 16., 16.)];
-    
+
     _arrowDown = [[NSTextAttachment alloc] init];
     _arrowDown.image = [UIImage imageNamed:@"ic_arrow_down"];
     [_arrowDown setBounds:CGRectMake(0, roundf(_upDownFont.capHeight - 16.)/ 2., 16., 16.)];
@@ -472,23 +472,23 @@
         [_badge removeFromSuperview];
         _badge = nil;
     }
-    
+
     UILabel *badgeLabel = [[UILabel alloc] initWithFrame:CGRectMake(0.0, 0.0, 100.0, 50.0)];
     badgeLabel.font = [UIFont systemFontOfSize:11.0];
     badgeLabel.text = [NSString stringWithFormat:@"%d", (int) self.doc.locationMarks.count];
     badgeLabel.textColor = UIColorFromRGB(0xFF8F00);
     badgeLabel.textAlignment = NSTextAlignmentCenter;
     [badgeLabel sizeToFit];
-    
+
     CGSize badgeSize = CGSizeMake(MAX(16.0, badgeLabel.bounds.size.width + 8.0), MAX(16.0, badgeLabel.bounds.size.height));
     badgeLabel.frame = CGRectMake(.5, .5, badgeSize.width, badgeSize.height);
     CGRect badgeFrame = CGRectMake(self.segmentView.bounds.size.width - badgeSize.width + 10.0, -4.0, badgeSize.width, badgeSize.height);
     _badge = [[UIView alloc] initWithFrame:badgeFrame];
     _badge.layer.cornerRadius = 8.0;
     _badge.layer.backgroundColor = [UIColor whiteColor].CGColor;
-    
+
     [_badge addSubview:badgeLabel];
-    
+
     [self.segmentViewContainer addSubview:_badge];
 }
 
@@ -511,7 +511,7 @@
     state.segmentType = _segmentType;
     state.scrollPos = (_segmentType == kSegmentStatistics ? self.tableView.contentOffset.y : _waypointsController.tableView.contentOffset.y);
     state.sortType = _sortingType;
-    
+
     return state;
 }
 
@@ -532,19 +532,19 @@
         case kSegmentStatistics:
         {
             _editing = NO;
-            
+
             self.tableView.hidden = NO;
 
             if (!_wasInit && _scrollPos != 0.0)
                 [self.tableView setContentOffset:CGPointMake(0.0, _scrollPos)];
-            
+
             if (_waypointsController)
             {
                 [_waypointsController resetData];
                 [_waypointsController doViewDisappear];
                 [_waypointsController.view removeFromSuperview];
             }
-            
+
             self.buttonSort.hidden = YES;
             self.buttonEdit.hidden = YES;
             if (self.showCurrentTrack)
@@ -557,14 +557,14 @@
                 self.buttonMore.hidden = NO;
                 self.buttonUpdate.hidden = YES;
             }
-            
+
             break;
         }
         case kSegmentWaypoints:
         {
             self.buttonUpdate.hidden = YES;
             [self updateWaypointsButtons];
-            
+
             if (!_waypointsController)
             {
                 _waypointsController = [[OAGPXWptListViewController alloc] initWithLocationMarks:self.doc.locationMarks];
@@ -573,7 +573,7 @@
                 [_waypointsController updateSortButton:self.buttonSort];
                 _waypointsController.allGroups = [self readGroups];
             }
-            
+
             if (self.delegate)
                 [self.delegate contentChanged];
             _waypointsController.view.frame = self.isLandscape ? CGRectMake(0.0, 0.0, self.contentView.frame.size.width, [self contentHeight]) : self.contentView.bounds;
@@ -581,22 +581,22 @@
             [self.contentView addSubview:_waypointsController.view];
 
             self.tableView.hidden = YES;
-            
+
             if (!_wasInit && _scrollPos != 0.0)
                 [_waypointsController.tableView setContentOffset:CGPointMake(0.0, _scrollPos)];
 
             if (!_wasOpenedWaypointsView && self.delegate)
                 [self.delegate requestFullScreenMode];
-            
+
             _wasOpenedWaypointsView = YES;
 
             break;
         }
-            
+
         default:
             break;
     }
-    
+
     _wasInit = YES;
 }
 
@@ -626,7 +626,7 @@
             [groups addObject:wptItem.type];
     }
     _groups = [groups allObjects];
-    
+
     return _groups;
 }
 
@@ -655,7 +655,7 @@
                                                  case 1:
                                                      [self exportClicked:nil];
                                                      break;
-                                                     
+
                                                  default:
                                                      break;
                                              }
@@ -705,10 +705,10 @@
                                          }
                                      }];
             }
-            
+
             break;
         }
-            
+
         default:
             break;
     }
@@ -723,7 +723,7 @@
         [alert show];
         return;
     }
-    
+
     _groupController = [[OAEditGroupViewController alloc] initWithGroupName:nil groups:_groups];
     _groupController.delegate = self;
     [self.navController pushViewController:_groupController animated:YES];
@@ -738,7 +738,7 @@
         [alert show];
         return;
     }
-    
+
     _colorController = [[OAEditColorViewController alloc] init];
     _colorController.delegate = self;
     [self.navController pushViewController:_colorController animated:YES];
@@ -753,7 +753,7 @@
         [alert show];
         return;
     }
-    
+
     [PXAlertView showAlertWithTitle:OALocalizedString(@"gpx_remove_wpts_q")
                             message:nil
                         cancelTitle:OALocalizedString(@"shared_string_no")
@@ -799,7 +799,7 @@
         [alert show];
         return;
     }
-    
+
     OAGPXMutableDocument *gpx = [[OAGPXMutableDocument alloc] init];
     NSArray *items = [_waypointsController getSelectedItems];
     for (OAGpxWptItem *item in items)
@@ -808,10 +808,10 @@
     _exportFileName = [@"exported_waypoints" stringByAppendingString:@".gpx"];
     _exportFilePath = [NSTemporaryDirectory() stringByAppendingString:_exportFileName];
     [gpx saveTo:_exportFilePath];
-    
+
     NSURL* gpxUrl = [NSURL fileURLWithPath:_exportFilePath];
     _exportController = [UIDocumentInteractionController interactionControllerWithURL:gpxUrl];
-    _exportController.UTI = @"net.osmand.gpx";
+    _exportController.UTI = @"com.topografix.gpx";
     _exportController.delegate = self;
     _exportController.name = _exportFileName;
     [_exportController presentOptionsMenuFromRect:CGRectZero
@@ -873,12 +873,12 @@
     [_waypointsController.tableView beginUpdates];
     [_waypointsController setEditing:value animated:YES];
     [self updateWaypointsButtons];
-    
+
     if (value)
         self.titleView.text = OALocalizedString(@"editing_waypoints");
     else
         self.titleView.text = [self.gpx getNiceTitle];
-    
+
     if (value)
     {
         _horizontalLine.frame = CGRectMake(0.0, 0.0, self.contentView.bounds.size.width, 0.5);
@@ -898,7 +898,7 @@
         CGSize cs = self.contentView.bounds.size;
         CGRect f = self.editToolbarView.frame;
         f.origin.y = cs.height + 1.0;
-        
+
         [UIView animateWithDuration:(animated ? .3 : 0.0) animations:^{
             self.editToolbarView.frame = f;
             _waypointsController.view.frame = self.isLandscape ? CGRectMake(0.0, 0.0, cs.width, [self contentHeight]) : self.contentView.bounds;
@@ -914,12 +914,12 @@
     OAGpxSegmentType newSegmentType = (OAGpxSegmentType)self.segmentView.selectedSegmentIndex;
     if (_segmentType == newSegmentType)
         return;
-    
+
     _editing = NO;
     [self updateEditingMode:self.editing animated:NO];
 
     _segmentType = newSegmentType;
-        
+
     [self applySegmentType];
 }
 
@@ -932,7 +932,7 @@
 
         NSDateFormatter *simpleFormat = [[NSDateFormatter alloc] init];
         [simpleFormat setDateFormat:@"HH-mm_EEE"];
-        
+
         _exportFileName = [NSString stringWithFormat:@"%@_%@", [fmt stringFromDate:[NSDate date]], [simpleFormat stringFromDate:[NSDate date]]];
         _exportFilePath = [NSString stringWithFormat:@"%@/%@.gpx", NSTemporaryDirectory(), _exportFileName];
 
@@ -943,11 +943,11 @@
         _exportFileName = _gpx.gpxFileName;
         _exportFilePath = [_app.gpxPath stringByAppendingPathComponent:self.gpx.gpxFilePath];
     }
-    
+
     NSURL* gpxUrl = [NSURL fileURLWithPath:_exportFilePath];
-    
+
     _exportController = [UIDocumentInteractionController interactionControllerWithURL:gpxUrl];
-    _exportController.UTI = @"net.osmand.gpx";
+    _exportController.UTI = @"com.topografix.gpx";
     _exportController.delegate = self;
     _exportController.name = _exportFileName;
     [_exportController presentOptionsMenuFromRect:CGRectZero
@@ -988,9 +988,9 @@
                              if (!cancelled)
                              {
                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                     
+
                                      OAAppSettings *settings = [OAAppSettings sharedManager];
-                                     
+
                                      if (self.showCurrentTrack)
                                      {
                                          settings.mapSettingTrackRecording = NO;
@@ -1007,7 +1007,7 @@
                                              [_mapViewController hideTempGpxTrack];
                                              [[[OsmAndApp instance] mapSettingsChangeObservable] notifyEvent];
                                          }
-                                         
+
                                          [[OAGPXDatabase sharedDb] removeGpxItem:self.gpx.gpxFilePath];
                                          [[OAGPXDatabase sharedDb] save];
                                      }
@@ -1067,7 +1067,7 @@
         [_exportController dismissMenuAnimated:YES];
         _exportFilePath = nil;
         _exportController = nil;
-        
+
         OASaveTrackViewController *saveTrackViewController = [[OASaveTrackViewController alloc] initWithFileName:_gpx.gpxFilePath.lastPathComponent.stringByDeletingPathExtension filePath:_gpx.gpxFilePath showOnMap:YES simplifiedTrack:YES];
         saveTrackViewController.delegate = self;
         [OARootViewController.instance presentViewController:saveTrackViewController animated:YES completion:nil];
@@ -1121,7 +1121,7 @@
                     NSArray *nib = [[NSBundle mainBundle] loadNibNamed:[OASwitchTableViewCell getCellIdentifier] owner:self options:nil];
                     cell = (OASwitchTableViewCell *)[nib objectAtIndex:0];
                 }
-                
+
                 if (cell)
                 {
                     OAAppSettings *settings = [OAAppSettings sharedManager];
@@ -1147,10 +1147,10 @@
                 cell.colorIconView.layer.cornerRadius = cell.colorIconView.frame.size.height / 2;
                 cell.colorIconView.backgroundColor = gpxColor.color;
                 [cell.descriptionView setText:gpxColor.name];
-                
+
                 cell.textView.text = OALocalizedString(@"fav_color");
                 cell.backgroundColor = UIColorFromRGB(0xffffff);
-                
+
                 return cell;
             }
             default:
@@ -1168,7 +1168,7 @@
             cell.lbTime.textColor = UIColor.blackColor;
             cell.lbTime.font = [UIFont systemFontOfSize:17. weight:UIFontWeightSemibold];
         }
-        
+
         switch (indexPath.row)
         {
             case 0: // Average speed
@@ -1183,11 +1183,11 @@
                 [cell.lbTime setText:[_app getFormattedSpeed:self.gpx.maxSpeed]];
                 break;
             }
-                
+
             default:
                 break;
         }
-        
+
         return cell;
     }
     else if (indexPath.section == _timeSectionIndex)
@@ -1201,7 +1201,7 @@
             cell.lbTime.textColor = UIColor.blackColor;
             cell.lbTime.font = [UIFont systemFontOfSize:17. weight:UIFontWeightSemibold];
         }
-        
+
         switch (indexPath.row)
         {
             case 0: // Start Time
@@ -1228,11 +1228,11 @@
                 [cell.lbTime setText:[_app getFormattedTimeInterval:self.gpx.timeMoving shortFormat:NO]];
                 break;
             }
-                
+
             default:
                 break;
         }
-        
+
         return cell;
     }
     else if (indexPath.section == _uphillsSectionIndex)
@@ -1246,7 +1246,7 @@
         }
         NSDictionary *attributesUp = @{NSForegroundColorAttributeName : UIColorFromRGB(color_gpx_up), NSFontAttributeName : _upDownFont};
         NSDictionary *attributesDown = @{NSForegroundColorAttributeName : UIColorFromRGB(color_gpx_down), NSFontAttributeName : _upDownFont};
-        
+
         switch (indexPath.row) {
             case 0: // Avg Elevation
             {
@@ -1258,26 +1258,26 @@
             case 1: // Elevation Range
             {
                 [cell.lbTitle setText:OALocalizedString(@"gpx_elev_range")];
-                
+
                 NSMutableAttributedString *rangeUp = [[NSMutableAttributedString alloc] initWithString:[_app getFormattedAlt:self.gpx.minElevation] attributes:attributesUp];
                 NSMutableAttributedString *rangeDown = [[NSMutableAttributedString alloc] initWithString:[_app getFormattedAlt:self.gpx.maxElevation] attributes:attributesDown];
                 [rangeUp appendAttributedString:[[NSAttributedString alloc] initWithString:@" "]];
                 [rangeUp appendAttributedString:[[NSAttributedString alloc] initWithString:@" "]];
                 [rangeUp appendAttributedString:rangeDown];
                 cell.lbTime.attributedText = rangeUp;
-                
+
                 break;
             }
             case 2: // Up/Down
             {
                 [cell.lbTitle setText:OALocalizedString(@"gpx_updown")];
-                
+
                 NSAttributedString *space = [[NSAttributedString alloc] initWithString:@" "];
                 NSAttributedString *arrowUpStr = [NSAttributedString attributedStringWithAttachment:_arrowUp];
                 NSAttributedString *arrowDownStr = [NSAttributedString attributedStringWithAttachment:_arrowDown];
                 NSAttributedString *eleUp = [[NSAttributedString alloc] initWithString:[_app getFormattedAlt:self.gpx.diffElevationUp] attributes:attributesUp];
                 NSAttributedString *eleDown = [[NSAttributedString alloc] initWithString:[_app getFormattedAlt:self.gpx.diffElevationDown] attributes:attributesDown];
-                
+
                 NSMutableAttributedString *res = [[NSMutableAttributedString alloc] initWithAttributedString:arrowUpStr];
                 [res appendAttributedString:space];
                 [res appendAttributedString:eleUp];
@@ -1286,9 +1286,9 @@
                 [res appendAttributedString:arrowDownStr];
                 [res appendAttributedString:space];
                 [res appendAttributedString:eleDown];
-                
+
                 cell.lbTime.attributedText = res;
-                
+
                 break;
             }
             case 3: // Uphills Total
@@ -1297,14 +1297,14 @@
                 cell.lbTime.attributedText = [[NSAttributedString alloc] initWithString:[_app getFormattedAlt:self.gpx.maxElevation - self.gpx.minElevation] attributes:attributesUp];
                 break;
             }
-                
+
             default:
                 break;
         }
-        
+
         return cell;
     }
-    
+
     return nil;
 }
 
@@ -1356,7 +1356,7 @@
 {
     NSArray *items = [_waypointsController getSelectedItems];
     NSString *newGroup = _groupController.groupName;
-    
+
     for (OAGpxWptItem *item in items)
     {
         item.point.type = newGroup;
@@ -1372,7 +1372,7 @@
         NSString *path = [_app.gpxPath stringByAppendingPathComponent:self.gpx.gpxFilePath];
         [_mapViewController updateWpts:items docPath:path updateMap:NO];
     }
-    
+
     _waypointsController.allGroups = [self readGroups];
     [_waypointsController generateData];
     [self editClicked:nil];
@@ -1396,18 +1396,18 @@
 {
     NSArray *items = [_waypointsController getSelectedItems];
     OAFavoriteColor *favCol = [[OADefaultFavorite builtinColors] objectAtIndex:_colorController.colorIndex];
-    
+
     for (OAGpxWptItem *item in items)
     {
         item.color = favCol.color;
-        
+
         if (_showCurrentTrack)
         {
             [OAGPXDocument fillWpt:item.point.wpt usingWpt:item.point];
             [_savingHelper saveWpt:item.point];
         }
     }
-    
+
     if (!_showCurrentTrack)
     {
         NSString *path = [_app.gpxPath stringByAppendingPathComponent:_gpx.gpxFilePath];
@@ -1416,9 +1416,9 @@
     else
     {
         // update map
-        [[_app trackRecordingObservable] notifyEvent];        
+        [[_app trackRecordingObservable] notifyEvent];
     }
-    
+
     [_waypointsController generateData];
     [self editClicked:nil];
 }
@@ -1452,7 +1452,7 @@
                 self.gpx.gpxFileName = newFileName;
                 self.gpx.gpxFilePath = newFilePath;
                 [[OAGPXDatabase sharedDb] save];
-                
+
                 OAGpxMetadata *metadata;
                 if (self.doc.metadata)
                 {
@@ -1481,27 +1481,27 @@
                             }
                         }
                     }
-                    
+
                     if (time == 0)
                         metadata.time = (long)[[NSDate date] timeIntervalSince1970];
                     else
                         metadata.time = time;
                 }
-                
+
                 metadata.name = newFileName;
-                
+
                 if ([NSFileManager.defaultManager fileExistsAtPath:oldPath])
                     [NSFileManager.defaultManager removeItemAtPath:oldPath error:nil];
-                
+
                 BOOL saveFailed = ![_mapViewController updateMetadata:metadata oldPath:oldPath docPath:newPath];
                 self.doc.path = newPath;
                 self.doc.metadata = metadata;
-                
+
                 if (saveFailed)
                     [self.doc saveTo:newPath];
-                
+
                 [OASelectedGPXHelper renameVisibleTrack:oldFilePath newPath:newFilePath];
-                
+
                 self.titleView.text = newName;
                 if (self.delegate)
                     [self.delegate contentChanged];
@@ -1543,22 +1543,22 @@
     NSString *oldPath = _gpx.gpxFilePath;
     NSString *oldName = _gpx.gpxFileName;
     NSString *sourcePath = [OsmAndApp.instance.gpxPath stringByAppendingPathComponent:oldPath];
-    
+
     NSString *newFolder = [newFolderName isEqualToString:OALocalizedString(@"tracks")] ? @"" : newFolderName;
     NSString *newFolderPath = [OsmAndApp.instance.gpxPath stringByAppendingPathComponent:newFolder];
     NSString *newName = newFileName ? newFileName : oldName;
     newName = [self getUniqueFileName:newName inFolderPath:newFolderPath];
     NSString *newStoringPath = [newFolder stringByAppendingPathComponent:newName];
     NSString *destinationPath = [newFolderPath stringByAppendingPathComponent:newName];
-    
+
     [[NSFileManager defaultManager] copyItemAtPath:sourcePath toPath:destinationPath error:nil];
-    
+
     if (deleteOriginalFile)
     {
         [OAGPXDatabase.sharedDb updateGPXFolderName:newStoringPath oldFilePath:oldPath];
         [OAGPXDatabase.sharedDb save];
         [[NSFileManager defaultManager] removeItemAtPath:sourcePath error:nil];
-        
+
         self.titleView.text = [newName stringByDeletingPathExtension];
         [OASelectedGPXHelper renameVisibleTrack:oldPath newPath:newStoringPath];
     }
@@ -1567,12 +1567,12 @@
         OAGPXDocument *gpxDoc = [[OAGPXDocument alloc] initWithGpxFile:sourcePath];
         OAGPXTrackAnalysis *analysis = [gpxDoc getAnalysis:0];
         [OAGPXDatabase.sharedDb addGpxItem:[newFolder stringByAppendingPathComponent:newName] title:newName desc:gpxDoc.metadata.desc bounds:gpxDoc.bounds analysis:analysis];
-        
+
         NSMutableArray *visibleGpx = [NSMutableArray arrayWithArray:OAAppSettings.sharedManager.mapSettingVisibleGpx.get];
         if ([visibleGpx containsObject:oldPath])
             [OAAppSettings.sharedManager showGpx:@[newStoringPath]];
     }
-    
+
     if (self.delegate)
         [self.delegate contentChanged];
 }
@@ -1589,7 +1589,7 @@
     NSString *newFolderPath = [OsmAndApp.instance.gpxPath stringByAppendingPathComponent:addedFolderName];
     if (![[NSFileManager defaultManager] fileExistsAtPath:newFolderPath])
         [[NSFileManager defaultManager] createDirectoryAtPath:newFolderPath withIntermediateDirectories:NO attributes:nil error:nil];
-    
+
     [self onFolderSelected:addedFolderName];
 }
 

--- a/Sources/Controllers/2.0/RoutePlanning/OASaveTrackBottomSheetViewController.mm
+++ b/Sources/Controllers/2.0/RoutePlanning/OASaveTrackBottomSheetViewController.mm
@@ -60,15 +60,15 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     [self.iconImageView setImage:[UIImage templateImageNamed:@"ic_custom_save_complete.png"]];
     self.iconImageView.tintColor = UIColorFromRGB(color_primary_purple);
     self.openSavedTrackButton.layer.cornerRadius = 9.;
     self.createNewRouteButton.layer.cornerRadius = 9.;
     self.shareButton.layer.cornerRadius = 9.;
-    
+
     self.isFullScreenAvailable = NO;
-    
+
     NSString *gpxTitle = _fileName.lastPathComponent.stringByDeletingPathExtension;
     NSString *titleString = [NSString stringWithFormat:OALocalizedString(@"track_is_saved"), gpxTitle];
     self.titleLabel.attributedText = [OAUtilities getColoredString:titleString highlightedString:gpxTitle highlightColor:UIColorFromRGB(color_primary_purple) fontSize:17. centered:YES];
@@ -79,7 +79,7 @@
     [self.openSavedTrackButton setTitle:OALocalizedString(@"open_saved_track") forState:UIControlStateNormal];
     [self.createNewRouteButton setTitle:OALocalizedString(@"plan_route_create_new_route") forState:UIControlStateNormal];
     [self.shareButton setTitle:OALocalizedString(@"ctx_mnu_share") forState:UIControlStateNormal];
-    
+
     [self.leftButton setTitle:OALocalizedString(@"shared_string_close") forState:UIControlStateNormal];
 }
 
@@ -115,12 +115,12 @@
     NSString* tempFolderPath = [NSTemporaryDirectory() stringByAppendingString:[_fileName lastPathComponent]];
     NSURL* destinationGpxUrl = [NSURL fileURLWithPath:tempFolderPath];
     [[NSData dataWithContentsOfURL:sourceGpxUrl] writeToURL:destinationGpxUrl options:NSDataWritingAtomic error:nil];
-    
+
     _exportController = [UIDocumentInteractionController interactionControllerWithURL:destinationGpxUrl];
-    _exportController.UTI = @"net.osmand.gpx";
+    _exportController.UTI = @"com.topografix.gpx";
     _exportController.delegate = self;
     _exportController.name = [tempFolderPath.lastPathComponent stringByDeletingPathExtension];
-    
+
     [_exportController presentOptionsMenuFromRect:self.shareButton.frame
                                            inView:[self.shareButton superview]
                                          animated:YES];


### PR DESCRIPTION
# Changes

Switching the import and export UTIs from `net.osmand.gpx` to the more generic `com.topografix.gpx`.

# Background Information

Other Apps could get into trouble when they register the generic UTI, but apple reserves `net.osmand.gpx` for `.gpx` files because OsmAnd is installed. I recognized this on my own App, which led to bad App Store reviews and other Apps that try to register for the generic UTI might run into the same issue. Please let me know if this PR makes sense and I also can extend this for the other file types that are registered in OsmAnd.

The problems that occured were, that the `UIDocumentPickerViewController` didn't recognize the `.gpx` files at all and the **Share Extension** recognized the files, but didn't read the contents of it. My work around was to support the generic UTI as well as the OsmAnd UTI.
