### PR TITLE
arabic numbers fixed

### DIFF
--- a/Sources/Helpers/OAOsmAndFormatter.mm
+++ b/Sources/Helpers/OAOsmAndFormatter.mm
@@ -271,7 +271,7 @@ static NSString * const _unitsmps = OALocalizedString(@"m_s");
     }
     numberFormatter.positiveFormat = pattern;
 
-    NSString *preferredLocale = [[OAAppSettings sharedManager] settingPrefMapLanguage].get;
+    NSString *preferredLocale = OAUtilities.currentLang;
     NSLocale *locale = [NSLocale localeWithLocaleIdentifier:preferredLocale];
 
     numberFormatter.locale = locale;


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-Issues/issues/2074)

imported setting:
<img width="300" alt="Screenshot 2023-07-04 at 15 57 23" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/e07c636b-3987-44a7-b90a-27c75d5351d1">

Before. App lang: English

<img width="500" alt="Screenshot 2023-07-04 at 15 54 07" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/32da1aa3-792a-4ead-bc2e-bb94b63925d4">

After. App lang: English

<img width="500" alt="Screenshot 2023-07-04 at 15 56 59" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/b4ad5187-c1f4-4145-bb31-01cd8abf0176">

After. App lang: Arabic

<img width="500" alt="Screenshot 2023-07-04 at 15 59 59" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/ca47a07e-d0e1-433c-af15-a2f08e90308d">



