### PR TITLE
Add several recycling waste types

### DIFF
--- a/Resources/phrases.xml
+++ b/Resources/phrases.xml
@@ -389,6 +389,10 @@
 	<string name="poi_recycling_car_batteries">Car batteries</string>
 	<string name="poi_recycling_cars">Cars</string>
 	<string name="poi_recycling_bicycles">Bicycles</string>
+	<string name="poi_recycling_plastic_bottle_caps">Plastic bottle caps</string>
+	<string name="poi_recycling_aluminium_cans">Aluminium cans</string>
+	<string name="poi_recycling_pet_drink_bottles">PET beverage bottles</string>
+	<string name="poi_recycling_textiles">Textiles</string>
 
 	<string name="poi_landfill">Landfill</string>
 	<string name="poi_landfill_waste_nuclear">Nuclear waste</string>


### PR DESCRIPTION
This adds four new types of recycling waste that I see in OSM. They are all present in the table for [`amenity=recycling`][table].

I've verified the changes locally after creating a piece of the map with these recycling POIs.

<img width="393" alt="recycling@2x" src="https://user-images.githubusercontent.com/9215359/220266074-885bb5c2-af8c-4a75-af74-83e99b4e4b6c.png">

[table]: https://wiki.openstreetmap.org/wiki/Tag:amenity=recycling#Accepts