### PR TITLE
add monospaced digits font to another downloading screens

### DIFF
--- a/Sources/FirstUsage/OAFirstUsageWizardController.mm
+++ b/Sources/FirstUsage/OAFirstUsageWizardController.mm
@@ -165,7 +165,7 @@ typedef enum
     [_btnDownload setTitle:OALocalizedString(@"shared_string_download") forState:UIControlStateNormal];
 
     // Init progress view
-    [_btnGoToMap setTitle:OALocalizedString(@"show_region_on_map_go") forState:UIControlStateNormal];
+    [self setDownloadingButtonTitle:OALocalizedString(@"show_region_on_map_go")];
     
     _bottomTextView.textContainerInset = UIEdgeInsetsZero;
     _bottomTextView.textContainer.lineFragmentPadding = 0;
@@ -310,6 +310,13 @@ typedef enum
         [self resizeToFitSubviews:_cardView.subviews[0]];
         _heightConstraint.constant = _cardView.subviews[0].frame.size.height;
     }
+}
+
+- (void) setDownloadingButtonTitle:(NSString *)title
+{
+    NSMutableAttributedString *attributedTitle = [[NSMutableAttributedString alloc] initWithString:title];
+    [attributedTitle addAttribute:NSFontAttributeName value:[UIFont monospacedFontAt:15 withTextStyle:UIFontTextStyleBody] range:NSMakeRange(0, attributedTitle.string.length)];
+    [_btnGoToMap setAttributedTitle:attributedTitle forState:UIControlStateNormal];
 }
 
 - (void)showCard:(UIView *)cardView
@@ -525,8 +532,7 @@ typedef enum
                 OARepositoryResourceItem *item = _indexItems[0];
                 _lbMapName1.text = item.title;
                 
-                [_btnGoToMap setTitle:[OALocalizedString(@"downloading") stringByAppendingFormat:@" %@", [NSByteCountFormatter stringFromByteCount:item.sizePkg countStyle:NSByteCountFormatterCountStyleFile]] forState:UIControlStateNormal];
-
+                [self setDownloadingButtonTitle:[OALocalizedString(@"downloading") stringByAppendingFormat:@" %@", [NSByteCountFormatter stringFromByteCount:item.sizePkg countStyle:NSByteCountFormatterCountStyleFile]]];
                 if (_mapDownloadCancelled)
                 {
                     _progress1.hidden = YES;
@@ -901,7 +907,8 @@ typedef enum
             uint64_t size = _indexItems[0].size;
             float progress = [value floatValue];
             NSString *progressStr = [OAResourcesUISwiftHelper formatedDownloadingProgressString:size progress:progress addZero:YES combineViaSlash:YES];
-            [_btnGoToMap setTitle:[OALocalizedString(@"downloading") stringByAppendingFormat:@" %@", progressStr] forState:UIControlStateNormal];
+            [self setDownloadingButtonTitle:[OALocalizedString(@"downloading") stringByAppendingFormat:@" %@", progressStr]];
+            
             [_progress1 setProgress:[value floatValue]];
         }
     });
@@ -919,7 +926,7 @@ typedef enum
         
         if (_indexItems.count > 0)
         {
-            [_btnGoToMap setTitle:OALocalizedString(@"show_region_on_map_go") forState:UIControlStateNormal];
+            [self setDownloadingButtonTitle:OALocalizedString(@"show_region_on_map_go")];
         }
 
         if (task.progressCompleted < 1.0)

--- a/Sources/SwiftExtensions/UIFont+Extension.swift
+++ b/Sources/SwiftExtensions/UIFont+Extension.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension UIFont {
-    static func monospacedFont(at size: CGFloat, withTextStyle style: TextStyle) -> UIFont {
+    @objc static func monospacedFont(at size: CGFloat, withTextStyle style: TextStyle) -> UIFont {
         let bodyFontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         let bodyMonospacedNumbersFontDescriptor = bodyFontDescriptor.addingAttributes(
             [

--- a/Sources/Views/OATargetPointView.mm
+++ b/Sources/Views/OATargetPointView.mm
@@ -2401,6 +2401,7 @@ static const NSInteger _buttonsCount = 4;
     
     [_downloadProgressBar setProgress:0.];
     _downloadProgressLabel.text = OALocalizedString(@"download_pending");
+    _downloadProgressLabel.font = [UIFont monospacedFontAt:15 withTextStyle:UIFontTextStyleBody];
     
     [self doLayoutSubviews:YES];
 }


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/2222)

## Context menu

<table style="width:100%">
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/9a24e2d8-a5c6-4b99-a0da-cf3af3bb0165"  width="300" height="auto"/> </td>
    <td><video src="https://github.com/user-attachments/assets/82e45cdb-dcac-4c13-9604-03b0d7fb2cd8"  width="300" height="auto"/> </td>
  </tr>
</table>  

## First usage screen

<table style="width:100%">
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/184aeb56-ea5e-4559-9467-ee3cc323b58a"  width="300" height="auto"/> </td>
    <td><video src="https://github.com/user-attachments/assets/a494217e-f337-44f3-baf6-d58eb31ce340"  width="300" height="auto"/> </td>
  </tr>
</table> 

