### PR TITLE
fix_subway_icon_in_search

### DIFF
--- a/Sources/POI/OAPOI.mm
+++ b/Sources/POI/OAPOI.mm
@@ -46,7 +46,7 @@ static NSArray<NSString *> *const HIDDEN_EXTENSIONS = @[
 {
     NSString *subwayRegion = [self getAdditionalInfo][@"subway_region"];
 	if (subwayRegion.length > 0)
-        return [UIImage svgImageNamed:[NSString stringWithFormat:@"map-icons-svg/mx_subway_%@", subwayRegion]];
+        return [UIImage svgImageNamed:[NSString stringWithFormat:@"map-icons-svg/c_mx_subway_%@", subwayRegion]];
     else if (_mapIconName && _mapIconName.length > 0 && ![_mapIconName containsString:@"_small"])
         return [UIImage mapSvgImageNamed:[NSString stringWithFormat:@"mx_%@", _mapIconName]];
     else if (_type)


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3711)

Before
<img width="1136" alt="Screenshot 2024-06-13 at 23 17 47" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/335c396a-e5ce-48fb-9f8b-8b94d0448e20">

After
<img width="1136" alt="Screenshot 2024-06-13 at 23 16 48" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/6e3d876a-b2e3-4766-b843-5086df09812d">

filenames:
<img width="1676" alt="Screenshot 2024-06-13 at 23 15 28" src="https://github.com/osmandapp/OsmAnd-iOS/assets/35684515/4bd1e80a-f2b9-46e2-b134-7601679dc901">
