### PR TITLE
pedestrian top widget fix. removes old unused settings

### DIFF
--- a/Sources/Controllers/Map/Widgets/OALanesControl.mm
+++ b/Sources/Controllers/Map/Widgets/OALanesControl.mm
@@ -205,7 +205,7 @@
     vector<int> loclanes;
     int dist = 0;
     // TurnType primary = null;
-    if ((![_rh isFollowingMode] || [OARoutingHelper isDeviatedFromRoute] || [_rh getCurrentGPXRoute]) && [_trackingUtilities isMapLinkedToLocation] && [_settings.showLanes get])
+    if ((![_rh isFollowingMode] || [OARoutingHelper isDeviatedFromRoute] || [_rh getCurrentGPXRoute]) && [_trackingUtilities isMapLinkedToLocation])
     {
         CLLocation *lp = _locationProvider.lastKnownLocation;
         std::shared_ptr<RouteDataObject> ro = nullptr;
@@ -223,7 +223,7 @@
     }
     else if ([_rh isRouteCalculated])
     {
-        if ([_rh isFollowingMode] && [_settings.showLanes get])
+        if ([_rh isFollowingMode])
         {
             OANextDirectionInfo *r = [_rh getNextRouteDirectionInfo:[[OANextDirectionInfo alloc] init] toSpeak:false];
             if (r && r.directionInfo && r.directionInfo.turnType)

--- a/Sources/Controllers/Map/Widgets/OAMapWidgetRegistry.mm
+++ b/Sources/Controllers/Map/Widgets/OAMapWidgetRegistry.mm
@@ -379,7 +379,6 @@
 - (void) resetDefaultAppearance:(OAApplicationMode *)appMode
 {
     [_settings.transparentMapTheme resetToDefault];
-    [_settings.showStreetName resetToDefault];
     [_settings.positionPlacementOnMap resetToDefault];
 }
 

--- a/Sources/Controllers/Map/Widgets/OATopTextView.mm
+++ b/Sources/Controllers/Map/Widgets/OATopTextView.mm
@@ -495,12 +495,9 @@
     {
         if ([_routingHelper isFollowingMode])
         {
-            if ([_settings.showStreetName get])
-            {
-                OANextDirectionInfo *nextDirInfo = [_routingHelper getNextRouteDirectionInfo:_calc1 toSpeak:YES];
-                streetName = [_routingHelper getCurrentName:nextDirInfo];
-                _turnDrawable.clr = [UIColor colorNamed:ACColorNameNavArrowColor].currentMapThemeColor;
-            }
+            OANextDirectionInfo *nextDirInfo = [_routingHelper getNextRouteDirectionInfo:_calc1 toSpeak:YES];
+            streetName = [_routingHelper getCurrentName:nextDirInfo];
+            _turnDrawable.clr = [UIColor colorNamed:ACColorNameNavArrowColor].currentMapThemeColor;
         }
         else
         {
@@ -513,7 +510,7 @@
             }
         }
     }
-    else if ([_trackingUtilities isMapLinkedToLocation] && [_settings.showStreetName get])
+    else if ([_trackingUtilities isMapLinkedToLocation])
     {
         streetName = [[OACurrentStreetName alloc] init];
         CLLocation *lastKnownLocation = _locationProvider.lastKnownLocation;

--- a/Sources/Helpers/OAAppSettings.h
+++ b/Sources/Helpers/OAAppSettings.h
@@ -898,7 +898,6 @@ typedef NS_ENUM(NSInteger, EOARateUsState)
 @property (nonatomic) OACommonBoolean *showSpeedLimitWarnings;
 @property (nonatomic) OACommonBoolean *showCameras;
 @property (nonatomic) OACommonBoolean *showTunnels;
-@property (nonatomic) OACommonBoolean *showLanes;
 @property (nonatomic) OACommonBoolean *showArrivalTime;
 @property (nonatomic) OACommonBoolean *showIntermediateArrivalTime;
 @property (nonatomic) OACommonBoolean *showRelativeBearing;
@@ -924,7 +923,6 @@ typedef NS_ENUM(NSInteger, EOARateUsState)
 @property (nonatomic) OACommonBoolean *showNearbyPoi;
 
 @property (nonatomic) OACommonBoolean *transparentMapTheme;
-@property (nonatomic) OACommonBoolean *showStreetName;
 @property (nonatomic) OACommonInteger *positionPlacementOnMap;
 @property (nonatomic) OACommonBoolean *showDistanceRuler;
 @property (nonatomic) OACommonBoolean *showElevationProfileWidget;

--- a/Sources/Helpers/OAAppSettings.m
+++ b/Sources/Helpers/OAAppSettings.m
@@ -114,7 +114,6 @@ static NSString * const customAppModesKey = @"customAppModes";
 
 static NSString * const mapInfoControlsKey = @"mapInfoControls";
 static NSString * const transparentMapThemeKey = @"transparentMapTheme";
-static NSString * const showStreetNameKey = @"showStreetName";
 static NSString * const positionPlacementOnMapKey = @"positionPlacementOnMap";
 static NSString * const rotateMapKey = @"rotateMap";
 static NSString * const firstMapIsDownloadedKey = @"firstMapIsDownloaded";
@@ -180,7 +179,6 @@ static NSString * const showPedestrianKey = @"showPedestrian";
 static NSString * const showSpeedLimitWarningsKey = @"showSpeedLimitWarnings";
 static NSString * const showCamerasKey = @"showCameras";
 static NSString * const showTunnelsKey = @"showTunnels";
-static NSString * const showLanesKey = @"showLanes";
 static NSString * const showGpxWptKey = @"showGpxWpt";
 static NSString * const showNearbyFavoritesKey = @"showNearbyFavorites";
 static NSString * const showNearbyPoiKey = @"showNearbyPoi";
@@ -3984,13 +3982,6 @@ static NSString *kWhenExceededKey = @"WHAN_EXCEEDED";
         _transparentMapTheme = [OACommonBoolean withKey:transparentMapThemeKey defValue:NO];
         [_profilePreferences setObject:_transparentMapTheme forKey:@"transparent_map_theme"];
 
-        _showStreetName = [OACommonBoolean withKey:showStreetNameKey defValue:NO];
-        [_showStreetName setModeDefaultValue:@NO mode:[OAApplicationMode DEFAULT]];
-        [_showStreetName setModeDefaultValue:@YES mode:[OAApplicationMode CAR]];
-        [_showStreetName setModeDefaultValue:@NO mode:[OAApplicationMode BICYCLE]];
-        [_showStreetName setModeDefaultValue:@NO mode:[OAApplicationMode PEDESTRIAN]];
-        [_profilePreferences setObject:_showStreetName forKey:@"show_street_name"];
-
         _showDistanceRuler = [OACommonBoolean withKey:showDistanceRulerKey defValue:NO];
         [_profilePreferences setObject:_showDistanceRuler forKey:@"show_distance_ruler"];
         
@@ -4177,11 +4168,6 @@ static NSString *kWhenExceededKey = @"WHAN_EXCEEDED";
         _showTunnels = [OACommonBoolean withKey:showTunnelsKey defValue:NO];
         [_showTunnels setModeDefaultValue:@YES mode:[OAApplicationMode CAR]];
         [_profilePreferences setObject:_showTunnels forKey:@"show_tunnels"];
-
-        _showLanes = [OACommonBoolean withKey:showLanesKey defValue:NO];
-        [_showLanes setModeDefaultValue:@YES mode:[OAApplicationMode CAR]];
-        [_showLanes setModeDefaultValue:@YES mode:[OAApplicationMode BICYCLE]];
-        [_profilePreferences setObject:_showLanes forKey:@"show_lanes"];
 
         _speakStreetNames = [OACommonBoolean withKey:speakStreetNamesKey defValue:YES];
         _speakTrafficWarnings = [OACommonBoolean withKey:speakTrafficWarningsKey defValue:YES];


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3845)

In this request I deleted old unused settings, that was stored but never changed. No one set method, no one call from UI. So it was always with default values. 

<img width="652" alt="Screenshot 2024-08-12 at 21 40 08" src="https://github.com/user-attachments/assets/43bad7f1-99ce-46b3-a0be-4dd176df700d">

In android this settings also not used. I think they also forgot to delete it.

<img width="986" alt="Screenshot 2024-08-12 at 21 40 30" src="https://github.com/user-attachments/assets/cba6161a-af5e-4464-b3e1-64b6d8ff7724">

So I deleted it. Now widgets visibility state sets only here. 

<img width="557" alt="Screenshot 2024-08-12 at 21 37 45" src="https://github.com/user-attachments/assets/7c3130f1-c33f-49e8-a20a-8992ff47b892">

---


Testing with this widget settings. For Car and Walking profiles.

<img width="400" alt="Screenshot 2024-08-12 at 19 59 45" src="https://github.com/user-attachments/assets/1d1be762-aae9-4d89-bb8b-aaf95a77abc8">

Testing Car profile 

https://github.com/user-attachments/assets/baf4d9f2-9175-48bc-a99c-a614f8e4932a


Testing Walking profile - widgets on

https://github.com/user-attachments/assets/52a7118b-f61c-4736-b104-c288a12ee77f


Testing Walking profile - widgets off

https://github.com/user-attachments/assets/44fc3fa9-419e-4326-84c6-c171419bcd70

---

