### PR TITLE
fix quick action button position

### DIFF
--- a/Sources/Controllers/QuickAction/OAQuickActionHudViewController.mm
+++ b/Sources/Controllers/QuickAction/OAQuickActionHudViewController.mm
@@ -166,10 +166,30 @@
 // Android counterpart: setQuickActionButtonMargin()
 - (void) setQuickActionButtonPosition
 {
+    CGFloat screenHeight = DeviceScreenHeight;
+    CGFloat screenWidth = DeviceScreenWidth;
+    CGFloat btnHeight = _quickActionFloatingButton.frame.size.height;
+    CGFloat btnWidth = _quickActionFloatingButton.frame.size.width;
+    CGFloat maxRightMargin = screenWidth - btnWidth;
+    CGFloat maxBottomMargin = screenHeight - btnHeight;
+    
+    CGFloat defaultX;
+    CGFloat defaultY;
+    BOOL isLandscape = [OAUtilities isLandscape];
+    if (isLandscape)
+    {
+        defaultX = _mapHudController.mapModeButton.frame.origin.x - btnWidth - kHudButtonsOffset;
+        defaultY = _mapHudController.mapModeButton.frame.origin.y;
+    }
+    else
+    {
+        defaultX = _mapHudController.zoomButtonsView.frame.origin.x;
+        defaultY = _mapHudController.zoomButtonsView.frame.origin.y - btnHeight - kHudButtonsOffset;
+    }
+    
     CGFloat x, y;
     CGFloat w = _quickActionFloatingButton.frame.size.width;
     CGFloat h = _quickActionFloatingButton.frame.size.height;
-    BOOL isLandscape = [OAUtilities isLandscape];
     if (isLandscape)
     {
         x = [_settings.quickActionLandscapeX get];
@@ -180,19 +200,25 @@
         x = [_settings.quickActionPortraitX get];
         y = [_settings.quickActionPortraitY get];
     }
-    if (x == 0. && y == 0.)
+    
+    // check limits
+    if (x <= 0)
     {
-        if (isLandscape)
-        {
-            x = _mapHudController.mapModeButton.frame.origin.x - w - kHudButtonsOffset;
-            y = _mapHudController.mapModeButton.frame.origin.y;
-        }
-        else
-        {
-            x = _mapHudController.zoomButtonsView.frame.origin.x;
-            y = _mapHudController.zoomButtonsView.frame.origin.y - h - kHudButtonsOffset;
-        }
+        x = defaultX;
     }
+    else if (x > maxRightMargin)
+    {
+        x = maxRightMargin;
+    }
+    if (y <= 0)
+    {
+        y = defaultY;
+    }
+    else if (y >= maxBottomMargin)
+    {
+        y = maxBottomMargin;
+    }
+    
     _quickActionFloatingButton.frame = CGRectMake(x, y, w, h);
 }
 

--- a/Sources/Controllers/QuickAction/OAQuickActionHudViewController.mm
+++ b/Sources/Controllers/QuickAction/OAQuickActionHudViewController.mm
@@ -207,14 +207,14 @@
     CGFloat maxBottomMargin = screenHeight - btnHeight - OAUtilities.getBottomMargin;
     
     // check limits
-    if (x < 0)
+    if (x <= 0)
         x = defaultX;
     else if (x > maxRightMargin)
         x = maxRightMargin;
 
-    if (y < OAUtilities.getTopMargin)
+    if (y <= OAUtilities.getTopMargin)
         y = defaultY;
-    else if (y >= maxBottomMargin)
+    else if (y > maxBottomMargin)
         y = maxBottomMargin;
     
     _quickActionFloatingButton.frame = CGRectMake(x, y, btnWidth, btnHeight);
@@ -233,9 +233,9 @@
     CGSize bigButtonSize = _quickActionFloatingButton.frame.size;
     CGFloat halfBigButtonWidth = bigButtonSize.width / 2;
     CGFloat halfSmallButtonWidth = kHudQuickActionButtonHeight / 2;
-    CGFloat leftSafeMargin = halfSmallButtonWidth;
+    CGFloat leftSafeMargin = halfSmallButtonWidth + 1;
     CGFloat rightSafeMargin = DeviceScreenWidth - 2 * OAUtilities.getLeftMargin - halfSmallButtonWidth;
-    CGFloat topSafeMargin = OAUtilities.getStatusBarHeight + halfSmallButtonWidth;
+    CGFloat topSafeMargin = OAUtilities.getStatusBarHeight + halfSmallButtonWidth + 1;
     CGFloat bottomSafeMargin = DeviceScreenHeight - OAUtilities.getBottomMargin - halfSmallButtonWidth;
     
     CGFloat x = newPosition.x;

--- a/Sources/Controllers/QuickAction/OAQuickActionHudViewController.mm
+++ b/Sources/Controllers/QuickAction/OAQuickActionHudViewController.mm
@@ -170,26 +170,24 @@
     CGFloat screenWidth = DeviceScreenWidth;
     CGFloat btnHeight = _quickActionFloatingButton.frame.size.height;
     CGFloat btnWidth = _quickActionFloatingButton.frame.size.width;
-    CGFloat maxRightMargin = screenWidth - btnWidth;
-    CGFloat maxBottomMargin = screenHeight - btnHeight;
+    CGFloat maxRightMargin = screenWidth - btnWidth - 2 * OAUtilities.getLeftMargin;
+    CGFloat maxBottomMargin = screenHeight - btnHeight - OAUtilities.getBottomMargin;
     
     CGFloat defaultX;
     CGFloat defaultY;
     BOOL isLandscape = [OAUtilities isLandscape];
     if (isLandscape)
     {
-        defaultX = _mapHudController.mapModeButton.frame.origin.x - btnWidth - kHudButtonsOffset;
-        defaultY = _mapHudController.mapModeButton.frame.origin.y;
+        defaultX = maxRightMargin - 2 * btnWidth - 2 * kHudButtonsOffset;
+        defaultY = maxBottomMargin;
     }
     else
     {
-        defaultX = _mapHudController.zoomButtonsView.frame.origin.x;
-        defaultY = _mapHudController.zoomButtonsView.frame.origin.y - btnHeight - kHudButtonsOffset;
+        defaultX = maxRightMargin - kHudButtonsOffset;
+        defaultY = maxBottomMargin - 2 * btnWidth - 2 * kHudButtonsOffset;
     }
     
     CGFloat x, y;
-    CGFloat w = _quickActionFloatingButton.frame.size.width;
-    CGFloat h = _quickActionFloatingButton.frame.size.height;
     if (isLandscape)
     {
         x = [_settings.quickActionLandscapeX get];
@@ -219,7 +217,7 @@
         y = maxBottomMargin;
     }
     
-    _quickActionFloatingButton.frame = CGRectMake(x, y, w, h);
+    _quickActionFloatingButton.frame = CGRectMake(x, y, btnWidth, btnHeight);
 }
 
 - (void)viewWillLayoutSubviews


### PR DESCRIPTION
[Issue](https://github.com/osmandapp/OsmAnd-iOS/issues/1730)

[Icon moving video](https://www.dropbox.com/s/coostbb8sl6lt6b/Screen%20Recording%202022-02-01%20at%2018.35.16.mov?dl=0)

If the saved icon coordinate is outside the screen boundary, it will be reset to the default value.

![Screenshot 2022-02-01 at 18 39 21](https://user-images.githubusercontent.com/35684515/152001091-ea2a96c3-ee8c-4d43-8566-356235402117.png)
![Screenshot 2022-02-01 at 18 41 43](https://user-images.githubusercontent.com/35684515/152001134-5a914e55-d0e5-4be4-a4dc-e62c89b145a7.png)

