### PR TITLE
47_crashfix_downloadRemoteVersion

### DIFF
--- a/Sources/Backup/OANetworkSettingsHelper.m
+++ b/Sources/Backup/OANetworkSettingsHelper.m
@@ -256,7 +256,7 @@
             }
             case EOABackupSyncOperationDownload:
             {
-                if (remoteFile)
+                if (remoteFile && remoteFile.item)
                     [syncTask downloadRemoteVersion:remoteFile.item filesType:filesType shouldReplace:shouldReplace restoreDeleted:restoreDeleted];
                 break;
             }


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3729)

`OsmAnd Maps: -[OASyncBackupTask downloadRemoteVersion:filesType:shouldReplace:restoreDeleted:] + 156`

Can't reproduce crash. But looking to code of crashed function it seems it can crash on creation an array with nil element. So I added a check for it.

<img width="1230" alt="Screenshot 2024-06-03 at 18 39 42" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/c69fea67-e1cc-4772-b9e3-ad1a19a32b6c">
