### PR TITLE
increace travel guides saved articles screen loading speed

### DIFF
--- a/.github/workflows/xcode-build.yml
+++ b/.github/workflows/xcode-build.yml
@@ -14,7 +14,7 @@ on:
       releaseversion:
         description: 'Release Version'
         required: true
-        default: '4.8.0'
+        default: '4.7.0'
       download_qt_ios_library:
         description: 'Download prebuilt qt library (true) or build locally (false) - extra 2 h'
         required: true
@@ -45,36 +45,36 @@ jobs:
     - name: Checkout ios
       uses: actions/checkout@v3
       with:
-        ref: refs/heads/master
+        ref: refs/heads/r4.7
         path: ios
     - name: Checkout android
       uses: actions/checkout@v3
       with:
-        ref: refs/heads/master
+        ref: refs/heads/r4.7
         repository: osmandapp/OsmAnd
         path: android
     - name: Checkout build
       uses: actions/checkout@v3
       with:
-        ref: refs/heads/master
+        ref: refs/heads/r4.7
         repository: osmandapp/OsmAnd-build
         path: build
     - name: Checkout core legacy
       uses: actions/checkout@v3
       with:
-        ref: refs/heads/master
+        ref: refs/heads/r4.7
         repository: osmandapp/OsmAnd-core-legacy
         path: core-legacy
     - name: Checkout core
       uses: actions/checkout@v3
       with:
-        ref: refs/heads/master
+        ref: refs/heads/r4.7
         repository: osmandapp/OsmAnd-core
         path: core
     - name: Checkout resources
       uses: actions/checkout@v3
       with:
-        ref: refs/heads/master
+        ref: refs/heads/r4.7
         repository: osmandapp/OsmAnd-resources
         path: resources
     - name: Select XCode 15.0.1

--- a/Sources/Helpers/OAWikiArticleHelper.mm
+++ b/Sources/Helpers/OAWikiArticleHelper.mm
@@ -381,11 +381,13 @@
 + (NSString *) fromHtml:(NSString *)htmlText
 {
     //method to replace Java Html.fromHtml()
-    NSString *result;
-    NSAttributedString *attrString = [OAUtilities attributedStringFromHtmlString:htmlText fontSize:17 textColor:nil];
-    if (attrString)
-        result = attrString.string;
-    return result;
+    NSRange r;
+    NSString *s = htmlText;
+    while ((r = [s rangeOfString:@"<[^>]+>" options:NSRegularExpressionSearch]).location != NSNotFound)
+        s = [s stringByReplacingCharactersInRange:r withString:@""];
+    while ((r = [s rangeOfString:@"(?=&#)(.*)(?<=;)" options:NSRegularExpressionSearch]).location != NSNotFound)
+        s = [s stringByReplacingCharactersInRange:r withString:@""];
+    return s;
 }
 
 + (NSString *) normalizeFileUrl:(NSString *)url

--- a/Sources/POI/OAPOIHelper.mm
+++ b/Sources/POI/OAPOIHelper.mm
@@ -1043,10 +1043,11 @@
                                         (const OsmAnd::ISearch::Criteria& criteria, const OsmAnd::ISearch::IResultEntry& resultEntry)
                                         {
                                             const auto &am = ((OsmAnd::AmenitiesByNameSearch::ResultEntry&)resultEntry).amenity;
-
-                                            OAPOI *poi = [OAPOIHelper parsePOI:resultEntry withValues:YES withContent:YES];
+                                            const auto decodedValues = am->getDecodedValues();
+        
+                                            OAPOI *poi = [OAPOIHelper parsePOI:resultEntry withValues:YES withContent:YES decodedValues:decodedValues];
                                             poi.distanceMeters = OsmAnd::Utilities::squareDistance31(_myLocation, am->position31);
-                                            [OAPOIHelper fetchValuesContentPOIByAmenity:am poi:poi];
+                                            [OAPOIHelper fetchValuesContentPOIByAmenity:am poi:poi decodedValues:decodedValues];
                                             
                                             if (publish)
                                             {
@@ -1338,9 +1339,14 @@
 
 + (OAPOI *) parsePOI:(const OsmAnd::ISearch::IResultEntry&)resultEntry withValues:(BOOL)withValues withContent:(BOOL)withContent
 {
+    return [self.class parsePOI:resultEntry withValues:withValues withContent:withContent];
+}
+
++ (OAPOI *) parsePOI:(const OsmAnd::ISearch::IResultEntry&)resultEntry withValues:(BOOL)withValues withContent:(BOOL)withContent decodedValues:(QList<OsmAnd::Amenity::DecodedValue>)decodedValues
+{
     const auto& amenity = ((OsmAnd::AmenitiesByNameSearch::ResultEntry&)resultEntry).amenity;
     OAPOIType *type = [self.class parsePOITypeByAmenity:amenity];
-    return [self.class parsePOIByAmenity:amenity type:type withValues:withValues withContent:withContent];
+    return [self.class parsePOIByAmenity:amenity type:type withValues:withValues withContent:withContent decodedValues:decodedValues];
 }
 
 + (OAPOIType *) parsePOITypeByAmenity:(const std::shared_ptr<const OsmAnd::Amenity> &)amenity
@@ -1381,6 +1387,11 @@
 
 + (OAPOI *) parsePOIByAmenity:(const std::shared_ptr<const OsmAnd::Amenity> &)amenity type:(OAPOIType *)type withValues:(BOOL)withValues withContent:(BOOL)withContent
 {
+    return [self.class parsePOIByAmenity:amenity type:type withValues:withValues withContent:withContent decodedValues:QList<OsmAnd::Amenity::DecodedValue>()];
+}
+
++ (OAPOI *) parsePOIByAmenity:(const std::shared_ptr<const OsmAnd::Amenity> &)amenity type:(OAPOIType *)type withValues:(BOOL)withValues withContent:(BOOL)withContent decodedValues:(QList<OsmAnd::Amenity::DecodedValue>)decodedValues
+{
     if (!type || type.mapOnly || [[OAAppSettings sharedManager] isTypeDisabled:amenity->subType.toNSString()])
         return nil;
     
@@ -1399,6 +1410,10 @@
     
     NSMutableDictionary *content = [NSMutableDictionary dictionary];
     NSMutableDictionary *values = [NSMutableDictionary dictionary];
+    QList<OsmAnd::Amenity::DecodedValue> decoded = decodedValues;
+    if (decoded.isEmpty())
+        decoded = amenity->getDecodedValues();
+    
     [OAPOIHelper processDecodedValues:amenity->getDecodedValues() content:(withContent ? content : nil) values:(withValues ? values : nil)];
     poi.values = values;
     poi.localizedContent = content;
@@ -1429,9 +1444,18 @@
 
 + (void) fetchValuesContentPOIByAmenity:(const std::shared_ptr<const OsmAnd::Amenity> &)amenity poi:(OAPOI *)poi
 {
+    [self.class fetchValuesContentPOIByAmenity:amenity poi:poi decodedValues:QList<OsmAnd::Amenity::DecodedValue>()];
+}
+
++ (void) fetchValuesContentPOIByAmenity:(const std::shared_ptr<const OsmAnd::Amenity> &)amenity poi:(OAPOI *)poi decodedValues:(QList<OsmAnd::Amenity::DecodedValue>)decodedValues
+{
     NSMutableDictionary *content = [NSMutableDictionary dictionary];
     NSMutableDictionary *values = [NSMutableDictionary dictionary];
-    [OAPOIHelper processDecodedValues:amenity->getDecodedValues() content:content values:values];
+    QList<OsmAnd::Amenity::DecodedValue> decoded = decodedValues;
+    if (decoded.isEmpty())
+        decoded = amenity->getDecodedValues();
+    
+    [OAPOIHelper processDecodedValues:decoded content:content values:values];
     poi.values = values;
     poi.localizedContent = content;
 }

--- a/Sources/POI/OAPOIHelper.mm
+++ b/Sources/POI/OAPOIHelper.mm
@@ -1414,7 +1414,7 @@
     if (decoded.isEmpty())
         decoded = amenity->getDecodedValues();
     
-    [OAPOIHelper processDecodedValues:amenity->getDecodedValues() content:(withContent ? content : nil) values:(withValues ? values : nil)];
+    [OAPOIHelper processDecodedValues:decoded content:(withContent ? content : nil) values:(withValues ? values : nil)];
     poi.values = values;
     poi.localizedContent = content;
     


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3542)
[core request](https://github.com/osmandapp/OsmAnd-core/pull/729)

Video Before ~ 8 sec
https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/b5aaa030-61f5-4b17-9a6c-96567fdeffca

Video After ~ 2 sec
https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/41152029-7c8d-417a-9c25-84d01c97946e

---
Turned off slowly ICU::cmathes for TravelGuides. Because this is not search. This is opening article by strict matching with article ID.
<img width="1728" alt="Screenshot 2024-04-19 at 20 53 57" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/d96289d7-bf09-4058-a0b0-ad5f6fbd17ff">

Rewrited HtmlToText function to regexp. System function via NSAttributedString was too slow.
<img width="1728" alt="Screenshot 2024-04-19 at 20 54 23" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/6b501359-ed94-4b78-95d8-dfc1525626e3">

Make decoding amenity values once (was twice)
<img width="1728" alt="Screenshot 2024-04-19 at 21 32 38" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/668c70d0-6ba5-4d40-a076-a8bc43575d33">


