### PR TITLE
travel_guides_poits_saving_bug

### DIFF
--- a/Sources/Controllers/TravelGuides/data/OATravelLocalDataDbHelper.mm
+++ b/Sources/Controllers/TravelGuides/data/OATravelLocalDataDbHelper.mm
@@ -67,6 +67,7 @@
     self = [super init];
     if (self) {
         BOOL isDir = YES;
+        _tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:TEMP_DIR_NAME];
         if (![[NSFileManager defaultManager] fileExistsAtPath:_tmpDir isDirectory:&isDir])
             [[NSFileManager defaultManager] createDirectoryAtPath:_tmpDir withIntermediateDirectories:YES attributes:nil error:nil];
     }

--- a/Sources/Controllers/TravelGuides/data/TravelLocalDataHelper.swift
+++ b/Sources/Controllers/TravelGuides/data/TravelLocalDataHelper.swift
@@ -84,10 +84,10 @@ final class TravelLocalDataHelper : NSObject {
     func removeArticleFromSaved(article: TravelArticle) {
         let savedArticle = getArticle(title: article.title ?? "", lang: article.lang ?? "")
         if let savedArticle {
+            dbHelper.removeSavedArticle(savedArticle)
             if let index = savedArticles.firstIndex(of: savedArticle) {
                 savedArticles.remove(at: index)
             }
-            dbHelper.removeSavedArticle(savedArticle)
             notifySavedUpdated()
         }
     }

--- a/Sources/Controllers/TravelGuides/data/TravelLocalDataHelper.swift
+++ b/Sources/Controllers/TravelGuides/data/TravelLocalDataHelper.swift
@@ -84,9 +84,9 @@ final class TravelLocalDataHelper : NSObject {
     func removeArticleFromSaved(article: TravelArticle) {
         let savedArticle = getArticle(title: article.title ?? "", lang: article.lang ?? "")
         if let savedArticle {
-            dbHelper.removeSavedArticle(savedArticle)
             if let index = savedArticles.firstIndex(of: savedArticle) {
                 savedArticles.remove(at: index)
+                dbHelper.removeSavedArticle(savedArticle)
             }
             notifySavedUpdated()
         }


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3459)

Fixed bug with saving and reading article gpx points.
Also fixed bug with deleting saved article.

Screenshot of opened saved article without any travel guides files. All points are available.  
<img alt="Screenshot 2024-03-25 at 18 25 08" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/0268d627-f53a-472a-ae8b-7934f4d5ba5c"> <img alt="Screenshot 2024-03-25 at 18 25 12" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/26f5d146-e3cd-47bf-a9ea-262f43b3ae0b">

