### PR TITLE
Use `saveTrackMinDistance` at location service level

### DIFF
--- a/Sources/Services/OALocationServices.mm
+++ b/Sources/Services/OALocationServices.mm
@@ -570,11 +570,21 @@
     CLLocationManager *manager = self.getLocationManager;
     if (!manager)
         return;
+    
+    OALog(@"Recording track: Is enabled: %@", _settings.mapSettingTrackRecording ? @"YES" : @"NO");
+    OALog(@"Recording track: Is following: %@", [_routingHelper isFollowingMode] ? @"YES" : @"NO");
 
-    if (enable)
+    // Distance filter will use the selected saveTrackMinDistance if not in following mode
+    if (enable && ![_routingHelper isFollowingMode] && _settings.mapSettingTrackRecording) {
+        manager.distanceFilter = (long)[_settings.saveTrackMinDistance get];
+        OALog(@"Recording track: Setting background distance filter to: %ld", (long)[_settings.saveTrackMinDistance get]);
+    } else if (enable) {
         manager.distanceFilter = [_settings.applicationMode.get getBackgroundDistanceFilter];
-    else
+        OALog(@"Setting background distance filter to: %ld", (long)[_settings.applicationMode.get getBackgroundDistanceFilter]);
+    } else {
         manager.distanceFilter = kCLDistanceFilterNone;
+        OALog(@"Setting background distance filter to: none");
+    }
 }
 
 + (BOOL) isPointAccurateForRouting:(CLLocation *)loc


### PR DESCRIPTION
I was looking for a way to improve battery usage when trip recording while the app is in background.

This PR is a draft and builds on the following assumptions, please correct me if they are wrong.

In my understanding whenever the `distanceFilter` value is reached, iOS will "wake" the app in the background. Currently when having a speed <10 this value defaults to 5 (meters?), which seems like a very high precision to me, especially when having bad GPS conditions. In my scenario it results in a 100% background activity every time (up to 1h background activity/hour)

In my trip recording settings I've set the value for "Minimum displacement" to 50 (meters). So there is no reason to call the update function every 5 meters/units, when no active navigation (following) is running.

I was not able to test if this change has the expected impact, as I don't have a valid provisioning profile to install the app on my physical device. I however tested the changes in the simulator, to see if the values were set correctly.

What do you think, could this change possibly reduce power consumption when running in background or did I miss the point?