### PR TITLE
Update Localizable.strings

### DIFF
--- a/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Resources/Localizations/de.lproj/Localizable.strings
@@ -2,8 +2,8 @@
 // Shared Strings
 "shared_string_back" = "Zurück";
 "shared_string_cancel" = "Abbrechen";
-"shared_string_no" = "nein";
-"shared_string_yes" = "ja";
+"shared_string_no" = "Nein";
+"shared_string_yes" = "Ja";
 "shared_string_save" = "Speichern";
 "shared_string_done" = "Fertig";
 "shared_string_update" = "Aktualisieren";


### PR DESCRIPTION
Warum auch immer wurden ausgerechnet "Ja" und "Nein" klein geschrieben..
 
Translation: Yes and no should be uppercase in german.