### PR TITLE
fix gpx import/export bug

### DIFF
--- a/Sources/OAGpxSettingsItem.m
+++ b/Sources/OAGpxSettingsItem.m
@@ -77,16 +77,20 @@
 - (NSString *)fileNameWithFolder
 {
     NSString *folderName = @"";
+    NSString *fileName = self.fileName;
     NSArray<NSString *> *pathComponents = self.filePath.pathComponents;
     if (pathComponents.count > 1)
+    {
         folderName = pathComponents[pathComponents.count - 2];
+        fileName = pathComponents[pathComponents.count - 1];
+    }
     
     NSString *tracksName = @"/tracks";
     if ([folderName isEqualToString:@"GPX"])
         folderName = tracksName;
     else
         folderName = [tracksName stringByAppendingPathComponent:folderName];
-    return [folderName stringByAppendingPathComponent:self.fileName];
+    return [folderName stringByAppendingPathComponent:fileName];
 }
 
 - (void) writeToJson:(id)json


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/discussions/12217

There was bug with creating filename string in exporting osf json. Now it's ok.

<img width="1189" alt="Screenshot 2021-07-23 at 19 48 44" src="https://user-images.githubusercontent.com/35684515/126815182-9cf7bb7a-9dfe-43c3-9ebe-6042c436c885.png">
