### PR TITLE
fix non resetting map angle by compass btn click

### DIFF
--- a/Sources/Controllers/Map/OAMapHudViewController.mm
+++ b/Sources/Controllers/Map/OAMapHudViewController.mm
@@ -772,6 +772,7 @@ static const float kDistanceMeters = 100.0;
 
 - (void)handleSingleTapCompass
 {
+    [[OAAppSettings sharedManager].mapManuallyRotatingAngle set:0];
     [[OAMapViewTrackingUtilities instance] animatedAlignAzimuthToNorth];
 }
 


### PR DESCRIPTION
ios before. north isn't up:

https://github.com/user-attachments/assets/e4464063-eac2-472a-836b-b43a4e66801e

ios after. north is up:

https://github.com/user-attachments/assets/9c7147be-85d7-4660-b81d-4b7364257440

how it works in android. north is up::

https://github.com/user-attachments/assets/c7165036-e28c-48f0-887d-0729f5f787e3
