### PR TITLE
Min_zoom_fix_2

### DIFF
--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -1344,7 +1344,7 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
                     auto angle = zoomAndRotation.y;
                     if (!isnan(zoom) && !isnan(angle))
                     {
-                        OAZoom *zoomObject = [[OAZoom alloc] initWitZoom:_mapView.zoom minZoom:1 maxZoom:22];
+                        OAZoom *zoomObject = [[OAZoom alloc] initWitZoom:_mapView.zoom minZoom:_mapView.minZoom maxZoom:_mapView.maxZoom];
                         float nextZoomStep = [zoomObject getValidZoomStep:zoom];
                         zoom = nextZoomStep;
                         

--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -1344,6 +1344,10 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
                     auto angle = zoomAndRotation.y;
                     if (!isnan(zoom) && !isnan(angle))
                     {
+                        OAZoom *zoomObject = [[OAZoom alloc] initWitZoom:_mapView.zoom minZoom:1 maxZoom:22];
+                        float nextZoomStep = [zoomObject getValidZoomStep:zoom];
+                        zoom = nextZoomStep;
+                        
                         float newZoom = _mapView.zoom + (float)zoom;
                         float newAzimuth = _mapView.azimuth + (float)angle;
                         if (pinchRecognizer)
@@ -1845,12 +1849,13 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
         return;
     }
     
-    [zoom changeZoom:zoomStep];
+    float nextZoomStep = [zoom getValidZoomStep:zoomStep];
+    [zoom changeZoom:nextZoomStep];
     
     _mapView.mapAnimator->pause();
     _mapView.mapAnimator->cancelAllAnimations();
     
-    _mapView.mapAnimator->animateZoomBy(zoomStep,
+    _mapView.mapAnimator->animateZoomBy(nextZoomStep,
                                         kQuickAnimationTime,
                                         OsmAnd::MapAnimator::TimingFunction::Linear,
                                         kUserInteractionAnimationKey);

--- a/Sources/Helpers/OAZoom.h
+++ b/Sources/Helpers/OAZoom.h
@@ -22,6 +22,7 @@
 - (void) zoomIn;
 - (void) zoomOut;
 - (void) changeZoom:(int)step;
+- (float) getValidZoomStep:(float)step;
 
 - (void) calculateAnimatedZoom:(int)currentBaseZoom deltaZoom:(float)deltaZoom;
 

--- a/Sources/Helpers/OAZoom.m
+++ b/Sources/Helpers/OAZoom.m
@@ -202,7 +202,19 @@
 
 + (int) getMinValidZoom
 {
-    return MAX(round(log(ceil([OAUtilities calculateScreenHeight] / 256))), 1);
+    return MAX(ceil(log(ceil([OAUtilities calculateScreenHeight] / 256))), 1);
+}
+
+- (float) getValidZoomStep:(float)step
+{
+    float newZoomStep = step;
+    float currentZoom = [self getBaseZoom] + [self getZoomFloatPart];
+    float nextZoom = currentZoom + step;
+    float minZoom = [OAZoom getMinValidZoom];
+    
+    if (nextZoom < minZoom)
+        newZoomStep = - (currentZoom - minZoom);
+    return newZoomStep;
 }
 
 @end


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3965)

Previous min zoom was 1 beause of rounding down. Make it rounding up.

<img width="720" alt="Screenshot 2024-10-16 at 22 42 05" src="https://github.com/user-attachments/assets/88d264e3-281b-466f-a2c0-362026316433">


before:

https://github.com/user-attachments/assets/f37ddd63-b0dc-4e02-81f6-4d88e8834691

after:

https://github.com/user-attachments/assets/40003eae-3b20-4a73-a134-7cb84a8d4e4b

