### PR TITLE
Weather alpha changing fix

### DIFF
--- a/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
+++ b/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
@@ -570,6 +570,9 @@
         _app.data.weatherWindAnimationAlpha = sender.value;
     else if (_layerType == EOAWeatherLayerTypeContours)
         _app.data.contoursAlpha = sender.value;
+    
+    [self generateData];
+    [self.tableView reloadData];
 }
 
 // MARK: UITableViewDataSource
@@ -707,8 +710,10 @@
             cell.valueLabel.text = [NSString stringWithFormat:@"%.0f%%", [item[@"value"] doubleValue] * 100];
             [cell.sliderView setValue:[item[@"value"] floatValue]];
             
+            // TODO: delete when android team fix alpha changing bug https://github.com/osmandapp/OsmAnd/issues/20533
+            //[cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
             [cell.sliderView removeTarget:nil action:NULL forControlEvents:UIControlEventAllEvents];
-            [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
+            [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside];
         }
         return cell;
     }

--- a/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
+++ b/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
@@ -707,10 +707,8 @@
             cell.valueLabel.text = [NSString stringWithFormat:@"%.0f%%", [item[@"value"] doubleValue] * 100];
             [cell.sliderView setValue:[item[@"value"] floatValue]];
             
-            // TODO: delete when android team fix alpha changing bug https://github.com/osmandapp/OsmAnd/issues/20533
-            //[cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
             [cell.sliderView removeTarget:nil action:NULL forControlEvents:UIControlEventAllEvents];
-            [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside];
+            [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
         }
         return cell;
     }

--- a/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
+++ b/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
@@ -709,6 +709,7 @@
             
             // TODO: delete when android team fix alpha changing bug https://github.com/osmandapp/OsmAnd/issues/20533
             //[cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
+            [cell.sliderView removeTarget:nil action:NULL forControlEvents:UIControlEventAllEvents];
             [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside];
         }
         return cell;

--- a/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
+++ b/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
@@ -706,7 +706,10 @@
             cell.titleLabel.text = item[@"title"];
             cell.valueLabel.text = [NSString stringWithFormat:@"%.0f%%", [item[@"value"] doubleValue] * 100];
             [cell.sliderView setValue:[item[@"value"] floatValue]];
-            [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
+            
+            // TODO: delete when android team fix alpha changing bug
+            //[cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
+            [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside];
         }
         return cell;
     }

--- a/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
+++ b/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
@@ -707,7 +707,7 @@
             cell.valueLabel.text = [NSString stringWithFormat:@"%.0f%%", [item[@"value"] doubleValue] * 100];
             [cell.sliderView setValue:[item[@"value"] floatValue]];
             
-            // TODO: delete when android team fix alpha changing bug
+            // TODO: delete when android team fix alpha changing bug https://github.com/osmandapp/OsmAnd/issues/20533
             //[cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
             [cell.sliderView addTarget:self action:@selector(onSliderValueChanged:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside];
         }

--- a/Sources/Controllers/Map/Layers/OAWeatherRasterLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAWeatherRasterLayer.mm
@@ -44,6 +44,7 @@
     CGSize _cachedViewFrame;
     OsmAnd::PointI _cachedCenterPixel;
     BOOL _cachedAnyWidgetVisible;
+    BOOL _wasAlphaChanged;
     NSTimeInterval _lastUpdateTime;
     
     int64_t _timePeriodStart;
@@ -133,6 +134,7 @@
     
     if (_dateTime == 0)
         [self setDateTime:[[NSDate now] timeIntervalSince1970] * 1000 goForward:YES resetPeriod:NO];
+//        [self setDateTime:[[NSDate now] timeIntervalSince1970] * 1000 goForward:NO resetPeriod:NO];
 
     if ([[OAPluginsHelper getPlugin:OAWeatherPlugin.class] isEnabled])
     {
@@ -159,9 +161,18 @@
                 layer = OsmAnd::WeatherLayer::Low;
                 break;
         }
-        if (!_provider || wasBandsChanged)
+        
+        // TODO: delete when android team fix alpha changing bug
+        if (_wasAlphaChanged)
+        {
+            _timePeriodEnd = _timePeriodStart;
+        }
+        
+        if (!_provider || wasBandsChanged || _wasAlphaChanged)
         {
             _requireTimePeriodChange = NO;
+            _wasAlphaChanged = NO;
+            
             _provider = std::make_shared<OsmAnd::WeatherRasterLayerProvider>(_resourcesManager, layer, _timePeriodStart, _timePeriodEnd, _timePeriodStep, bands, self.app.data.weatherUseOfflineData);
             [self.mapView setProvider:_provider forLayer:self.layerIndex];
 
@@ -284,6 +295,7 @@
 
 - (void) onWeatherLayerAlphaChanged
 {
+    _wasAlphaChanged = YES;
     [self updateWeatherLayerAlpha];
 /*
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/Sources/Controllers/Map/Layers/OAWeatherRasterLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAWeatherRasterLayer.mm
@@ -133,7 +133,6 @@
     
     if (_dateTime == 0)
         [self setDateTime:[[NSDate now] timeIntervalSince1970] * 1000 goForward:YES resetPeriod:NO];
-//        [self setDateTime:[[NSDate now] timeIntervalSince1970] * 1000 goForward:NO resetPeriod:NO];
 
     if ([[OAPluginsHelper getPlugin:OAWeatherPlugin.class] isEnabled])
     {

--- a/Sources/Controllers/Map/Layers/OAWeatherRasterLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAWeatherRasterLayer.mm
@@ -162,7 +162,7 @@
                 break;
         }
         
-        // TODO: delete when android team fix alpha changing bug
+        // TODO: delete when android team fix alpha changing bug https://github.com/osmandapp/OsmAnd/issues/20533
         if (_wasAlphaChanged)
         {
             _timePeriodEnd = _timePeriodStart;


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3779)

video before (r4.8) - opacity slider doesn't work at all. The same bug exists in android. Created [issue](https://github.com/osmandapp/OsmAnd/issues/20533) for them.

https://github.com/user-attachments/assets/4288a844-1044-4ee7-bdec-477ce972d4bd


video before (master) - opacity slider works but layer blinks

https://github.com/user-attachments/assets/db1c6906-1979-4298-a1d1-59b175088ff2


video after fix - slider works. layer doesn't blink

https://github.com/user-attachments/assets/5748eb72-f35a-4035-89bf-9eeddbf1c643


