### PR TITLE
fix speed widget text bug

### DIFF
--- a/Sources/Controllers/Map/Widgets/OATextInfoWidget.mm
+++ b/Sources/Controllers/Map/Widgets/OATextInfoWidget.mm
@@ -206,6 +206,8 @@
     if (text.length == 0 && subtext.length == 0)
     {
         _textView.text = @"";
+        _text = @"";
+        _subtext = @"";
     }
     else
     {


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd-iOS/issues/1454

Before:
https://www.dropbox.com/s/enu0y1i4s4v6mlv/Screen%20Recording%202021-08-25%20at%2010.17.35.mov?dl=0
After:
https://www.dropbox.com/s/7i5ib1h56xktwy5/Screen%20Recording%202021-08-25%20at%2010.22.12.mov?dl=0

How to reproduce:
Turn on max speed widget.
Start navigation from  48.45075 22.68769   to    48.73547 22.48596
Text disappears here:  48.46020 22.64747