### PR TITLE
fix show on map button

### DIFF
--- a/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
+++ b/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
@@ -1690,12 +1690,7 @@ typedef BOOL(^OASearchFinishedCallback)(OASearchPhrase *phrase);
         }
     }
     NSString *txt = [[self.searchUICore getPhrase] getText:YES];
-    self.searchQuery = txt;
-    [self updateTextField:txt];
-    OASearchSettings *settings = [self.searchUICore getSearchSettings];
-    if ([settings getRadiusLevel] != 1)
-        [self.searchUICore updateSettings:[settings setRadiusLevel:1]];
-
+    [self replaceQueryWithText:txt];
     [self runCoreSearch:txt updateResult:NO searchMore:NO];
 }
 
@@ -1703,10 +1698,25 @@ typedef BOOL(^OASearchFinishedCallback)(OASearchPhrase *phrase);
 {
     self.searchQuery = txt;
     [self updateTextField:txt];
+    
+    OASearchWord *lastWord = [self.searchUICore getPhrase].getLastSelectedWord;
+    BOOL buttonToolbarVisible = self.searchType == OAQuickSearchType::REGULAR;
+    if (!buttonToolbarVisible)
+    {
+        if (!lastWord)
+            buttonToolbarVisible = YES;
+        else if (self.searchType != OAQuickSearchType::REGULAR && lastWord.getLocation)
+            buttonToolbarVisible = YES;
+    }
+    
+    if (buttonToolbarVisible)
+        [self restoreInputLayout];
+    
+    _barActionView.hidden = !buttonToolbarVisible;
+    [self updateBarActionView];
     OASearchSettings *settings = [self.searchUICore getSearchSettings];
     if ([settings getRadiusLevel] != 1)
         [self.searchUICore updateSettings:[settings setRadiusLevel:1]];
-
     [self runCoreSearch:txt updateResult:NO searchMore:NO];
 }
 

--- a/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
+++ b/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
@@ -1692,7 +1692,7 @@ typedef BOOL(^OASearchFinishedCallback)(OASearchPhrase *phrase);
         }
     }
     NSString *txt = [[self.searchUICore getPhrase] getText:YES];
-    [self replaceQueryWithText:txt];
+    self.searchQuery = txt;
     [self updateTextField:txt];
     OASearchSettings *settings = [self.searchUICore getSearchSettings];
     if ([settings getRadiusLevel] != 1)


### PR DESCRIPTION
[issue Stresa](https://github.com/osmandapp/OsmAnd/issues/14983)

Part 1 Search results order.

Skipped. Because order in iOS and Androis is laready the same
<img width="787" alt="Screenshot 2022-09-30 at 15 05 34" src="https://user-images.githubusercontent.com/35684515/193799044-59c9db08-30a5-4e49-8a9c-9f5f99a6539f.png">


Part 2 - Disappeared button

Before - without button
<img width="400" alt="Screenshot 2022-09-30 at 15 10 22" src="https://user-images.githubusercontent.com/35684515/193797059-4c0bec7f-f6f2-4d9c-a65e-100642a2495e.png">

Now - with button
<img width="400" alt="Screenshot 2022-10-04 at 15 30 06" src="https://user-images.githubusercontent.com/35684515/193797364-dd198bb3-2a89-49c0-bc6f-b80d55feb742.png">

Synced this code from Android:
https://github.com/osmandapp/OsmAnd/blob/238a37c1e4640b8f4c7a2a646ee2005399f46e65/OsmAnd/src/net/osmand/plus/search/QuickSearchDialogFragment.java#L1970

---

[issue Milano](https://github.com/osmandapp/OsmAnd-iOS/issues/2140)
Also this PR fixed that issue

<img width="400" alt="Screenshot 2022-10-04 at 15 32 27" src="https://user-images.githubusercontent.com/35684515/193797957-5830baa0-9630-49bf-989c-919e692cf2ff.png">

