### PR TITLE
47_crashfix_locationName

### DIFF
--- a/Sources/Router/OATargetPointsHelper.mm
+++ b/Sources/Router/OATargetPointsHelper.mm
@@ -653,7 +653,7 @@
     BOOL isAddressFound = NO;
     NSString *formattedTargetName = nil;
     NSString *roadTitle = nil;
-    if (location)
+    if (location && CLLocationCoordinate2DIsValid(location.coordinate))
         roadTitle = [[OAReverseGeocoder instance] lookupAddressAtLat:location.coordinate.latitude lon:location.coordinate.longitude];
     if (!roadTitle || roadTitle.length == 0)
     {

--- a/Sources/Router/OATargetPointsHelper.mm
+++ b/Sources/Router/OATargetPointsHelper.mm
@@ -652,7 +652,9 @@
     NSString *addressString = nil;
     BOOL isAddressFound = NO;
     NSString *formattedTargetName = nil;
-    NSString *roadTitle = [[OAReverseGeocoder instance] lookupAddressAtLat:location.coordinate.latitude lon:location.coordinate.longitude];
+    NSString *roadTitle = nil;
+    if (location)
+        roadTitle = [[OAReverseGeocoder instance] lookupAddressAtLat:location.coordinate.latitude lon:location.coordinate.longitude];
     if (!roadTitle || roadTitle.length == 0)
     {
         addressString = OALocalizedString(@"map_no_address");


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3729)

`OsmAnd Maps: -[OATargetPointsHelper getLocationName:] + 64`

Can't reproduce. But this line from crashlog can crash only if location is nil. So I added a check for it.

<img width="1728" alt="Screenshot 2024-05-31 at 18 53 47" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/6309e997-7891-4823-9405-d621c1e326cc">
