### PR TITLE
Update Localizable.strings

### DIFF
--- a/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Resources/Localizations/de.lproj/Localizable.strings
@@ -320,7 +320,7 @@
 "show_alt_in_drive" = "Höhe im Fahrmodus anzeigen";
 "shared_string_get" = "Erwerben";
 "srtm_plugin_disabled" = "Topographie deaktiviert";
-"shared_string_open" = "Öffnen";
+"shared_string_open" = "Geöffnet";
 "time_closed" = "Geschlossen";
 "will_close_at" = "Schließt um";
 "time_will_open" = "Öffnet in";


### PR DESCRIPTION
I fixed a grammar mistake in the German localization file. I'm a native speaker.

"Öffnen" means to open. "Geöffnet" means that sth is open.