### PR TITLE
47_crashfix_createUniqueFileName

### DIFF
--- a/Sources/Controllers/RoutePlanning/OARoutePlanningHudViewController.mm
+++ b/Sources/Controllers/RoutePlanning/OARoutePlanningHudViewController.mm
@@ -968,9 +968,7 @@ typedef NS_ENUM(NSInteger, EOAHudMode) {
     }
     if (gpxData == nil || displayedName == nil)
     {
-        NSDateFormatter *objDateFormatter = [[NSDateFormatter alloc] init];
-        [objDateFormatter setDateFormat:@"EEE dd MMM yyyy"];
-        NSString *suggestedName = [objDateFormatter stringFromDate:[NSDate date]];
+        NSString *suggestedName = [OAUtilities generateCurrentDateFilename];
         displayedName = [self createUniqueFileName:suggestedName];
     }
     else

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
@@ -1510,7 +1510,12 @@
     NSString *folderPath = [_app.gpxPath stringByAppendingPathComponent:@"Travel"];
     if (![[NSFileManager defaultManager] fileExistsAtPath:folderPath])
         [[NSFileManager defaultManager] createDirectoryAtPath:folderPath withIntermediateDirectories:NO attributes:nil error:nil];
-    NSString *path = [self createUniqueFileName:self.doc.path.lastPathComponent path:folderPath];
+    
+    NSString *filename = self.doc.path.lastPathComponent;
+    if (!filename || filename.length == 0)
+        filename = [OAUtilities generateCurrentDateFilename];
+        
+    NSString *path = [self createUniqueFileName:filename path:folderPath];
     [self.doc saveTo:path];
     self.doc.path = path;
     OAGPX *gpx = [[OAGPXDatabase sharedDb] addGpxItem:path title:self.doc.metadata.name desc:nil bounds:self.doc.bounds document:self.doc];

--- a/Sources/Helpers/OAUtilities.h
+++ b/Sources/Helpers/OAUtilities.h
@@ -410,4 +410,6 @@ static inline UIColor * colorFromARGB(NSInteger rgbValue)
 
 + (BOOL) isReleaseVersion;
 
++ (NSString *) generateCurrentDateFilename;
+
 @end

--- a/Sources/Helpers/OAUtilities.m
+++ b/Sources/Helpers/OAUtilities.m
@@ -2966,4 +2966,11 @@ static const double d180PI = 180.0 / M_PI_2;
     return ![kDocsLatestVersion containsString:@"future-ios"];
 }
 
++ (NSString *) generateCurrentDateFilename
+{
+    NSDateFormatter *objDateFormatter = [[NSDateFormatter alloc] init];
+    [objDateFormatter setDateFormat:@"EEE dd MMM yyyy"];
+    return [objDateFormatter stringFromDate:[NSDate date]];
+}
+
 @end


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3729)

`OsmAnd Maps: -[OATrackMenuHudViewController createUniqueFileName:path:] + 256`

video:
https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/311e0769-6780-44e3-89d5-d2c923ba20ae

