### PR TITLE
add minimal zoom calculation formula for current screen

### DIFF
--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -534,6 +534,12 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
                                            _app.data.mapLastViewedState.target31.y);
 
         float zoom = _app.data.mapLastViewedState.zoom;
+        
+        //calculate minimal zoom value for current screen
+        OAZoom *zoomObject = [[OAZoom alloc] initWitZoom:zoom minZoom:1 maxZoom:_mapView.maxZoom];
+        [zoomObject checkZoomBounds];
+        zoom = [zoomObject getBaseZoom] + [zoomObject getZoomFloatPart];
+        
         _mapView.zoom = qBound(_mapView.minZoom, isnan(zoom) ? 5 : zoom, _mapView.maxZoom);
         float azimuth = _app.data.mapLastViewedState.azimuth;
         _mapView.azimuth = isnan(azimuth) ? 0 : azimuth;
@@ -1845,12 +1851,16 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
         return;
     }
     
-    [zoom changeZoom:zoomStep];
+    if (zoomStep > 0)
+        [zoom zoomIn];
+    else
+        [zoom zoomOut];
+    float updatedZoom = zoom.getBaseZoom + zoom.getZoomFloatPart;
     
     _mapView.mapAnimator->pause();
     _mapView.mapAnimator->cancelAllAnimations();
     
-    _mapView.mapAnimator->animateZoomBy(zoomStep,
+    _mapView.mapAnimator->animateZoomTo(updatedZoom,
                                         kQuickAnimationTime,
                                         OsmAnd::MapAnimator::TimingFunction::Linear,
                                         kUserInteractionAnimationKey);

--- a/Sources/Helpers/OAZoom.h
+++ b/Sources/Helpers/OAZoom.h
@@ -25,6 +25,7 @@
 
 - (void) calculateAnimatedZoom:(int)currentBaseZoom deltaZoom:(float)deltaZoom;
 
+- (void) checkZoomBounds;
 + (OAZoom *) checkZoomBoundsWithZoom:(float)zoom minZoom:(int)minZoom maxZoom:(int)maxZoom;
 + (OAZoom *) checkZoomBoundsWithBaseZoom:(int)baseZoom floatZoomPart:(float)floatZoomPart minZoom:(int)minZoom maxZoom:(int)maxZoom;
 

--- a/Sources/Helpers/OAZoom.m
+++ b/Sources/Helpers/OAZoom.m
@@ -13,7 +13,7 @@
     int _baseZoom;
     float _zoomFloatPart;
     float _zoomAnimation;
-    int _minZoom;
+    float _minZoom;
     int _maxZoom;
 }
 
@@ -24,7 +24,7 @@
     {
         _baseZoom = baseZoom;
         _zoomFloatPart = zoomFloatPart;
-        _minZoom = minZoom;
+        _minZoom = log(ceil([OAUtilities calculateScreenHeight] / 256));
         _maxZoom = maxZoom;
     }
     return self;
@@ -64,11 +64,18 @@
 
 - (void) zoomIn
 {
+    if (_zoomFloatPart > 0)
+        _zoomFloatPart = 0;
     [self changeZoom:1];
+    [self checkZoomBounds];
 }
 - (void) zoomOut
 {
-    [self changeZoom:-1];
+    if (_zoomFloatPart > 0)
+        _zoomFloatPart = 0;
+    else
+        [self changeZoom:-1];
+    [self checkZoomBounds];
 }
 
 - (void) changeZoom:(int)step
@@ -135,8 +142,8 @@
     }
     else if (_baseZoom < _minZoom)
     {
-        _baseZoom = _minZoom;
-        _zoomFloatPart = 0;
+        _baseZoom = (int) _minZoom;
+        _zoomFloatPart = _minZoom - _baseZoom;
     }
 }
 
@@ -177,7 +184,6 @@
     int startIntZoom = ((int) startZoom);
     float startZoomFloatPart = startZoom - startIntZoom;
     double startDistanceIntZoom = startDistance * [self.class floatPartToVisual:startZoomFloatPart];
-    double log2 = log(startDistanceIntZoom / endDistance) / log(2);
     int intZoomDelta = ((int) log(2));
     double startDistanceIntZoomed = intZoomDelta >= 0
         ? startDistanceIntZoom / (1 << intZoomDelta)

--- a/Sources/Helpers/OAZoom.m
+++ b/Sources/Helpers/OAZoom.m
@@ -34,6 +34,18 @@
 {
     int baseZoom = floor(zoom);
     float zoomFloatPart = zoom - baseZoom;
+    
+    // rounding values near int
+    if (zoomFloatPart > 0.9999)
+    {
+        zoomFloatPart = 0;
+        baseZoom += 1;
+    }
+    else if (zoomFloatPart < 0.0001)
+    {
+        zoomFloatPart = 0;
+    }
+    
     return [self initWithBaseZoom:baseZoom zoomFloatPart:zoomFloatPart minZoom:minZoom maxZoom:maxZoom];
 }
 
@@ -59,7 +71,7 @@
 
 - (BOOL) isZoomOutAllowed
 {
-    return _baseZoom > _minZoom || (_baseZoom == _minZoom && _zoomFloatPart > 0);
+    return (_baseZoom > _minZoom || (_baseZoom == _minZoom && _zoomFloatPart > 0)) && (_baseZoom != 1);
 }
 
 - (void) zoomIn


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3965)

before / after
<img width="400" alt="before Screenshot 2024-10-03 at 20 36 26" src="https://github.com/user-attachments/assets/d3d8a3c8-0655-4bc6-83e0-6cf191906572"> <img width="400" alt="after Screenshot 2024-10-03 at 21 12 27" src="https://github.com/user-attachments/assets/864d75e5-113a-4d69-a486-a844254de413">

<img width="400" alt="before Screenshot 2024-10-03 at 20 37 11" src="https://github.com/user-attachments/assets/457c393e-b61c-43c2-8863-da50eda74bb9"> <img width="400" alt="after Screenshot 2024-10-03 at 21 13 12" src="https://github.com/user-attachments/assets/c4b8b5be-56e2-49fa-a191-7028e8b02fdb">

fist app launch also use this formula

<img width="400" alt="Screenshot 2024-10-03 at 21 28 44" src="https://github.com/user-attachments/assets/6d7296e5-39e3-4f97-9641-abee1546d2f3"> <img width="400" alt="Screenshot 2024-10-03 at 21 27 24" src="https://github.com/user-attachments/assets/9672750a-bdee-415a-85eb-23c4f18775c3">



https://github.com/user-attachments/assets/0dda83fc-25dd-4769-9400-ca5ea3f31424





