### PR TITLE
gpx with metadata links crash fix

### DIFF
--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
@@ -1355,18 +1355,18 @@
     NSArray *links = self.doc.metadata.links;
     if (links && links.count > 0)
     {
-        for (NSString *link in links)
+        for (OAGpxLink *link in links)
         {
-            if (link.length > 0)
+            if (link.url.absoluteString && link.url.absoluteString.length > 0)
             {
-                NSString *lowerCaseLink = [link lowerCase];
+                NSString *lowerCaseLink = [link.url.absoluteString lowerCase];
                 if ([lowerCaseLink containsString:@".jpg"] ||
                     [lowerCaseLink containsString:@".jpeg"] ||
                     [lowerCaseLink containsString:@".png"] ||
                     [lowerCaseLink containsString:@".bmp"] ||
                     [lowerCaseLink containsString:@".webp"])
                 {
-                    return link;
+                    return link.url.absoluteString;
                 }
             }
         }


### PR DESCRIPTION
<img width="519" alt="Screenshot 2022-02-04 at 15 10 45" src="https://user-images.githubusercontent.com/35684515/152527035-eb2be0b4-4563-4c63-9479-82798f4c70d8.png">

<img width="519" alt="Screenshot 2022-02-04 at 15 10 52" src="https://user-images.githubusercontent.com/35684515/152527055-79b2a5a7-3621-4d24-bed8-6d63531548e9.png">

<img width="519" alt="Screenshot 2022-02-04 at 15 10 56" src="https://user-images.githubusercontent.com/35684515/152527075-8c62d659-d987-4cd6-ac15-29cac449de83.png">

[gpx file](https://www.dropbox.com/s/ewaja5ixiw9ue6p/Venice.gpx?dl=0)