### PR TITLE
Fix: description text is not fit on iPhone 13 mini

### DIFF
--- a/Sources/Controllers/ChoosePlan/Views/OASubscriptionCardView.mm
+++ b/Sources/Controllers/ChoosePlan/Views/OASubscriptionCardView.mm
@@ -177,7 +177,7 @@
     );
     self.labelTitle.frame = CGRectMake(
             leftMargin,
-            9.,
+            self.viewTitleContainer.frame.origin.y,
             titleSize.width,
             titleSize.height
     );


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 13 mini - 2022-10-27 at 12 17 40](https://user-images.githubusercontent.com/111898301/198283053-4e17aa1f-2cc7-4155-bb80-02b6451372fb.png)
![Simulator Screen Shot - iPhone 13 mini - 2022-10-27 at 12 17 53](https://user-images.githubusercontent.com/111898301/198283056-dd9b6ce9-21dc-4bd5-bc12-8553a59bc8cf.png)
