### PR TITLE
fix turn icon in street name widget

### DIFF
--- a/Sources/Controllers/Map/Widgets/OACurrentStreetName.mm
+++ b/Sources/Controllers/Map/Widgets/OACurrentStreetName.mm
@@ -55,7 +55,7 @@
         streetName.text = [OARoutingHelperUtils formatStreetName:nm ref:rf destination:dn towards:@"»"];
         streetName.turnType = n.directionInfo.turnType;
         streetName.shieldObject = n.directionInfo.routeDataObject;
-        if (streetName.turnType)
+        if (!streetName.turnType)
             streetName.turnType = TurnType::ptrValueOf(TurnType::C, false);
         if (n.directionInfo.exitInfo != nil)
         {


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/2014)
[video](https://www.dropbox.com/s/inbf7zovldq3ugv/Screen%20Recording%202022-06-29%20at%2023.18.04.mov?dl=0)
<img width="808" alt="Screenshot 2022-06-29 at 23 18 54" src="https://user-images.githubusercontent.com/35684515/176613111-83addfb6-8c38-4694-b4e7-f8f737eebebe.png">
