### PR TITLE
47_crashfix_tracksList

### DIFF
--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
@@ -233,8 +233,13 @@
 
     [self startLocationServices];
 
-    if (_reopeningState && _reopeningState.showingState != EOADraggableMenuStateInitial)
-        [self updateShowingState:_reopeningState.showingState];
+    if (_reopeningState)
+    {
+        if (_reopeningState.showingState != EOADraggableMenuStateInitial)
+            [self updateShowingState:_reopeningState.showingState];
+        if (_reopeningState.openedFromTracksList)
+            [OARootViewController instance].navigationController.interactivePopGestureRecognizer.enabled = NO;
+    }
 
     UIImage *groupsImage = [UIImage templateImageNamed:@"ic_custom_folder_visible"];
     [self.groupsButton setImage:groupsImage forState:UIControlStateNormal];
@@ -411,6 +416,7 @@
         {
             [[OARootViewController instance].navigationController setViewControllers:_navControllerHistory animated:YES];
         }
+        [OARootViewController instance].navigationController.interactivePopGestureRecognizer.enabled = YES;
     }
 }
 


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd-iOS/issues/3729

`OsmAnd Maps: UIKitCore: -[UINavigationController _setViewControllers:transition:animated:operation:] + 364`

video before (long tryin to reproduce crash)
https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/71d8e76d-fbc9-40a1-a5be-f8c3f7fd3a89

video after
https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/bbf55194-7f35-4e8d-b8f3-df36fa329679


