### PR TITLE
fix reseting zoom on app initing

### DIFF
--- a/Sources/AppHost/OsmAndAppImpl.mm
+++ b/Sources/AppHost/OsmAndAppImpl.mm
@@ -154,6 +154,8 @@
 @synthesize carPlayActive = _carPlayActive;
 @synthesize backgroundStateObservable = _backgroundStateObservable;
 
+@synthesize appSettingsLoadedObservable = _appSettingsLoadedObservable;
+
 - (instancetype) init
 {
     self = [super init];
@@ -430,8 +432,8 @@
     OALog(@"Weather Forecast path: %@", _weatherForecastPath);
 
     // Unpack app data
+    _appSettingsLoadedObservable = [[OAObservable alloc] init];
     _data = [NSKeyedUnarchiver unarchiveObjectWithData:[[NSUserDefaults standardUserDefaults] dataForKey:kAppData]];
-    [_data postInit];
 
     settings.simulateNavigation = NO;
     settings.simulateNavigationMode = [OASimulationMode toKey:EOASimulationModePreview];

--- a/Sources/AppHost/OsmAndAppImpl.mm
+++ b/Sources/AppHost/OsmAndAppImpl.mm
@@ -417,8 +417,11 @@
         [defaults registerDefaults:defResetRouting];
 
         _data = [OAAppData defaults];
-        [defaults setObject:[NSKeyedArchiver archivedDataWithRootObject:_data]
-                         forKey:kAppData];
+        NSError *error;
+        [defaults setObject:[NSKeyedArchiver archivedDataWithRootObject:_data requiringSecureCoding:NO error:&error] forKey:kAppData];
+        if (error)
+            NSLog(@"error archiving data: %@", error.localizedDescription);
+        
         [defaults setBool:NO forKey:@"hide_all_gpx"];
         [defaults setBool:NO forKey:@"reset_settings"];
         [defaults setBool:NO forKey:@"reset_routing"];
@@ -433,7 +436,17 @@
 
     // Unpack app data
     _appSettingsLoadedObservable = [[OAObservable alloc] init];
-    _data = [NSKeyedUnarchiver unarchiveObjectWithData:[[NSUserDefaults standardUserDefaults] dataForKey:kAppData]];
+    
+    NSError *error;
+    NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc]
+                                     initForReadingFromData:[[NSUserDefaults standardUserDefaults] dataForKey:kAppData]
+                                     error:&error];
+    [unarchiver setRequiresSecureCoding:NO];
+    
+    _data = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+    if (error)
+        NSLog(@"error unarchiving data: %@", error.localizedDescription);
+
 
     settings.simulateNavigation = NO;
     settings.simulateNavigationMode = [OASimulationMode toKey:EOASimulationModePreview];
@@ -1174,8 +1187,10 @@
 {
     NSMutableDictionary* initialUserDefaults = [[NSMutableDictionary alloc] init];
 
-    [initialUserDefaults setValue:[NSKeyedArchiver archivedDataWithRootObject:[OAAppData defaults]]
-                           forKey:kAppData];
+    NSError *error;
+    [initialUserDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:[OAAppData defaults] requiringSecureCoding:NO error:&error] forKey:kAppData];
+    if (error)
+        NSLog(@"error archiving data: %@", error.localizedDescription);
 
     return initialUserDefaults;
 }
@@ -1219,8 +1234,10 @@
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
 
     // App data
-    [userDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:_data]
-                                              forKey:kAppData];
+    NSError *error;
+    [userDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:_data requiringSecureCoding:NO error:&error] forKey:kAppData];
+    if (error)
+        NSLog(@"error archiving data: %@", error.localizedDescription);
     [userDefaults synchronize];
 }
 

--- a/Sources/AppHost/OsmAndAppProtocol.h
+++ b/Sources/AppHost/OsmAndAppProtocol.h
@@ -51,6 +51,7 @@
 @property(nonatomic) OAMapMode prevMapMode;
 @property(readonly) OAObservable* mapModeObservable;
 @property(readonly) OAObservable* applicationModeChangedObservable;
+@property(readonly) OAObservable* appSettingsLoadedObservable;
 
 @property(nonatomic) OAMapViewState* initialURLMapState;
 

--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -541,8 +541,6 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
         _mapView.target31 = OsmAnd::PointI(_app.data.mapLastViewedState.target31.x,
                                            _app.data.mapLastViewedState.target31.y);
 
-        OAAppDelegate *appDelegate = (OAAppDelegate *)[[UIApplication sharedApplication] delegate];
-        NSLog(@"!!! %f     OAMapVC - getZoom    %f", appDelegate.startTime, [_app.data getZoom]);
         if (_app.data.isInited)
         {
             float zoom = MAX([OAZoom getMinValidZoom], [_app.data getZoom]);
@@ -2084,10 +2082,6 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
 - (void) onAppSettingsLoaded
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        
-        OAAppDelegate *appDelegate = (OAAppDelegate *)[[UIApplication sharedApplication] delegate];
-        NSLog(@"!!! %f     OAMapVC - onAppSettingsLoaded setZoom    %f", appDelegate.startTime, [_app.data getZoom]);
-        
         [self.mapView setZoom:[_app.data getZoom]];
         self.mapView.isZoomInited = YES;
     });

--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -1680,6 +1680,8 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
         case OAMapRendererViewStateEntryZoom:
         {
             [_zoomObservable notifyEventWithKey:nil andValue:[NSNumber numberWithFloat:_mapView.zoom]];
+            
+            // Sometimes due to the async bugs MapVC can overwrite OAAppData.zoom setting right in time when it is reading. This check force it to wait for completion of downloading.
             if (_mapView.isZoomInited)
                 [_app.data setZoom:_mapView.zoom];
 

--- a/Sources/Data/OAAppData.h
+++ b/Sources/Data/OAAppData.h
@@ -158,6 +158,11 @@ static const NSInteger kSlopeDefMaxZoom = 16;
 @property (nonatomic) OARTargetPoint *pointToNavigateBackup;
 @property (nonatomic) NSMutableArray<OARTargetPoint *> *intermediatePointsBackup;
 
+@property (nonatomic) BOOL isInited;
+
+- (float) getZoom;
+- (void) setZoom:(float)newZoom;
+
 - (void) postInit;
 
 - (void) clearPointToStart;

--- a/Sources/Data/OAAppData.m
+++ b/Sources/Data/OAAppData.m
@@ -188,6 +188,7 @@
     self = [super init];
     if (self)
     {
+        _isInited = NO;
         [self commonInit];
         [self safeInit];
     }
@@ -1719,6 +1720,7 @@
     defaults.mapLastViewedState.zoom = 1.0f;
     defaults.mapLastViewedState.azimuth = 0.0f;
     defaults.mapLastViewedState.elevationAngle = 90.0f;
+    defaults.isInited = NO;
 
     return defaults;
 }
@@ -1765,6 +1767,10 @@
     self = [super init];
     if (self) {
         [self commonInit];
+        
+        _isInited = NO;
+        _mapLastViewedState.zoom = -1;
+        
         _lastMapSources = [aDecoder decodeObjectForKey:kLastMapSources];
         _mapLastViewedState = [aDecoder decodeObjectForKey:kMapLastViewedState];
         _destinations = [aDecoder decodeObjectForKey:kDestinations];
@@ -1777,9 +1783,26 @@
         _intermediatePointsBackup = [aDecoder decodeObjectForKey:kIntermediatePointsBackup];
         _myLocationToStart = [aDecoder decodeObjectForKey:kMyLocationToStart];
         
+        
         [self safeInit];
+        [self postInit];
+        
+        _isInited = YES;
+        [OsmAndApp.instance.appSettingsLoadedObservable notifyEvent];
     }
     return self;
+}
+
+- (float) getZoom
+{
+    return _mapLastViewedState.zoom;
+}
+
+- (void) setZoom:(float)newZoom
+{
+    // Stop any rewritings until reading completed
+    if (_isInited && _mapLastViewedState.zoom != -1 && newZoom != 1)
+        _mapLastViewedState.zoom = newZoom;
 }
 
 - (void) resetProfileSettingsForMode:(OAApplicationMode *)mode

--- a/Sources/Data/OAAppData.m
+++ b/Sources/Data/OAAppData.m
@@ -1800,7 +1800,7 @@
 
 - (void) setZoom:(float)newZoom
 {
-    // Stop any rewritings until reading completed
+    // Stop any rewritings until reading is completed
     if (_isInited && _mapLastViewedState.zoom != -1 && newZoom != 1)
         _mapLastViewedState.zoom = newZoom;
 }

--- a/Sources/Data/OAAppData.m
+++ b/Sources/Data/OAAppData.m
@@ -1800,7 +1800,7 @@
 
 - (void) setZoom:(float)newZoom
 {
-    // Stop any rewritings until reading is completed
+    // Sometimes due to the async bugs MapVC can overwrite OAAppData.zoom setting right in time when it is reading. This check force it to wait for completion of downloading.
     if (_isInited && _mapLastViewedState.zoom != -1 && newZoom != 1)
         _mapLastViewedState.zoom = newZoom;
 }

--- a/Sources/FirstUsage/OAFirstUsageWizardController.mm
+++ b/Sources/FirstUsage/OAFirstUsageWizardController.mm
@@ -839,7 +839,7 @@ typedef enum
         point31.x = locationI.x;
         point31.y = locationI.y;
         _app.data.mapLastViewedState.target31 = point31;
-        _app.data.mapLastViewedState.zoom = 13.0;
+        [_app.data setZoom: 13.0];
 
         [self closeWizard];
     }

--- a/Sources/Views/OAMapRendererView.h
+++ b/Sources/Views/OAMapRendererView.h
@@ -69,6 +69,8 @@ struct CLLocationCoordinate2D;
 
 @property (nonatomic, readonly, assign) std::shared_ptr<OsmAnd::IMapRenderer> renderer;
 
+@property (nonatomic) BOOL isZoomInited;
+
 - (std::shared_ptr<OsmAnd::IMapLayerProvider>)providerFor:(unsigned int)layer;
 - (void)setProvider:(std::shared_ptr<OsmAnd::IMapLayerProvider>)provider forLayer:(unsigned int)layer;
 - (void)setProviderForced:(std::shared_ptr<OsmAnd::IMapLayerProvider>)provider forLayer:(unsigned int)layer;


### PR DESCRIPTION
[issue 1](https://github.com/osmandapp/OsmAnd-iOS/issues/3988)
[issue 2](https://github.com/osmandapp/OsmAnd-iOS/issues/3965)

Found and fixed some async bugs.

Sometimes due to the asynchrony the loading order was not correct. There was happening something like this:

```
Valid loading order. As usual:

AppData.initStart()
AppData.readSettings()
AppData.initFinish()
MapVC.init(AppData.zoom)
AppData.setZoom(MapVC.zoom)


Invalid loading order. Not very often:

AppData.initStart()
MapVC.init(AppData.zoom) 		// MapVC inited with not inited AppData.zoom value (1)
AppData.readSettings()
AppData.setZoom(MapVC.zoom)		// Inited AppData.zoom value is rewriting with invalid MapVC.zoom value
AppData.initFinish()
```

Added some checks to stop this bad loop. And to handle loading if invalid case appear. Now it looks well.

<img width="1728" alt="Screenshot 2024-11-14 at 01 56 06" src="https://github.com/user-attachments/assets/b411bf77-6377-4021-9276-2ab38b424926">
