### PR TITLE
Fix device logs

### DIFF
--- a/OsmAnd MapsTests/Router/OARouteResultPreparationTest.mm
+++ b/OsmAnd MapsTests/Router/OARouteResultPreparationTest.mm
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import "OARouteProvider.h"
 #import "OARouteCalculationParams.h"
+#import "OALog.h"
 #import "OsmAndApp.h"
 #import "OAUtilities.h"
 #import <CoreLocation/CoreLocation.h>
@@ -72,7 +73,7 @@
 
 - (void) testLanes:(NSDictionary *)testCase
 {
-    NSLog(@"Testing: %@", testCase[@"testName"]);
+    OALog(@"Testing: %@", testCase[@"testName"]);
     CLLocation *start = [[CLLocation alloc] initWithLatitude:[testCase[@"startPoint"][@"latitude"] doubleValue] longitude:[testCase[@"startPoint"][@"longitude"] doubleValue]];
     CLLocation *end = [[CLLocation alloc] initWithLatitude:[testCase[@"endPoint"][@"latitude"] doubleValue] longitude:[testCase[@"endPoint"][@"longitude"] doubleValue]];
     int startX = get31TileNumberX(start.coordinate.longitude);
@@ -106,17 +107,17 @@
                     if ([@"skipToSpeak" isEqualToString:expectedResult])
                     {
                         XCTAssertTrue(skipToSpeak);
-                        NSLog(@"Test case %@ failed", testCase[@"testName"]);
+                        OALog(@"Test case %@ failed", testCase[@"testName"]);
                     } else if (![expectedResult isEqualToString:turnLanes] &&
                        ![expectedResult isEqualToString:lanes] &&
                        ![expectedResult isEqualToString:turn])
                     {
                         XCTAssertEqualObjects(expectedResult, turnLanes, @"Segment %ld", segmentId);
-                        NSLog(@"Test case %@ failed", testCase[@"testName"]);
+                        OALog(@"Test case %@ failed", testCase[@"testName"]);
                     }
                 }
                 
-                NSLog(@"segmentId: %ld description: %@", segmentId, name);
+                OALog(@"segmentId: %ld description: %@", segmentId, name);
             }
             prevSegment = i;
         }
@@ -153,7 +154,7 @@
     {
         float te = [[NSDate date] timeIntervalSince1970];
         if (te - tm > 30)
-            NSLog(@"Defalt routing config init took %f ms", (te - tm));
+            OALog(@"Defalt routing config init took %f ms", (te - tm));
     }
 }
 

--- a/OsmAnd MapsTests/Search/SearchUICoreTest.mm
+++ b/OsmAnd MapsTests/Search/SearchUICoreTest.mm
@@ -18,6 +18,7 @@
 #import "OASearchResultMatcher.h"
 #import "OAAtomicInteger.h"
 #import "OAUtilities.h"
+#import "OALog.h"
 #import "OAObjectType.h"
 #import "OsmAndApp.h"
 
@@ -67,12 +68,12 @@ static BOOL TEST_EXTRA_RESULTS = YES;
     for (NSString *path in _filePaths)
         [self testSearchCase:path];
 
-    NSLog(@"Search tests done");
+    OALog(@"Search tests done");
 }
 
 - (void) testSearchCase:(NSString *)path
 {
-    NSLog(@"Testing case: %@", path.lastPathComponent);
+    OALog(@"Testing case: %@", path.lastPathComponent);
 
     NSString *jsonFile = path;
     NSString *obfFile = [[path stringByDeletingPathExtension] stringByAppendingPathExtension:@"obf"];
@@ -216,11 +217,11 @@ static BOOL TEST_EXTRA_RESULTS = YES;
                 XCTAssertEqualObjects(expected, present);
                 if (![expected isEqualToString:present])
                 {
-                    NSLog(@"Phrase: %@", [phrase toString]);
-                    NSLog(@"Mismatch for '%@' != '%@'. Result: ", expected, present);
+                    OALog(@"Phrase: %@", [phrase toString]);
+                    OALog(@"Mismatch for '%@' != '%@'. Result: ", expected, present);
                     for (OASearchResult *r : searchResults)
                     {
-                        NSLog(@"\t\"%@\",", [self formatResult:NO res:r phrase:phrase]);
+                        OALog(@"\t\"%@\",", [self formatResult:NO res:r phrase:phrase]);
                     }
                     passed = NO;
                     break;
@@ -228,7 +229,7 @@ static BOOL TEST_EXTRA_RESULTS = YES;
             }
             
         }
-        NSLog(@"Test phrase: %@ done (%@)", [phrase toString], passed ? @"PASSED" : @"FAILED");
+        OALog(@"Test phrase: %@ done (%@)", [phrase toString], passed ? @"PASSED" : @"FAILED");
     }
     // Do not use this map for future searches
     //[OsmAndApp.instance removeTestResource:obfFile];

--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		32EAF9FF2AE15A3C00646807 /* AFNetworkReachabilityManagerWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32EAF9FE2AE15A3C00646807 /* AFNetworkReachabilityManagerWrapper.m */; };
 		32EAFA012AE17F3100646807 /* TravelGuidesSettingsDownloadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EAFA002AE17F3100646807 /* TravelGuidesSettingsDownloadViewController.swift */; };
 		32EB3DF12AC325780018D9B8 /* OATravelLocalDataDbHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 32EB3DF02AC325780018D9B8 /* OATravelLocalDataDbHelper.mm */; };
+		32F184A32CF8CC78002396E1 /* OALogWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F184A22CF8CC2C002396E1 /* OALogWrapper.swift */; };
 		32F6225D29A7AE080069EE04 /* OAAmenityExtendedNameFilter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 320EADAB29A77AAB002F9883 /* OAAmenityExtendedNameFilter.mm */; };
 		32FE7AA72B65138800F82728 /* OAGPXImportUIHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 32FE7AA62B65138800F82728 /* OAGPXImportUIHelper.mm */; };
 		32FF4C292C183B1D00246B36 /* SegmentTableHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 32FF4C252C183A6400246B36 /* SegmentTableHeaderView.xib */; };
@@ -3857,6 +3858,7 @@
 		32EB3DEF2AC3256B0018D9B8 /* OATravelLocalDataDbHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OATravelLocalDataDbHelper.h; sourceTree = "<group>"; };
 		32EB3DF02AC325780018D9B8 /* OATravelLocalDataDbHelper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OATravelLocalDataDbHelper.mm; sourceTree = "<group>"; };
 		32ECBEAD2657AD7F005D33BD /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		32F184A22CF8CC2C002396E1 /* OALogWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OALogWrapper.swift; sourceTree = "<group>"; };
 		32FE7AA52B65136D00F82728 /* OAGPXImportUIHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAGPXImportUIHelper.h; sourceTree = "<group>"; };
 		32FE7AA62B65138800F82728 /* OAGPXImportUIHelper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OAGPXImportUIHelper.mm; sourceTree = "<group>"; };
 		32FF4C252C183A6400246B36 /* SegmentTableHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SegmentTableHeaderView.xib; sourceTree = "<group>"; };
@@ -10719,6 +10721,7 @@
 				DA5A79BF26C563A000F274C7 /* main.m */,
 				DA5A79BB26C563A000F274C7 /* OALog.h */,
 				DA5A79C226C563A000F274C7 /* OALog.mm */,
+				32F184A22CF8CC2C002396E1 /* OALogWrapper.swift */,
 				DA5A79B726C563A000F274C7 /* OsmAndApp.h */,
 				DA5A79C026C563A000F274C7 /* OsmAndApp.mm */,
 				DA5A79B926C563A000F274C7 /* OsmAndAppCppProtocol.h */,
@@ -16773,6 +16776,7 @@
 				DA5A818326C563A700F274C7 /* OASwitchableAction.m in Sources */,
 				DA5A844A26C563A900F274C7 /* OAHudButton.m in Sources */,
 				46FB65BA2A8BBC2000A21850 /* CoordinatesMapCenterWidget.swift in Sources */,
+				32F184A32CF8CC78002396E1 /* OALogWrapper.swift in Sources */,
 				32BC95732CC021CE00FEEAB8 /* UIFont+Extension.swift in Sources */,
 				DA5A845526C563A900F274C7 /* OAOsmEditsLayer.mm in Sources */,
 				DA5A815526C563A700F274C7 /* OACarPlayActiveViewController.m in Sources */,

--- a/Sources/AppHost/CarPlayDelegate/CarPlaySceneDelegates.swift
+++ b/Sources/AppHost/CarPlayDelegate/CarPlaySceneDelegates.swift
@@ -10,13 +10,13 @@ final class CarPlaySceneDelegate: UIResponder {
     private var isForegroundScene = false
     
     func sceneWillEnterForeground(_ scene: UIScene) {
-        NSLog("[CarPlay] CarPlaySceneDelegate sceneWillEnterForeground")
+        OALog("[CarPlay] CarPlaySceneDelegate sceneWillEnterForeground")
         isForegroundScene = true
         configureScene()
     }
     
     func sceneWillResignActive(_ scene: UIScene) {
-        NSLog("[CarPlay] CarPlaySceneDelegate sceneWillResignActive")
+        OALog("[CarPlay] CarPlaySceneDelegate sceneWillResignActive")
         NotificationCenter.default.removeObserver(self)
         isForegroundScene = false
     }
@@ -113,13 +113,13 @@ final class CarPlaySceneDelegate: UIResponder {
     }
     
     @objc private func appInitEventConfigureScene(notification: Notification) {
-        NSLog("[CarPlay] CarPlaySceneDelegate appInitEventConfigureScene")
+        OALog("[CarPlay] CarPlaySceneDelegate appInitEventConfigureScene")
         guard let userInfo = notification.userInfo,
               let item = userInfo["event"] as? Int,
               let event = AppLaunchEvent(rawValue: item) else { return }
         if case .setupRoot = event {
             guard isForegroundScene else { return }
-            NSLog("[CarPlay] CarPlaySceneDelegate appInitEventConfigureScene success")
+            OALog("[CarPlay] CarPlaySceneDelegate appInitEventConfigureScene success")
             configureScene()
         }
     }
@@ -127,7 +127,7 @@ final class CarPlaySceneDelegate: UIResponder {
 
 extension CarPlaySceneDelegate: CPTemplateApplicationSceneDelegate {
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController, to window: CPWindow) {
-        NSLog("[CarPlay] CarPlaySceneDelegate didConnect")
+        OALog("[CarPlay] CarPlaySceneDelegate didConnect")
         
         OsmAndApp.swiftInstance().carPlayActive = true
         windowToAttach = window
@@ -135,7 +135,7 @@ extension CarPlaySceneDelegate: CPTemplateApplicationSceneDelegate {
     }
     
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnect interfaceController: CPInterfaceController, from window: CPWindow) {
-        NSLog("[CarPlay] CarPlaySceneDelegate didDisconnect")
+        OALog("[CarPlay] CarPlaySceneDelegate didDisconnect")
         
         OsmAndApp.swiftInstance().carPlayActive = false
         if defaultAppMode != nil && !isRoutingActive() {
@@ -144,13 +144,13 @@ extension CarPlaySceneDelegate: CPTemplateApplicationSceneDelegate {
         
         defaultAppMode = nil
         guard let mapPanel = OARootViewController.instance()?.mapPanel else {
-            NSLog("[CarPlay] CarPlaySceneDelegate rootViewController mapPanel is nil")
+            OALog("[CarPlay] CarPlaySceneDelegate rootViewController mapPanel is nil")
             return
         }
         
         mapPanel.onCarPlayDisconnected { [weak self] in
             guard let self else { return }
-            NSLog("[CarPlay] CarPlaySceneDelegate onCarPlayDisconnected")
+            OALog("[CarPlay] CarPlaySceneDelegate onCarPlayDisconnected")
             carPlayMapController?.detachFromCarPlayWindow()
             carPlayDashboardController = nil
             carPlayMapController?.navigationController?.popViewController(animated: true)

--- a/Sources/AppHost/CarPlayDelegate/DashboardCarPlaySceneDelegate.swift
+++ b/Sources/AppHost/CarPlayDelegate/DashboardCarPlaySceneDelegate.swift
@@ -8,13 +8,13 @@ final class DashboardCarPlaySceneDelegate: UIResponder {
     private var isForegroundScene = false
     
     func sceneWillEnterForeground(_ scene: UIScene) {
-        NSLog("[CarPlay] DashboardCarPlaySceneDelegate sceneWillEnterForeground")
+        OALog("[CarPlay] DashboardCarPlaySceneDelegate sceneWillEnterForeground")
         isForegroundScene = true
         configureScene()
     }
     
     func sceneWillResignActive(_ scene: UIScene) {
-        NSLog("[CarPlay] DashboardCarPlaySceneDelegate sceneWillResignActive")
+        OALog("[CarPlay] DashboardCarPlaySceneDelegate sceneWillResignActive")
         NotificationCenter.default.removeObserver(self)
         isForegroundScene = false
         mapVC?.isCarPlayDashboardActive = false
@@ -68,13 +68,13 @@ final class DashboardCarPlaySceneDelegate: UIResponder {
     }
     
     @objc private func appInitEventConfigureScene(notification: Notification) {
-        NSLog("[CarPlay] DashboardCarPlaySceneDelegate appInitEventConfigureScene")
+        OALog("[CarPlay] DashboardCarPlaySceneDelegate appInitEventConfigureScene")
         guard let userInfo = notification.userInfo,
               let item = userInfo["event"] as? Int,
               let event = AppLaunchEvent(rawValue: item) else { return }
         if case .setupRoot = event {
             guard isForegroundScene else { return }
-            NSLog("[CarPlay] DashboardCarPlaySceneDelegate appInitEventConfigureScene success")
+            OALog("[CarPlay] DashboardCarPlaySceneDelegate appInitEventConfigureScene success")
             configureScene()
         }
     }
@@ -83,7 +83,7 @@ final class DashboardCarPlaySceneDelegate: UIResponder {
 extension DashboardCarPlaySceneDelegate: CPTemplateApplicationDashboardSceneDelegate {
     
     func templateApplicationDashboardScene(_ templateApplicationDashboardScene: CPTemplateApplicationDashboardScene, didConnect dashboardController: CPDashboardController, to window: UIWindow) {
-        NSLog("[CarPlay] DashboardCarPlaySceneDelegate didConnect")
+        OALog("[CarPlay] DashboardCarPlaySceneDelegate didConnect")
         self.window = window
         dashboardController.shortcutButtons = [
             CPDashboardButton(titleVariants: [localizedString("shared_string_navigation")], subtitleVariants: [""], image: UIImage(named: "ic_carplay_navigation")!, handler: { _ in
@@ -97,7 +97,7 @@ extension DashboardCarPlaySceneDelegate: CPTemplateApplicationDashboardSceneDele
     }
     
     func templateApplicationDashboardScene(_ templateApplicationDashboardScene: CPTemplateApplicationDashboardScene, didDisconnect dashboardController: CPDashboardController, from window: UIWindow) {
-        NSLog("[CarPlay] DashboardCarPlaySceneDelegate didDisconnect")
+//        OALog("[CarPlay] DashboardCarPlaySceneDelegate didDisconnect")
         dashboardVC?.detachFromCarPlayWindow()
         mapVC = nil
         self.window = nil

--- a/Sources/AppHost/OAAppDelegate.mm
+++ b/Sources/AppHost/OAAppDelegate.mm
@@ -77,7 +77,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
     self = [super init];
     if (self)
     {
-        NSLog(@"AppDelegate initialized");
+        OALog(@"AppDelegate initialized");
         initializeQueue = dispatch_queue_create("OAAppDelegateInitializeQueue", dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, QOS_CLASS_USER_INTERACTIVE, 0));
     }
     return self;
@@ -105,7 +105,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 
     [self configureAppLaunchEvent:AppLaunchEventStart];
 
-    NSLog(@"OAAppDelegate initialize start");
+    OALog(@"OAAppDelegate initialize start");
 
     // Configure device
     UIDevice* device = [UIDevice currentDevice];
@@ -133,19 +133,19 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
     
     dispatch_async(initializeQueue, ^{
         
-        NSLog(@"OAAppDelegate beginBackgroundTask");
+        OALog(@"OAAppDelegate beginBackgroundTask");
 
         // Initialize OsmAnd core
         if (![_app initializeCore])
         {
-            NSLog(@"OAAppDelegate failed to initialize core");
+            OALog(@"OAAppDelegate failed to initialize core");
             return;
         }
 
         // Initialize application in background
         if (![_app initialize])
         {
-            NSLog(@"OAAppDelegate failed to initialize app");
+            OALog(@"OAAppDelegate failed to initialize app");
             return;
         }
 
@@ -199,14 +199,14 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
             [[UIApplication sharedApplication] endBackgroundTask:_appInitTask];
             _appInitTask = UIBackgroundTaskInvalid;
 
-            NSLog(@"OAAppDelegate endBackgroundTask");
+            OALog(@"OAAppDelegate endBackgroundTask");
             
             // Check for updates every hour when the app is in the foreground
             [self initCheckUpdatesTimer];
         });
     });
     
-    NSLog(@"OAAppDelegate initialize finish");
+    OALog(@"OAAppDelegate initialize finish");
     return YES;
 }
 
@@ -284,14 +284,14 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
         _dataFetchQueue = [[NSOperationQueue alloc] init];
         @try
         {
-            NSLog(@"BGTaskScheduler registerForTaskWithIdentifier");
+            OALog(@"BGTaskScheduler registerForTaskWithIdentifier");
             [BGTaskScheduler.sharedScheduler registerForTaskWithIdentifier:kFetchDataUpdatesId usingQueue:nil launchHandler:^(__kindof BGTask * _Nonnull task) {
                 [self handleBackgroundDataFetch:(BGProcessingTask *)task];
             }];
         }
         @catch (NSException *e)
         {
-            NSLog(@"Failed to schedule background fetch. Reason: %@", e.reason);
+            OALog(@"Failed to schedule background fetch. Reason: %@", e.reason);
         }
     }
 
@@ -322,14 +322,14 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
     request.earliestBeginDate = [NSDate dateWithTimeIntervalSinceNow:kCheckUpdatesInterval];
     @try
     {
-        NSLog(@"BGTaskScheduler submitTaskRequest");
+        OALog(@"BGTaskScheduler submitTaskRequest");
         NSError *error = nil;
         // e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"net.osmand.fetchDataUpdates"]
         [BGTaskScheduler.sharedScheduler submitTaskRequest:request error:&error];
         if (error)
-            NSLog(@"Could not schedule app refresh: %@", error.description);
+            OALog(@"Could not schedule app refresh: %@", error.description);
     } @catch (NSException *e) {
-        NSLog(@"Could not schedule app refresh: %@", e.reason);
+        OALog(@"Could not schedule app refresh: %@", e.reason);
     }
 }
 
@@ -340,14 +340,14 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 
 - (void)applicationWillResignActive
 {
-    NSLog(@"OAAppDelegate applicationWillResignActive %d", _appInitDone);
+    OALog(@"OAAppDelegate applicationWillResignActive %d", _appInitDone);
     if (_appInitDone)
         [_app onApplicationWillResignActive];
 }
 
 - (void)applicationDidEnterBackground
 {
-    NSLog(@"OAAppDelegate applicationDidEnterBackground %d", _appInitDone);
+    OALog(@"OAAppDelegate applicationDidEnterBackground %d", _appInitDone);
     [self invalidateIfNeededCheckUpdatesTimer];
     if (_appInitDone)
         [_app onApplicationDidEnterBackground];
@@ -358,7 +358,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 
 - (void)applicationWillEnterForeground
 {
-    NSLog(@"OAAppDelegate applicationWillEnterForeground %d", _appInitDone);
+    OALog(@"OAAppDelegate applicationWillEnterForeground %d", _appInitDone);
     if (_appInitDone)
     {
         [_app onApplicationWillEnterForeground];
@@ -369,7 +369,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
             id<OADownloadTask> nextTask = [_app.downloadsManager firstDownloadTasksWithKey:[_app.downloadsManager.keysOfDownloadTasks objectAtIndex:0]];
             if (nextTask)
             {
-                NSLog(@"Resume suspended download %@", nextTask.key);
+                OALog(@"Resume suspended download %@", nextTask.key);
                 [nextTask resume];
             }
         }
@@ -378,7 +378,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 
 - (void)applicationDidBecomeActive
 {
-    NSLog(@"OAAppDelegate applicationDidBecomeActive %d", _appInitDone);
+    OALog(@"OAAppDelegate applicationDidBecomeActive %d", _appInitDone);
     if (_appInitDone)
     {
         [self initCheckUpdatesTimer];
@@ -394,7 +394,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 
 - (void)applicationWillTerminate:(UIApplication *)application
 {
-    NSLog(@"OAAppDelegate applicationWillTerminate");
+    OALog(@"OAAppDelegate applicationWillTerminate");
     [_app shutdown];
     OAMapViewController *mapVc = OARootViewController.instance.mapPanel.mapViewController;
     [mapVc onApplicationDestroyed];
@@ -409,17 +409,17 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication *)application
 {
-    NSLog(@"OAAppDelegate applicationDidReceiveMemoryWarning");
+    OALog(@"OAAppDelegate applicationDidReceiveMemoryWarning");
 }
 
 - (void)applicationProtectedDataWillBecomeUnavailable:(UIApplication *)application
 {
-    NSLog(@"OAAppDelegate applicationProtectedDataWillBecomeUnavailable");
+    OALog(@"OAAppDelegate applicationProtectedDataWillBecomeUnavailable");
 }
 
 - (void)applicationProtectedDataDidBecomeAvailable:(UIApplication *)application
 {
-    NSLog(@"OAAppDelegate applicationProtectedDataDidBecomeAvailable");
+    OALog(@"OAAppDelegate applicationProtectedDataDidBecomeAvailable");
 }
 
 #pragma mark - UISceneSession Lifecycle

--- a/Sources/AppHost/OAFetchBackgroundDataOperation.m
+++ b/Sources/AppHost/OAFetchBackgroundDataOperation.m
@@ -12,6 +12,7 @@
 #import "OAAutoObserverProxy.h"
 #import "OAObservable.h"
 #import "OADownloadTask.h"
+#import "OALog.h"
 #import <AFNetworking/AFNetworkReachabilityManager.h>
 
 @implementation OAFetchBackgroundDataOperation
@@ -58,11 +59,11 @@
 
 - (void) performUpdatesCheck
 {
-    NSLog(@"OAFetchBackgroundDataOperation start");
+    OALog(@"OAFetchBackgroundDataOperation start");
 
     [_app checkAndDownloadOsmAndLiveUpdates:NO];
 
-    NSLog(@"OAFetchBackgroundDataOperation LiveUpdates checked");
+    OALog(@"OAFetchBackgroundDataOperation LiveUpdates checked");
 
     OADownloadsManager *downloadManager = _app.downloadsManager;
     BOOL hasNetworkConnection = NO;
@@ -73,46 +74,46 @@
         hasNetworkConnection = AFNetworkReachabilityManager.sharedManager.isReachable;
         hasTasks = [downloadManager numberOfDownloadTasksWithKeySuffix:@".live.obf"] > 0;
 
-        NSLog(@"OAFetchBackgroundDataOperation processing live tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@".live.obf"]);
+        OALog(@"OAFetchBackgroundDataOperation processing live tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@".live.obf"]);
 
     } while (hasNetworkConnection && hasTasks && !self.cancelled);
 
     if (self.cancelled && hasTasks)
     {
-        NSLog(@"OAFetchBackgroundDataOperation LiveUpdates cancel tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@".live.obf"]);
+        OALog(@"OAFetchBackgroundDataOperation LiveUpdates cancel tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@".live.obf"]);
         NSArray *tasks = [downloadManager downloadTasksWithKeySuffix:@".live.obf"];
         for (id<OADownloadTask> task in tasks)
             [task cancel];
     }
 
-    NSLog(@"OAFetchBackgroundDataOperation LiveUpdates done");
+    OALog(@"OAFetchBackgroundDataOperation LiveUpdates done");
 
     if (!self.cancelled && hasNetworkConnection)
     {
         [_app checkAndDownloadWeatherForecastsUpdates];
-        NSLog(@"OAFetchBackgroundDataOperation ForecastsUpdates checked");
+        OALog(@"OAFetchBackgroundDataOperation ForecastsUpdates checked");
         do {
             [NSThread sleepForTimeInterval:0.5];
 
             hasNetworkConnection = AFNetworkReachabilityManager.sharedManager.isReachable;
             hasTasks = [downloadManager numberOfDownloadTasksWithKeySuffix:@"tifsqlite"] > 0;
 
-            NSLog(@"OAFetchBackgroundDataOperation processing forecasts tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@"tifsqlite"]);
+            OALog(@"OAFetchBackgroundDataOperation processing forecasts tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@"tifsqlite"]);
 
         } while (hasNetworkConnection && hasTasks && !self.cancelled);
 
         if (self.cancelled && hasTasks)
         {
-            NSLog(@"OAFetchBackgroundDataOperation ForecastsUpdates cancel tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@"tifsqlite"]);
+            OALog(@"OAFetchBackgroundDataOperation ForecastsUpdates cancel tasks %d", [downloadManager numberOfDownloadTasksWithKeySuffix:@"tifsqlite"]);
             NSArray *tasks = [downloadManager downloadTasksWithKeySuffix:@"tifsqlite"];
             for (id<OADownloadTask> task in tasks)
                 [task cancel];
         }
 
-        NSLog(@"OAFetchBackgroundDataOperation ForecastsUpdates done");
+        OALog(@"OAFetchBackgroundDataOperation ForecastsUpdates done");
     }
 
-    NSLog(@"OAFetchBackgroundDataOperation finish");
+    OALog(@"OAFetchBackgroundDataOperation finish");
 }
 
 @end

--- a/Sources/AppHost/OALog.h
+++ b/Sources/AppHost/OALog.h
@@ -21,4 +21,8 @@ extern "C"
 
 + (void) log:(NSString *)format withArguments:(va_list)arguments;
 
++ (NSString *) getFormattedTimestamp;
++ (NSString *) getFormattedTimestampByDate:(NSDate *)date;
++ (NSString *) getFormattedThread:(NSThread *)thread;
+
 @end

--- a/Sources/AppHost/OALog.h
+++ b/Sources/AppHost/OALog.h
@@ -18,4 +18,7 @@ extern "C"
 #endif
 
 @interface OALogger : NSObject
+
++ (void) log:(NSString *)format withArguments:(va_list)arguments;
+
 @end

--- a/Sources/AppHost/OALog.h
+++ b/Sources/AppHost/OALog.h
@@ -8,18 +8,31 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSUInteger, EOALog) {
+    EOALogVerbose,
+    EOALogDebug,
+    EOALogInfo,
+    EOALogWarning,
+    EOALogError
+};
+
+
 #if __cplusplus
 extern "C"
 {
 #endif
+    void OALogWithLevel(EOALog level, NSString *format, ...);
     void OALog(NSString *format, ...) __attribute__((format(__NSString__, 1, 2)));
 #if __cplusplus
 }
 #endif
 
+
 @interface OALogger : NSObject
 
 + (void) log:(NSString *)format withArguments:(va_list)arguments;
+
++ (void) createLogFileIfNeeded;
 
 + (NSString *) getFormattedTimestamp;
 + (NSString *) getFormattedTimestampByDate:(NSDate *)date;

--- a/Sources/AppHost/OALog.mm
+++ b/Sources/AppHost/OALog.mm
@@ -13,6 +13,11 @@
 #include <OsmAndCore.h>
 #include <OsmAndCore/Logging.h>
 
+#include <pthread.h>
+
+// set true for printing logs without timestamp and thread ingo
+static const BOOL useShortFormat = NO;
+
 #if __cplusplus
 extern "C"
 {
@@ -23,8 +28,21 @@ extern "C"
         va_start(args, format);
         NSString* formattedString = [[NSString alloc] initWithFormat:format
                                                        arguments:args];
+        
+        
+        
         va_end(args);
         NSCAssert((formattedString != nil), @"Log formatting failed");
+        
+        if (!useShortFormat)
+        {
+            NSString *timestamp = [OALogger getFormattedTimestamp];
+            NSString *threadInfo = [OALogger getFormattedThread:[NSThread currentThread]];
+            formattedString = [NSString stringWithFormat:@"%@  %@  %@",
+                               timestamp,
+                               threadInfo,
+                               formattedString];
+        }
 
         const char* pcsFormattedString = [formattedString cStringUsingEncoding:NSASCIIStringEncoding];
         if (pcsFormattedString != nullptr)
@@ -43,6 +61,51 @@ extern "C"
 {
     NSString *logString = [[NSString alloc] initWithFormat:format arguments:args];
     OALog(@"%@", logString);
+}
+
++ (NSString *) getFormattedTimestamp
+{
+    return [self getFormattedTimestampByDate:[NSDate now]];
+}
+
++ (NSString *) getFormattedTimestampByDate:(NSDate *)date
+{
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+    return [dateFormatter stringFromDate:date];
+}
+
++ (NSString *) getFormattedThread:(NSThread *)thread
+{
+    BOOL isMain = [thread isMainThread];
+    NSString *name = thread.name;
+    name = (name && name.length > 0) ? [NSString stringWithFormat:@" \"%@\"", thread.name] : @"";
+    NSString *quality = [self formattedQualityOfServise:thread.qualityOfService];
+    mach_port_t machTID = pthread_mach_thread_np(pthread_self());
+    
+    return [NSString stringWithFormat:@"[%@ %d%@%@]",
+            isMain ? @"MainTread" : @"Tread",
+            machTID,
+            name,
+            quality];
+}
+
++ (NSString *) formattedQualityOfServise:(NSQualityOfService)quality
+{
+    switch (quality) {
+        case NSQualityOfServiceUserInteractive:
+            return @"";
+            //most common format. don't write
+            //return @"Interactive";
+        case NSQualityOfServiceUserInitiated:
+            return @"  Initiated";
+        case NSQualityOfServiceUtility:
+            return @"  Utility";
+        case NSQualityOfServiceBackground:
+            return @"  Background";
+        default:
+            return @"  Default";
+    }
 }
 
 @end

--- a/Sources/AppHost/OALog.mm
+++ b/Sources/AppHost/OALog.mm
@@ -37,4 +37,12 @@ extern "C"
 #endif
 
 @implementation OALogger
+
+// for using OALog() from swift
++ (void) log:(NSString *)format withArguments:(va_list)args;
+{
+    NSString *logString = [[NSString alloc] initWithFormat:format arguments:args];
+    OALog(@"%@", logString);
+}
+
 @end

--- a/Sources/AppHost/OALogWrapper.swift
+++ b/Sources/AppHost/OALogWrapper.swift
@@ -1,0 +1,13 @@
+//
+//  OALogWrapper.swift
+//  OsmAnd
+//
+//  Created by Max Kojin on 28/11/24.
+//  Copyright © 2024 OsmAnd. All rights reserved.
+//
+
+import Foundation
+
+func OALog(_ format: String, _ arguments: CVarArg...) {
+    withVaList(arguments) { OALogger.log(format, withArguments: $0) }
+}

--- a/Sources/AppHost/OsmAndAppImpl.mm
+++ b/Sources/AppHost/OsmAndAppImpl.mm
@@ -244,15 +244,25 @@
     if (![manager fileExistsAtPath:logsPath])
         [manager createDirectoryAtPath:logsPath withIntermediateDirectories:NO attributes:nil error:nil];
     NSArray<NSString *> *files = [manager contentsOfDirectoryAtPath:logsPath error:nil];
+    
+    files = [[[files sortedArrayUsingComparator:^NSComparisonResult(NSString *filename1, NSString *filename2) {
+        return [filename1 compare:filename2];
+    }] reverseObjectEnumerator] allObjects];
+    
     for (NSInteger i = 0; i < files.count; i++)
     {
         if (i > kMaxLogFiles)
            [manager removeItemAtPath:[logsPath stringByAppendingPathComponent:files[i]] error:nil];
     }
+    
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"MMM dd, yyyy HH:mm"];
+    [formatter setDateFormat:@"MMM dd, yyyy HH:mm:ss"];
     NSString *destPath = [[logsPath stringByAppendingPathComponent:[formatter stringFromDate:NSDate.date]] stringByAppendingPathExtension:@"log"];
+    
+    freopen([destPath fileSystemRepresentation], "a+", stdin);
+    freopen([destPath fileSystemRepresentation], "a+", stdout);
     freopen([destPath fileSystemRepresentation], "a+", stderr);
+    
 #endif
 }
 
@@ -324,23 +334,23 @@
     {
         if (_initializedCore)
         {
-            NSLog(@"OsmAndApp Core already initialized. Finish.");
+            OALog(@"OsmAndApp Core already initialized. Finish.");
             return YES;
         }
 
         @try
         {
             // Initialize OsmAnd Core
-            NSLog(@"OsmAndApp InitializeCore start");
+            OALog(@"OsmAndApp InitializeCore start");
             const std::shared_ptr<CoreResourcesFromBundleProvider> coreResourcesFromBundleProvider(new CoreResourcesFromBundleProvider());
             OsmAnd::InitializeCore(coreResourcesFromBundleProvider);
             _initializedCore = YES;
-            NSLog(@"OsmAndApp InitializeCore finish");
+            OALog(@"OsmAndApp InitializeCore finish");
             return YES;
         }
         @catch (NSException *e)
         {
-            NSLog(@"Failed to InitializeCore. Reason: %@", e.reason);
+            OALog(@"Failed to InitializeCore. Reason: %@", e.reason);
             return NO;
         }
     }
@@ -356,7 +366,7 @@
         }
         @catch (NSException *e)
         {
-            NSLog(@"Failed to initialize OsmAndApp. Reason: %@", e.reason);
+            OALog(@"Failed to initialize OsmAndApp. Reason: %@", e.reason);
             return NO;
         }
     }
@@ -364,10 +374,10 @@
 
 - (BOOL) initializeImpl
 {
-    NSLog(@"OsmAndApp initialize start (%@)", [NSThread isMainThread] ? @"Main thread" : @"Background thread");
+    OALog(@"OsmAndApp initialize start (%@)", [NSThread isMainThread] ? @"Main thread" : @"Background thread");
     if (_initialized)
     {
-        NSLog(@"OsmAndApp already initialized. Finish.");
+        OALog(@"OsmAndApp already initialized. Finish.");
         return YES;
     }
 
@@ -599,7 +609,7 @@
         NSError *error = nil;
         [[NSFileManager defaultManager] copyItemAtPath:ocbfPathBundle toPath:ocbfPathLib error:&error];
         if (error)
-            NSLog(@"Error copying file: %@ to %@ - %@", ocbfPathBundle, ocbfPathLib, [error localizedDescription]);
+            OALog(@"Error copying file: %@ to %@ - %@", ocbfPathBundle, ocbfPathLib, [error localizedDescription]);
     }
     [self applyExcludedFromBackup:ocbfPathLib];
 
@@ -613,12 +623,12 @@
         [[NSFileManager defaultManager] createDirectoryAtPath:[NSHomeDirectory() stringByAppendingString:@"/Library/Application Support/proj"]
                                   withIntermediateDirectories:YES attributes:nil error:&errorDir];
         if (errorDir)
-            NSLog(@"Error creating dir for proj: %@", [errorDir localizedDescription]);
+            OALog(@"Error creating dir for proj: %@", [errorDir localizedDescription]);
 
         NSError *error = nil;
         [[NSFileManager defaultManager] copyItemAtPath:projDbPathBundle toPath:projDbPathLib error:&error];
         if (error)
-            NSLog(@"Error copying file: %@ to %@ - %@", projDbPathBundle, projDbPathLib, [error localizedDescription]);
+            OALog(@"Error copying file: %@ to %@ - %@", projDbPathBundle, projDbPathLib, [error localizedDescription]);
 
     }
     [self applyExcludedFromBackup:projDbPathLib];
@@ -741,7 +751,7 @@
         return NO;
 
     _initialized = YES;
-    NSLog(@"OsmAndApp initialize finish");
+    OALog(@"OsmAndApp initialize finish");
     return YES;
 }
 
@@ -885,7 +895,7 @@
     {
         NSString *pathToCache = [self.cachePath stringByAppendingPathComponent:folderName];
         BOOL success = [manager removeItemAtPath:pathToCache error:nil];
-        NSLog(@"Removing tiles at path: %@ %@", pathToCache, success ? @"successful" : @"failed - No such directory");
+        OALog(@"Removing tiles at path: %@ %@", pathToCache, success ? @"successful" : @"failed - No such directory");
     }
 }
 
@@ -909,7 +919,7 @@
     {
         float te = [[NSDate date] timeIntervalSince1970];
         if (te - tm > 30)
-            NSLog(@"Defalt routing config init took %f ms", (te - tm));
+            OALog(@"Defalt routing config init took %f ms", (te - tm));
     }
 }
 
@@ -1071,12 +1081,12 @@
 
     @synchronized (self)
     {
-        NSLog(@"Prepare checkAndDownloadOsmAndLiveUpdates start");
+        OALog(@"Prepare checkAndDownloadOsmAndLiveUpdates start");
         QList<std::shared_ptr<const OsmAnd::IncrementalChangesManager::IncrementalUpdate> > updates;
         for (const auto& localResource : _resourcesManager->getLocalResources())
             [OAOsmAndLiveHelper downloadUpdatesForRegion:QString(localResource->id).remove(QStringLiteral(".obf")) resourcesManager:_resourcesManager checkUpdatesAsync:checkUpdatesAsync];
 
-        NSLog(@"Prepare checkAndDownloadOsmAndLiveUpdates finish");
+        OALog(@"Prepare checkAndDownloadOsmAndLiveUpdates finish");
     }
 }
 
@@ -1087,11 +1097,11 @@
 
     @synchronized (self)
     {
-        NSLog(@"Prepare checkAndDownloadWeatherForecastsUpdates start");
+        OALog(@"Prepare checkAndDownloadWeatherForecastsUpdates start");
         OAWeatherHelper *weatherHelper = [OAWeatherHelper sharedInstance];
         NSArray<NSString *> *regionIds = [weatherHelper getRegionIdsForDownloadedWeatherForecast];
         [weatherHelper checkAndDownloadForecastsByRegionIds:regionIds];
-        NSLog(@"Prepare checkAndDownloadWeatherForecastsUpdates finish");
+        OALog(@"Prepare checkAndDownloadWeatherForecastsUpdates finish");
     }
 }
 

--- a/Sources/AppHost/OsmAndAppImpl.mm
+++ b/Sources/AppHost/OsmAndAppImpl.mm
@@ -82,8 +82,6 @@
 #define VERSION_4_4_1 4.41
 #define VERSION_4_7_4 4.74
 
-#define kMaxLogFiles 3
-
 #define kAppData @"app_data"
 #define kSubfolderPlaceholder @"_%_"
 #define kBuildVersion @"buildVersion"
@@ -187,7 +185,7 @@
         _legacyFavoritesFilePrefix = @"favourites";
 
         [self buildFolders];
-        [self createLogFile];
+        [OALogger createLogFileIfNeeded];
 
         [self initOpeningHoursParser];
 
@@ -232,38 +230,6 @@
         if (![fileManager createDirectoryAtPath:path withIntermediateDirectories:NO attributes:nil error:&error])
             OALog(@"Error creating folder \"%@\": %@", path, error.localizedFailureReason);
     }
-}
-
-- (void) createLogFile
-{
-#if DEBUG
-    return;
-#else
-    NSFileManager *manager = NSFileManager.defaultManager;
-    NSString *logsPath = [_documentsPath stringByAppendingPathComponent:@"Logs"];
-    if (![manager fileExistsAtPath:logsPath])
-        [manager createDirectoryAtPath:logsPath withIntermediateDirectories:NO attributes:nil error:nil];
-    NSArray<NSString *> *files = [manager contentsOfDirectoryAtPath:logsPath error:nil];
-    
-    files = [[[files sortedArrayUsingComparator:^NSComparisonResult(NSString *filename1, NSString *filename2) {
-        return [filename1 compare:filename2];
-    }] reverseObjectEnumerator] allObjects];
-    
-    for (NSInteger i = 0; i < files.count; i++)
-    {
-        if (i > kMaxLogFiles)
-           [manager removeItemAtPath:[logsPath stringByAppendingPathComponent:files[i]] error:nil];
-    }
-    
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"MMM dd, yyyy HH:mm:ss"];
-    NSString *destPath = [[logsPath stringByAppendingPathComponent:[formatter stringFromDate:NSDate.date]] stringByAppendingPathExtension:@"log"];
-    
-    freopen([destPath fileSystemRepresentation], "a+", stdin);
-    freopen([destPath fileSystemRepresentation], "a+", stdout);
-    freopen([destPath fileSystemRepresentation], "a+", stderr);
-    
-#endif
 }
 
 - (void) initOpeningHoursParser

--- a/Sources/AppHost/SceneDelegate.mm
+++ b/Sources/AppHost/SceneDelegate.mm
@@ -71,16 +71,16 @@
     self = [super init];
     if (self)
     {
-        NSLog(@"SceneDelegate initialized");
+        OALog(@"SceneDelegate initialized");
     }
     return self;
 }
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
 {
-    NSLog(@"SceneDelegate willConnectToSession");
+    OALog(@"SceneDelegate willConnectToSession");
     _windowScene = (UIWindowScene *)scene;
     if (!_windowScene) {
-        NSLog(@"SceneDelegate _windowScene in nil");
+        OALog(@"SceneDelegate _windowScene in nil");
         return;
     }
     
@@ -143,7 +143,7 @@
     NSDictionary *info = notification.userInfo;
     if (info[@"event"]) {
         NSNumber *num = info[@"event"];
-        NSLog(@"launchUpdateStateNotification: %@", num);
+        OALog(@"launchUpdateStateNotification: %@", num);
         [self configureSceneState:(AppLaunchEvent)num.intValue];
     }
 }
@@ -152,16 +152,16 @@
 {
     switch (event) {
         case AppLaunchEventStart:
-            NSLog(@"AppLaunchEventStart");
+            OALog(@"AppLaunchEventStart");
             _window.rootViewController = [OALaunchScreenViewController new];
             [_window makeKeyAndVisible];
             break;
         case AppLaunchEventFirstLaunch:
-            NSLog(@"AppLaunchEventFirstLaunch");
+            OALog(@"AppLaunchEventFirstLaunch");
             [_rootViewController.navigationController pushViewController:[OAFirstUsageWizardController new] animated:NO];
             break;
         case AppLaunchEventRestoreSession:
-            NSLog(@"AppLaunchEventRestoreSession");
+            OALog(@"AppLaunchEventRestoreSession");
             _rootViewController = [OARootViewController new];
             if ([self appDelegate].rootViewController == nil)
                 [self appDelegate].rootViewController = _rootViewController;
@@ -170,7 +170,7 @@
             [_window makeKeyAndVisible];
             break;
         case AppLaunchEventSetupRoot:
-            NSLog(@"AppLaunchEventSetupRoot");
+            OALog(@"AppLaunchEventSetupRoot");
             [self configureLaunchEventSetupRootState];
             break;
         default:

--- a/Sources/Backup/LocalBackup/ImportExportData/ReadWrite/OASettingsItemReader.m
+++ b/Sources/Backup/LocalBackup/ImportExportData/ReadWrite/OASettingsItemReader.m
@@ -9,6 +9,7 @@
 #import "OASettingsItemReader.h"
 #import "OASettingsHelper.h"
 #import "OASettingsItem.h"
+#import "OALog.h"
 
 @interface OASettingsItemReader<__covariant ObjectType : OASettingsItem *>()
 
@@ -67,7 +68,7 @@
     [self.item readFromJson:json error:&parsingError];
     if (parsingError)
     {
-        NSLog(@"Json parsing error");
+        OALog(@"Json parsing error");
         return NO;
     }
 

--- a/Sources/Backup/LocalBackup/OAExportAsyncTask.m
+++ b/Sources/Backup/LocalBackup/OAExportAsyncTask.m
@@ -8,6 +8,7 @@
 
 #import "OAExportAsyncTask.h"
 #import "OASettingsExporter.h"
+#import "OALog.h"
 
 @interface OAExportAsyncTask()
 
@@ -54,7 +55,7 @@
     [_exporter exportSettings:_filePath error:&exportError];
     if (exportError)
     {
-        NSLog(@"Failed to export items to: %@ %@", _filePath, exportError);
+        OALog(@"Failed to export items to: %@ %@", _filePath, exportError);
         return NO;
     }
     return YES;

--- a/Sources/Backup/LocalBackup/OASettingsExporter.mm
+++ b/Sources/Backup/LocalBackup/OASettingsExporter.mm
@@ -14,6 +14,7 @@
 #import "OsmAndApp.h"
 #import "OARootViewController.h"
 #import "OAExportAsyncTask.h"
+#import "OALog.h"
 
 #include <OsmAndCore/ArchiveWriter.h>
 
@@ -83,7 +84,7 @@
     if (!ok)
     {
         NSString *message = [NSString stringWithFormat:@"Archive creation failed: %@", file];
-        NSLog(@"%@", message);
+        OALog(@"%@", message);
         NSMutableDictionary* details = [NSMutableDictionary dictionary];
         [details setValue:message forKey:NSLocalizedDescriptionKey];
         *error = [NSError errorWithDomain:@"SettingsExporter" code:0 userInfo:details];

--- a/Sources/Backup/LocalBackup/OASettingsImporter.mm
+++ b/Sources/Backup/LocalBackup/OASettingsImporter.mm
@@ -44,6 +44,7 @@
 #import "OASuggestedDownloadsItem.h"
 #import "OAExportAsyncTask.h"
 #import "OAApplicationMode.h"
+#import "OALog.h"
 
 #include <OsmAndCore/ArchiveReader.h>
 #include <OsmAndCore/ResourcesManager.h>
@@ -98,7 +99,7 @@
         items = [self getItemsFromJson:file];
     else if ([items count] == 0)
     {
-        NSLog(@"No items");
+        OALog(@"No items");
         return nil;
     }
 
@@ -107,7 +108,7 @@
     const auto archiveItems = archive.getItems(&ok, false);
     if (!ok)
     {
-        NSLog(@"Error reading zip file");
+        OALog(@"Error reading zip file");
         return items;
     }
 
@@ -146,7 +147,7 @@
                         {
                             if (!archive.extractItemToFile(archiveItem.name, QString::fromNSString([_tmpFilesDir stringByAppendingPathComponent:itemName])))
                             {
-                                NSLog(@"Error processing directory item");
+                                OALog(@"Error processing directory item");
                                 continue;
                             }
                         }
@@ -156,7 +157,7 @@
                 {
                     if (!archive.extractItemToFile(archiveItem.name, QString::fromNSString(tmpFileName)))
                     {
-                        NSLog(@"Error processing items");
+                        OALog(@"Error processing items");
                         continue;
                     }
                 }
@@ -184,7 +185,7 @@
     const auto archiveItems = archive.getItems(&ok, false);
     if (!ok)
     {
-        NSLog(@"Error reading zip file");
+        OALog(@"Error reading zip file");
         return items;
     }
 
@@ -199,7 +200,7 @@
             if (itemsJsonData.isEmpty())
             {
                 [fileManager removeItemAtPath:_tmpFilesDir error:nil];
-                NSLog(@"Error reading or empty items.json");
+                OALog(@"Error reading or empty items.json");
                 return items;
             }
             OASettingsItemsFactory *factory = [[OASettingsItemsFactory alloc] initWithJSONData:itemsJsonData.toRawNSData()];
@@ -262,7 +263,7 @@
     NSInteger version = json[@"version"] ? [json[@"version"] integerValue] : kVersion;
     if (version > kVersion)
     {
-        NSLog(@"Error: unsupported version");
+        OALog(@"Error: unsupported version");
         return;
     }
     [[OASettingsHelper sharedInstance] setCurrentBackupVersion:version];
@@ -296,7 +297,7 @@
     }
     if ([_items count] == 0)
     {
-        NSLog(@"No items");
+        OALog(@"No items");
         return;
     }
     for (OASettingsItem *item in _items)
@@ -323,7 +324,7 @@
     NSDictionary *json = [NSJSONSerialization JSONObjectWithData:jsonUtf8Data options:kNilOptions error:&jsonError];
     if (jsonError)
     {
-        NSLog(@"Error reading json");
+        OALog(@"Error reading json");
         return;
     }
 
@@ -535,7 +536,7 @@
             @try {
                 return [_importer collectItems:_filePath];
             } @catch (NSException *exception) {
-                NSLog(@"Failed to collect items from: %@ %@", _filePath, exception);
+                OALog(@"Failed to collect items from: %@ %@", _filePath, exception);
             }
             break;
         case EOAImportTypeCheckDuplicates:

--- a/Sources/Backup/LocalBackup/SettingsItems/OAGpxSettingsItem.mm
+++ b/Sources/Backup/LocalBackup/SettingsItems/OAGpxSettingsItem.mm
@@ -12,6 +12,7 @@
 #import "OsmAndApp.h"
 #import "OAGPXAppearanceCollection.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 @interface OAGpxSettingsItem()
 
@@ -166,7 +167,7 @@
     }
     else
     {
-        NSLog(@"[ERROR] -> OAGpxSettingsItem -> gpx for self.filePath: %@ is empty", self.filePath);
+        OALog(@"[ERROR] -> OAGpxSettingsItem -> gpx for self.filePath: %@ is empty", self.filePath);
     }
 
 }

--- a/Sources/Backup/LocalBackup/SettingsItems/OAQuickActionsSettingsItem.mm
+++ b/Sources/Backup/LocalBackup/SettingsItems/OAQuickActionsSettingsItem.mm
@@ -18,6 +18,7 @@
 #import "OAShowHidePoiAction.h"
 #import "Localization.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 #define APPROXIMATE_QUICK_ACTION_SIZE_BYTES 135
 
@@ -168,7 +169,7 @@
         }
         @catch (NSException *e)
         {
-            NSLog(@"Failed to read quick action items: %@", e.reason);
+            OALog(@"Failed to read quick action items: %@", e.reason);
             return;
         }
     }

--- a/Sources/Backup/OABackupDbHelper.m
+++ b/Sources/Backup/OABackupDbHelper.m
@@ -7,6 +7,7 @@
 //
 
 #import "OABackupDbHelper.h"
+#import "OALog.h"
 
 #import <sqlite3.h>
 
@@ -146,7 +147,7 @@
                 
                 if (sqlite3_exec(backupFilesDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
+                    OALog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
                 
@@ -154,7 +155,7 @@
                 const char *create_index = [NSString stringWithFormat:@"CREATE INDEX IF NOT EXISTS %@ ON %@ (%@, %@)", UPLOADED_FILES_INDEX_TYPE_NAME, UPLOADED_FILES_TABLE_NAME, UPLOADED_FILE_COL_TYPE, UPLOADED_FILE_COL_NAME].UTF8String;
                 if (sqlite3_exec(backupFilesDB, create_index, NULL, NULL, &idxErrMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to create index: %@", [NSString stringWithCString:idxErrMsg encoding:NSUTF8StringEncoding]);
+                    OALog(@"Failed to create index: %@", [NSString stringWithCString:idxErrMsg encoding:NSUTF8StringEncoding]);
                 }
                 if (idxErrMsg != NULL) sqlite3_free(idxErrMsg);
                 
@@ -163,7 +164,7 @@
                 
                 if (sqlite3_exec(backupFilesDB, modified_sql_stmt, NULL, NULL, &modifiederrMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to create table: %@", [NSString stringWithCString:modifiederrMsg encoding:NSUTF8StringEncoding]);
+                    OALog(@"Failed to create table: %@", [NSString stringWithCString:modifiederrMsg encoding:NSUTF8StringEncoding]);
                 }
                 if (modifiederrMsg != NULL) sqlite3_free(modifiederrMsg);
                 

--- a/Sources/Backup/OABackupHelper.mm
+++ b/Sources/Backup/OABackupHelper.mm
@@ -34,6 +34,7 @@
 #import "OABackupListeners.h"
 #import "OAPrepareBackupTask.h"
 #import "OAURLSessionProgress.h"
+#import "OALog.h"
 #import "OsmAnd_Maps-Swift.h"
 
 #define kUpdateIdOperation @"Update order id"
@@ -347,7 +348,7 @@ static NSString *VERSION_HISTORY_PREFIX = @"save_version_history_";
     OASubscription *purchasedSubscription = iapHelper.getAnyPurchasedOsmAndProSubscription;
     if (purchasedSubscription)
     {
-        NSLog(@"Found purchased subscription: %@", [purchasedSubscription getOrderId]);
+        OALog(@"Found purchased subscription: %@", [purchasedSubscription getOrderId]);
         return [purchasedSubscription getOrderId];
     }
     return nil;
@@ -850,7 +851,7 @@ static NSString *VERSION_HISTORY_PREFIX = @"save_version_history_";
         }
         else
         {
-            NSLog(@"Cannot obtain updatetime after upload. Server response: %@", [[NSString alloc] initWithData:resp encoding:NSUTF8StringEncoding]);
+            OALog(@"Cannot obtain updatetime after upload. Server response: %@", [[NSString alloc] initWithData:resp encoding:NSUTF8StringEncoding]);
         }
     }
     if (error == nil && [status isEqualToString:@"ok"])

--- a/Sources/Backup/OABackupImporter.m
+++ b/Sources/Backup/OABackupImporter.m
@@ -21,6 +21,7 @@
 #import "OACollectionSettingsItem.h"
 #import "OAOperationLog.h"
 #import "OAAtomicInteger.h"
+#import "OALog.h"
 #import "Localization.h"
 
 @interface OAItemFileDownloadTask : NSOperation
@@ -57,7 +58,7 @@
     [reader readFromFile:tempFilePath error:&err];
     [item applyAdditionalParams:tempFilePath];
     if (err)
-        NSLog(@"Error reading downloaded item: %@", tempFilePath);
+        OALog(@"Error reading downloaded item: %@", tempFilePath);
 }
 
 @end
@@ -192,7 +193,7 @@
             }
         }];
     } @catch (NSException *e) {
-        NSLog(@"Failed to collect items for backup");
+        OALog(@"Failed to collect items for backup");
     }
     [operationLog finishOperation];
     if (error.length > 0)
@@ -297,7 +298,7 @@
     @catch (NSException *exception)
     {
         [item.warnings addObject:[NSString stringWithFormat:OALocalizedString(@"settings_item_read_error"), item.name]];
-        NSLog(@"Error reading item data: %@ %@", item.name, exception.reason);
+        OALog(@"Error reading item data: %@ %@", item.name, exception.reason);
     }
 }
 
@@ -555,7 +556,7 @@
                 if (json && ! jsonErr)
                     [itemsJson addObject:json];
                 else
-                    NSLog(@"generateItemsJson error: filePath:%@ %@", filePath, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                    OALog(@"generateItemsJson error: filePath:%@ %@", filePath, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
             }
             else
             {

--- a/Sources/Backup/OAExportBackupTask.m
+++ b/Sources/Backup/OAExportBackupTask.m
@@ -17,6 +17,7 @@
 #import "OAPrepareBackupResult.h"
 #import "OARemoteFile.h"
 #import "OAConcurrentCollections.h"
+#import "OALog.h"
 
 @interface OAExportBackupTask () <OANetworkExportProgressListener>
 
@@ -92,7 +93,7 @@
     }
     @catch (NSException *e)
     {
-        NSLog(@"Failed to backup items: %@", e.reason);
+        OALog(@"Failed to backup items: %@", e.reason);
         error = e.reason;
     }
     return error;

--- a/Sources/Backup/OAImportBackupItemsTask.m
+++ b/Sources/Backup/OAImportBackupItemsTask.m
@@ -11,6 +11,7 @@
 #import "OABackupHelper.h"
 #import "OAPrepareBackupResult.h"
 #import "OASettingsItem.h"
+#import "OALog.h"
 
 @implementation OAImportBackupItemsTask
 {
@@ -57,7 +58,7 @@
         [_importer importItems:_items remoteFiles:remoteFiles forceReadData:_foreceReadData restoreDeleted:_restoreDeleted];
         return YES;
     } @catch (NSException *exception) {
-        NSLog(@"Failed to import items from backup");
+        OALog(@"Failed to import items from backup");
     }
     return NO;
 }

--- a/Sources/Backup/OAImportBackupTask.m
+++ b/Sources/Backup/OAImportBackupTask.m
@@ -19,6 +19,7 @@
 #import "OAImportBackupItemsTask.h"
 #import "OASettingsImporter.h"
 #import "OABackupInfo.h"
+#import "OALog.h"
 
 @implementation OAItemProgressInfo
 
@@ -167,7 +168,7 @@
             if (json && !jsonErr)
                 [itemsJson addObject:json];
             else
-                NSLog(@"importBackupTask error: filePath:%@ %@", filePath, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                OALog(@"importBackupTask error: filePath:%@ %@", filePath, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
         }
         else
         {
@@ -199,7 +200,7 @@
             }
             @catch (NSException *e)
             {
-                NSLog(@"Failed to collect items for backup: %@", e.reason);
+                OALog(@"Failed to collect items for backup: %@", e.reason);
             }
             return nil;
         }
@@ -224,7 +225,7 @@
                 }
                 @catch (NSException *e)
                 {
-                    NSLog(@"Failed to recollect items for backup import: %@", e.reason);
+                    OALog(@"Failed to recollect items for backup import: %@", e.reason);
                     return nil;
                 }
             }

--- a/Sources/Backup/OANetworkWriter.mm
+++ b/Sources/Backup/OANetworkWriter.mm
@@ -13,6 +13,7 @@
 #import "OASettingsItemWriter.h"
 #import "OAFileSettingsItem.h"
 #import "OrderedDictionary.h"
+#import "OALog.h"
 
 #include <OsmAndCore/ArchiveWriter.h>
 
@@ -81,7 +82,7 @@
     }
     if (error != nil)
     {
-        NSLog(@"OANetworkWriter error: %@", error);
+        OALog(@"OANetworkWriter error: %@", error);
         @throw [NSException exceptionWithName:@"IOException" reason:error userInfo:nil];
     }
 }

--- a/Sources/Backup/OAPrepareBackupTask.m
+++ b/Sources/Backup/OAPrepareBackupTask.m
@@ -12,6 +12,7 @@
 #import "OAPrepareBackupResult.h"
 #import "OANetworkSettingsHelper.h"
 #import "Localization.h"
+#import "OALog.h"
 
 @interface OABackupTaskType ()
 
@@ -172,7 +173,7 @@ static OABackupTaskType *GENERATE_BACKUP_INFO;
         {
             [self onError:message];
         }
-        NSLog(@"Collect remote files error: %@", e.reason);
+        OALog(@"Collect remote files error: %@", e.reason);
     }
 }
 

--- a/Sources/Backup/OASyncBackupTask.mm
+++ b/Sources/Backup/OASyncBackupTask.mm
@@ -20,6 +20,7 @@
 #import "OARemoteFile.h"
 #import "OsmAndApp.h"
 #import "OAAppSettings.h"
+#import "OALog.h"
 
 #include <OsmAndCore/ResourcesManager.h>
 
@@ -156,7 +157,7 @@
     }
     @catch (NSException *e)
     {
-        NSLog(@"Backup generation error: %@", e.reason);
+        OALog(@"Backup generation error: %@", e.reason);
     }
 }
 

--- a/Sources/Controllers/Cloud/OACloudAccountCreateViewController.m
+++ b/Sources/Controllers/Cloud/OACloudAccountCreateViewController.m
@@ -16,6 +16,7 @@
 #import "OAInputTableViewCell.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 @interface OACloudAccountCreateViewController () <OAOnRegisterUserListener, OAOnRegisterDeviceListener>
 
@@ -204,7 +205,7 @@
         }
         _continuePressed = NO;
         [self updateScreen];
-        NSLog(@"Backup error: %@", error.getLocalizedError);
+        OALog(@"Backup error: %@", error.getLocalizedError);
     }
 }
 
@@ -221,7 +222,7 @@
         else
         {
             self.errorMessage = error != nil ? error.getLocalizedError : message;
-            NSLog(@"%@", message);
+            OALog(@"%@", message);
             _continuePressed = NO;
             [self updateScreen];
         }

--- a/Sources/Controllers/Cloud/OACloudAccountLoginViewController.m
+++ b/Sources/Controllers/Cloud/OACloudAccountLoginViewController.m
@@ -17,6 +17,7 @@
 #import "OAInputTableViewCell.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 @interface OACloudAccountLoginViewController () <OAOnRegisterUserListener, OAOnRegisterDeviceListener, OAOnSendCodeListener>
 
@@ -308,7 +309,7 @@
         }
         _continuePressed = NO;
         [self updateScreen];
-        NSLog(@"Backup error: %@", error.getLocalizedError);
+        OALog(@"Backup error: %@", error.getLocalizedError);
     }
 }
 

--- a/Sources/Controllers/Cloud/OACloudAccountVerificationViewController.m
+++ b/Sources/Controllers/Cloud/OACloudAccountVerificationViewController.m
@@ -15,6 +15,7 @@
 #import "OAInputTableViewCell.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 #define VERIFICATION_CODE_EXPIRATION_TIME_MIN (10 * 60)
 
@@ -205,7 +206,7 @@
     {
         self.errorMessage = OALocalizedString(@"backup_error_invalid_token");
         [self updateScreen];
-        NSLog(@"Token is not valid");
+        OALog(@"Token is not valid");
     }
 }
 

--- a/Sources/Controllers/DashboardOnMap/MapSettings/OAMapSettingsOnlineSourcesScreen.mm
+++ b/Sources/Controllers/DashboardOnMap/MapSettings/OAMapSettingsOnlineSourcesScreen.mm
@@ -15,6 +15,7 @@
 #import "OASimpleTableViewCell.h"
 #import "OAMapSource.h"
 #import "OAAppData.h"
+#import "OALog.h"
 
 #include <QSet>
 #include <OsmAndCore/Map/IOnlineTileSources.h>
@@ -123,7 +124,7 @@ typedef enum
         }
         else
         {
-            NSLog(@"Failed to download online tile resources list.");
+            OALog(@"Failed to download online tile resources list.");
         }
     });
 }

--- a/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
+++ b/Sources/Controllers/DashboardOnMap/MapSettings/OAWeatherLayerSettingsViewController.mm
@@ -23,6 +23,7 @@
 #import "OAAppData.h"
 #import "OAAutoObserverProxy.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 #import "OsmAnd_Maps-Swift.h"
 
 #import "OASwitchTableViewCell.h"
@@ -334,7 +335,7 @@
             @"type" : kEnableDescrCell,
             @"title" : text
         }];
-        NSLog([NSString stringWithFormat:@"%.1f", [OAUtilities calculateTextBounds:text width:width font:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]].height]);
+        OALog([NSString stringWithFormat:@"%.1f", [OAUtilities calculateTextBounds:text width:width font:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]].height]);
         _menuHeight += [OAUtilities calculateTextBounds:text width:width font:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]].height + kTextLineCellFixedHeight;
     }
     

--- a/Sources/Controllers/Help/OAHelpViewController.mm
+++ b/Sources/Controllers/Help/OAHelpViewController.mm
@@ -17,6 +17,7 @@
 #import "OsmAnd_Maps-Swift.h"
 #import "OAAppVersion.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 static NSString * const kLinkInternalType = @"internal_link";
 static NSString * const kLinkExternalType = @"ext_link";
@@ -242,7 +243,7 @@ static NSString * const kLinkExternalType = @"ext_link";
     [_helpDataManager loadAndParseJsonFrom:kPopularArticlesAndTelegramChats for:HelperDataItemsPopularArticles completion:^(NSArray *articles, NSError *error) {
         if (error)
         {
-            NSLog(OALocalizedString(@"osm_failed_uploads"));
+            OALog(OALocalizedString(@"osm_failed_uploads"));
         }
         else if (articles)
         {
@@ -258,7 +259,7 @@ static NSString * const kLinkExternalType = @"ext_link";
     [_helpDataManager loadAndParseJsonFrom:kPopularArticlesAndTelegramChats for:HelperDataItemsSiteArticles completion:^(NSArray *articles, NSError *error) {
         if (error)
         {
-            NSLog(@"Error loading articles: %@", error.localizedDescription);
+            OALog(@"Error loading articles: %@", error.localizedDescription);
         } 
         else if (articles)
         {

--- a/Sources/Controllers/Map/Layers/OAGPXLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAGPXLayer.mm
@@ -36,6 +36,7 @@
 #import "OAConcurrentCollections.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "OsmAndSharedWrapper.h"
+#import "OALog.h"
 
 #include <OsmAndCore/LatLon.h>
 #include <OsmAndCore/Map/VectorLineBuilder.h>
@@ -534,7 +535,7 @@ static const CGFloat kTemperatureToHeightOffset = 100.0;
                             }
                             else
                             {
-                                NSLog(@"Track not found or index is out of bounds");
+                                OALog(@"Track not found or index is out of bounds");
                             }
                         }
                         segStartIndex += seg.points.count;

--- a/Sources/Controllers/Map/Layers/OAPreviewRouteLineLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAPreviewRouteLineLayer.mm
@@ -25,6 +25,7 @@
 #import "OAAppData.h"
 #import "OAApplicationMode.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Map/VectorLineBuilder.h>
 #include <OsmAndCore/Map/MapMarker.h>
@@ -585,7 +586,7 @@
         BOOL success = [self fillRouteInfoAttributeArrays:points distances:distances angles:angles colors:colors];
         if (!success)
         {
-            NSLog(@"Failed to draw attribute coloring for appearance");
+            OALog(@"Failed to draw attribute coloring for appearance");
             _colorizationScheme = COLORIZATION_NONE;
         }
     }

--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -2319,7 +2319,7 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
 
             _obfMapObjectsProvider.reset(new OsmAnd::ObfMapObjectsProvider(_app.resourcesManager->obfsCollection));
 
-            NSLog(@"%@", [OAUtilities currentLang]);
+            OALog(@"%@", [OAUtilities currentLang]);
             
             OsmAnd::MapPresentationEnvironment::LanguagePreference langPreferences = OsmAnd::MapPresentationEnvironment::LanguagePreference::NativeOnly;
             
@@ -2478,7 +2478,7 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
             
             _obfMapObjectsProvider.reset(new OsmAnd::ObfMapObjectsProvider(_app.resourcesManager->obfsCollection));
             
-            NSLog(@"%@", [OAUtilities currentLang]);
+            OALog(@"%@", [OAUtilities currentLang]);
             
             OsmAnd::MapPresentationEnvironment::LanguagePreference langPreferences = OsmAnd::MapPresentationEnvironment::LanguagePreference::NativeOnly;
             
@@ -3573,9 +3573,9 @@ static const NSInteger kReplaceLocalNamesMaxZoom = 6;
             gpxFile.author = [OAAppVersion getFullVersionWithAppName];
             OASKException *exception = [OASGpxUtilities.shared writeGpxFileFile:file gpxFile:gpxFile];
             if (!exception) {
-                NSLog(@"writeGpxFileFile is true");
+                OALog(@"writeGpxFileFile is true");
             } else {
-                NSLog(@"writeGpxFileFile is false");
+                OALog(@"writeGpxFileFile is false");
             }
 
             return YES;

--- a/Sources/Controllers/Map/Widgets/OABaseWidgetView.m
+++ b/Sources/Controllers/Map/Widgets/OABaseWidgetView.m
@@ -10,6 +10,7 @@
 #import "OAMapInfoController.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 @implementation OABaseWidgetView
 {
@@ -186,7 +187,7 @@
 
 - (void)updateSimpleLayout
 {
-    NSLog(@"call base updateSimpleLayout");
+    OALog(@"call base updateSimpleLayout");
 }
 
 - (void)showBottomSeparator:(BOOL)show

--- a/Sources/Controllers/Map/Widgets/OADestinationsLineWidget.mm
+++ b/Sources/Controllers/Map/Widgets/OADestinationsLineWidget.mm
@@ -20,6 +20,7 @@
 #import "OAMapLayers.h"
 #import "OAColors.h"
 #import "OAOsmAndFormatter.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Map/MapMarkerBuilder.h>
 
@@ -297,7 +298,7 @@
                 }
                 else
                 {
-                    NSLog(@"Faliled to create OADestinationsLineWidget image for colorName: %@", colorName);
+                    OALog(@"Faliled to create OADestinationsLineWidget image for colorName: %@", colorName);
                 }
             }
             CGContextRestoreGState(ctx);

--- a/Sources/Controllers/MyPlaces/TracksViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksViewController.swift
@@ -1286,7 +1286,7 @@ final class TracksViewController: OACompoundViewController, UITableViewDelegate,
                     updateAllFoldersVCData(forceLoad: true)
                 }
             } else {
-                NSLog("renameFolder -> parentFile is empty")
+                OALog("renameFolder -> parentFile is empty")
             }
         } else {
             showErrorAlert(localizedString("folder_already_exsists"))

--- a/Sources/Controllers/OsmEditing/OAOpeningHoursSelectionViewController.mm
+++ b/Sources/Controllers/OsmEditing/OAOpeningHoursSelectionViewController.mm
@@ -17,6 +17,7 @@
 #import "OAOSMSettings.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 #include <ctime>
 
@@ -275,7 +276,7 @@ static const NSInteger timeSectionIndex = 1;
 -(void)updateRuleTime
 {
     const auto rule = std::dynamic_pointer_cast<OpeningHoursParser::BasicOpeningHourRule>(_currentRule);
-    NSLog(@"startMinutes: %d", [self dateToMinutes:_startDate]);
+    OALog(@"startMinutes: %d", [self dateToMinutes:_startDate]);
     rule->setStartTime([self dateToMinutes:_startDate]);
     rule->setEndTime([self dateToMinutes:_endDate]);
 }

--- a/Sources/Controllers/OsmEditing/OAOsmEditingViewController.mm
+++ b/Sources/Controllers/OsmEditing/OAOsmEditingViewController.mm
@@ -32,6 +32,7 @@
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
 #import "OAPluginsHelper.h"
+#import "OALog.h"
 
 #import <AFNetworking/AFNetworkReachabilityManager.h>
 
@@ -120,7 +121,7 @@ typedef NS_ENUM(NSInteger, EditingTab)
 {
     if (!info && CREATE != action && [util isKindOfClass:OAOpenStreetMapRemoteUtil.class])
     {
-        NSLog(@"Entity info was not loaded");
+        OALog(@"Entity info was not loaded");
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -2208,7 +2208,7 @@ typedef enum
         }
         else
         {
-            NSLog(@"targetGoToGPX wrong cast");
+            OALog(@"targetGoToGPX wrong cast");
         }
     }
     else
@@ -4072,7 +4072,7 @@ typedef enum
 
 - (void) updateProgress:(int)progress
 {
-    //NSLog(@"Route calculation in progress: %d", progress);
+    //OALog(@"Route calculation in progress: %d", progress);
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.hudViewController onRoutingProgressChanged:progress];
     });
@@ -4080,7 +4080,7 @@ typedef enum
 
 - (void) finish
 {
-    NSLog(@"Route calculation finished");
+    OALog(@"Route calculation finished");
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.hudViewController onRoutingProgressFinished];
     });

--- a/Sources/Controllers/Resources/OADonationSettingsViewController.mm
+++ b/Sources/Controllers/Resources/OADonationSettingsViewController.mm
@@ -19,6 +19,7 @@
 #import "OAWorldRegion.h"
 #import "OAIAPHelper.h"
 #import "OANetworkUtilities.h"
+#import "OALog.h"
 #import <MBProgressHUD.h>
 
 #include <OsmAndCore/WorldRegions.h>
@@ -564,7 +565,7 @@
                                 if (![map objectForKey:@"error"])
                                 {
                                     NSString *userId = [map objectForKey:@"userid"];
-                                    NSLog(@"UserId = %@", userId);
+                                    OALog(@"UserId = %@", userId);
                                     if (userId.length > 0)
                                     {
                                         [_settings.billingUserId set:userId];

--- a/Sources/Controllers/RouteInfoMenu/OARouteInfoView.mm
+++ b/Sources/Controllers/RouteInfoMenu/OARouteInfoView.mm
@@ -68,6 +68,7 @@
 #import "OARequiredMapsResourceViewController.h"
 #import "OAResourcesUIHelper.h"
 #import "OsmAndSharedWrapper.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Map/FavoriteLocationsPresenter.h>
 
@@ -1997,7 +1998,7 @@ typedef NS_ENUM(NSInteger, EOARouteInfoMenuState)
     }
     else
     {
-        NSLog(@"showRequiredMapsResourceViewController _missingMaps or _mapsToUpdate is empty");
+        OALog(@"showRequiredMapsResourceViewController _missingMaps or _mapsToUpdate is empty");
     }
 }
 

--- a/Sources/Controllers/RoutePlanning/OARoutePlanningHudViewController.mm
+++ b/Sources/Controllers/RoutePlanning/OARoutePlanningHudViewController.mm
@@ -58,6 +58,7 @@
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
 #import "OsmAndSharedWrapper.h"
+#import "OALog.h"
 
 #define kHeaderSectionHeigh 60.0
 
@@ -835,12 +836,12 @@ typedef NS_ENUM(NSInteger, EOAHudMode) {
         }
         else
         {
-            NSLog(@"An error occured while saving route planning track for navigation");
+            OALog(@"An error occured while saving route planning track for navigation");
         }
     }
     else
     {
-        NSLog(@"An error occured while saving route planning track for navigation: no route to save");
+        OALog(@"An error occured while saving route planning track for navigation: no route to save");
     }
 }
 
@@ -1748,7 +1749,7 @@ typedef NS_ENUM(NSInteger, EOAHudMode) {
     if (_editingContext.getPointsCount > 0)
         [self showAddToTrackDialog];
 //    else
-//        NSLog(@"No points to add");
+//        OALog(@"No points to add");
 //        Toast.makeText(mapActivity, getString(R.string.none_point_error), Toast.LENGTH_SHORT).show();
 }
 
@@ -1850,7 +1851,7 @@ typedef NS_ENUM(NSInteger, EOAHudMode) {
     }
     else
     {
-        NSLog(@"Can't reverse one point");
+        OALog(@"Can't reverse one point");
     }
 }
 

--- a/Sources/Controllers/Settings/ImportExport/OAImportDuplicatesViewController.mm
+++ b/Sources/Controllers/Settings/ImportExport/OAImportDuplicatesViewController.mm
@@ -35,6 +35,7 @@
 #import "OAPOIHelper.h"
 #import "OASizes.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 @interface OAHeaderType : NSObject
 
@@ -232,7 +233,7 @@
                         } catch (NSException *e)
                         {
                             routingProfile = [routingProfileValue capitalizedString];
-                            NSLog(@"Error trying to get routing resource for %@ \n %@ %@", routingProfileValue, e.name, e.reason);
+                            OALog(@"Error trying to get routing resource for %@ \n %@ %@", routingProfileValue, e.name, e.reason);
                         }
                     }
                     if (routingProfile.length == 0)

--- a/Sources/Controllers/Settings/OSMEditing/OAMappersViewController.m
+++ b/Sources/Controllers/Settings/OSMEditing/OAMappersViewController.m
@@ -16,6 +16,7 @@
 #import "Localization.h"
 #import <SafariServices/SafariServices.h>
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 #define USER_CHANGES_URL @"https://osmand.net/changesets/user-changes"
 #define CONTRIBUTIONS_URL @"https://www.openstreetmap.org/user/"
@@ -381,7 +382,7 @@
                 }
                 @catch (NSException *e)
                 {
-                    NSLog(e.reason);
+                    OALog(e.reason);
                 }
             }
         }

--- a/Sources/Controllers/Settings/OSMEditing/OAOsmUploadGPXVisibilityViewConroller.m
+++ b/Sources/Controllers/Settings/OSMEditing/OAOsmUploadGPXVisibilityViewConroller.m
@@ -14,6 +14,7 @@
 #import "Localization.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 @implementation OAOsmUploadGPXVisibilityViewConroller
 {
@@ -173,7 +174,7 @@
 
 - (void) onVisibilityChanged:(EOAOsmUploadGPXVisibility)visibility
 {
-    NSLog(@"onVisibilityChanged");
+    OALog(@"onVisibilityChanged");
     _selectedVisibility = visibility;
     [self generateData];
     [self.tableView reloadData];

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
@@ -70,6 +70,7 @@
 #import "OsmAnd_Maps-Swift.h"
 #import <DGCharts/DGCharts-Swift.h>
 #import "OsmAndSharedWrapper.h"
+#import "OALog.h"
 
 #define kGpxDescriptionImageHeight 149
 #define kOverviewTabIndex @0
@@ -1586,7 +1587,7 @@
         gpx = [gpxDb addGPXFileToDBIfNeeded:path];
         if (!gpx)
         {
-            NSLog(@"[ERROR] saveNetworkRoute");
+            OALog(@"[ERROR] saveNetworkRoute");
             return;
         }
         OASGpxTrackAnalysis *analysis = [gpx getAnalysis];

--- a/Sources/Controllers/TargetMenu/Routing/OARouteDetailsGraphViewController.mm
+++ b/Sources/Controllers/TargetMenu/Routing/OARouteDetailsGraphViewController.mm
@@ -29,6 +29,7 @@
 #import "OARouteStatisticsModeCell.h"
 #import "OAStatisticsSelectionBottomSheetViewController.h"
 #import "OAGPXDatabase.h"
+#import "OALog.h"
 #import "GeneratedAssetSymbols.h"
 #import <DGCharts/DGCharts-Swift.h>
 
@@ -426,7 +427,7 @@
                 }
                 else
                 {
-                    NSLog(@"trackItem is empty");
+                    OALog(@"trackItem is empty");
                 }
             }];
         }

--- a/Sources/Controllers/TravelGuides/data/OATravelGuidesHelper.mm
+++ b/Sources/Controllers/TravelGuides/data/OATravelGuidesHelper.mm
@@ -26,6 +26,7 @@
 #import "OAMapLayers.h"
 #import "OARootViewController.h"
 #import "OAMapPanelViewController.h"
+#import "OALog.h"
 #import "OAMapViewController.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "OAAppVersion.h"
@@ -232,7 +233,7 @@ static const NSArray<NSString *> *wikivoyageOSMTags = @[@"wikidata", @"wikipedia
             }
         }
     } else {
-        NSLog(@"[ERROR] -> save gpx");
+        OALog(@"[ERROR] -> save gpx");
     }
     
     return filePath;

--- a/Sources/Controllers/TravelGuides/data/OATravelLocalDataDbHelper.mm
+++ b/Sources/Controllers/TravelGuides/data/OATravelLocalDataDbHelper.mm
@@ -11,6 +11,7 @@
 #import "OsmAnd_Maps-Swift.h"
 #import <sqlite3.h>
 #import "OsmAndSharedWrapper.h"
+#import "OALog.h"
 
 #include <OsmAndCore/ArchiveReader.h>
 #include <OsmAndCore/ArchiveWriter.h>
@@ -85,7 +86,7 @@
         NSError *error;
         [NSFileManager.defaultManager copyItemAtPath:gpxPath toPath:tmpFilePath error:&error];
         if (error)
-            NSLog(@"Error copying file: %@ to %@ - %@", gpxPath, tmpFilePath, [error localizedDescription]);
+            OALog(@"Error copying file: %@ to %@ - %@", gpxPath, tmpFilePath, [error localizedDescription]);
     }
     
     OsmAnd::ArchiveWriter archiveWriter;
@@ -317,14 +318,14 @@
             char *errMsg;
             if (sqlite3_exec(_dbInstance, [[self.class HISTORY_TABLE_CREATE] UTF8String], NULL, NULL, &errMsg) != SQLITE_OK)
             {
-                NSLog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
+                OALog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
             }
             if (errMsg != NULL) sqlite3_free(errMsg);
             
             //create empty Bookmarks table
             if (sqlite3_exec(_dbInstance, [[self.class BOOKMARKS_TABLE_CREATE] UTF8String], NULL, NULL, &errMsg) != SQLITE_OK)
             {
-                NSLog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
+                OALog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
             }
             if (errMsg != NULL) sqlite3_free(errMsg);
             
@@ -332,7 +333,7 @@
             const char *sql_stmt = [[NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS %@ (%@ integer)", VERSION_TABLE_NAME, VERSION_COL] UTF8String];
             if (sqlite3_exec(_dbInstance, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
             {
-                NSLog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
+                OALog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
             }
             if (errMsg != NULL) sqlite3_free(errMsg);
             
@@ -356,7 +357,7 @@
                 char *errMsg;
                 if (sqlite3_exec(_dbInstance, [[NSString stringWithFormat:@"ALTER TABLE %@ ADD %@ TEXT", HISTORY_TABLE_NAME, HISTORY_COL_IMAGE_TITLE] UTF8String], NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to migrate to 9 version Travel Guides table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
+                    OALog(@"Failed to migrate to 9 version Travel Guides table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
                     isError = YES;
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);

--- a/Sources/Data/OAMapStyleSettings.mm
+++ b/Sources/Data/OAMapStyleSettings.mm
@@ -13,6 +13,7 @@
 #import "OAMapSource.h"
 #import "OAAppData.h"
 #import "OAObservable.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Utilities.h>
 #include <OsmAndCore/Map/IMapStylesCollection.h>
@@ -155,7 +156,7 @@
     {
         NSString *name = resolvedMapStyle->getStringById(p->getNameId()).toNSString();
 
-        //NSLog(@"name = %@ title = %@ decs = %@ category = %@", name, p->getTitle().toNSString(), p->getDescription().toNSString(), p->getCategory().toNSString());
+        //OALog(@"name = %@ title = %@ decs = %@ category = %@", name, p->getTitle().toNSString(), p->getDescription().toNSString(), p->getCategory().toNSString());
 
         if ([name isEqualToString:@"appMode"] ||
             [name isEqualToString:@"baseAppMode"] ||

--- a/Sources/DownloadsManager/OADownloadTask_AFURLSessionManager.m
+++ b/Sources/DownloadsManager/OADownloadTask_AFURLSessionManager.m
@@ -169,7 +169,7 @@
             andStoredAt:(NSURL*)targetPath
               withError:(NSError*)error
 {
-    //NSLog(@"onCompletedWith response=%@ targetPath=%@ error=%d (%@)", response, targetPath, error.code, error.description);
+    //OALog(@"onCompletedWith response=%@ targetPath=%@ error=%d (%@)", response, targetPath, error.code, error.description);
 
     [_owner notifyTaskDeactivated:self];
     

--- a/Sources/DownloadsManager/OADownloadsManager.m
+++ b/Sources/DownloadsManager/OADownloadsManager.m
@@ -145,7 +145,7 @@
 
 - (void)cancelDownloadTasks
 {
-    NSLog(@"Cancel all download tasks");
+    OALog(@"Cancel all download tasks");
     @synchronized(_tasksSync)
     {
         [_tasks enumerateKeysAndObjectsUsingBlock:^(id key_, id obj_, BOOL *stop) {
@@ -158,7 +158,7 @@
 
 - (void)pauseDownloadTasks
 {
-    NSLog(@"Suspend all download tasks");
+    OALog(@"Suspend all download tasks");
     @synchronized(_tasksSync)
     {
         [_tasks enumerateKeysAndObjectsUsingBlock:^(id key_, id obj_, BOOL *stop) {
@@ -490,13 +490,13 @@
         // Start background task if not started yet
         if (_backgroundDownloadTask == UIBackgroundTaskInvalid)
         {
-            NSLog(@"Begin background download task");
+            OALog(@"Begin background download task");
             _backgroundDownloadTask = [[UIApplication sharedApplication] beginBackgroundTaskWithName:@"DownloadManagerBackgroundTask" expirationHandler:^{
-                NSLog(@"Background download expired");
+                OALog(@"Background download expired");
                 [self pauseDownloadTasks];
                 if (_backgroundDownloadTask != UIBackgroundTaskInvalid)
                 {
-                    NSLog(@"End background download task (time expired)");
+                    OALog(@"End background download task (time expired)");
                     [[UIApplication sharedApplication] endBackgroundTask:_backgroundDownloadTask];
                     _backgroundDownloadTask = UIBackgroundTaskInvalid;
 
@@ -561,7 +561,7 @@
         // When the all task are done, end the background task
         if (_tasks.count == 0 && _backgroundDownloadTask != UIBackgroundTaskInvalid)
         {
-            NSLog(@"End background download task (all downloads complete");
+            OALog(@"End background download task (all downloads complete");
             [[UIApplication sharedApplication] endBackgroundTask:_backgroundDownloadTask];
             _backgroundDownloadTask = UIBackgroundTaskInvalid;
         }

--- a/Sources/FirstUsage/OAFirstUsageWizardController.mm
+++ b/Sources/FirstUsage/OAFirstUsageWizardController.mm
@@ -30,6 +30,7 @@
 #import "OAUtilities.h"
 #import "OAAppVersion.h"
 #import "OAResourcesUISwiftHelper.h"
+#import "OALog.h"
 
 #include <OsmAndCore.h>
 #include <OsmAndCore/Utilities.h>
@@ -405,7 +406,7 @@ typedef enum
                 if (!isDownloading)
                     [self configureSearchLocationState];
                 else
-                    NSLog(@"resource: %@ is downloading", resourceId);
+                    OALog(@"resource: %@ is downloading", resourceId);
             }
             else
             {

--- a/Sources/GPX/OAGPXDatabase.mm
+++ b/Sources/GPX/OAGPXDatabase.mm
@@ -19,6 +19,7 @@
 #import "OAAppData.h"
 #import "OASharedUtil.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 #define kDbName @"gpx.db"
 #define GPX_EXT @"gpx"
@@ -274,26 +275,26 @@
 
             BOOL success = [[OASGpxDbHelper shared] addItem:dataItem];
             NSString *status = success ? @"SUCCESS" : @"ERROR";
-            NSLog(@"[%@] added to db | %@", status, dataItem.file.path);
+            OALog(@"[%@] added to db | %@", status, dataItem.file.path);
             // app.getSmartFolderHelper().addTrackItemToSmartFolder(new TrackItem(SharedUtil.kFile(file)));
 
             return dataItem;
         }
         else
         {
-            NSLog(@"[ERROR] loadGpxFileFile: %@ | %@", file.path, gpxFile.error.message);
+            OALog(@"[ERROR] loadGpxFileFile: %@ | %@", file.path, gpxFile.error.message);
         }
     }
     else
     {
-        NSLog(@"[INFO] file: %@ | already exist", file.path);
+        OALog(@"[INFO] file: %@ | already exist", file.path);
     }
     return nil;
 }
 
 - (void)save
 {
-    NSLog(@"[WARNING] is empty save");
+    OALog(@"[WARNING] is empty save");
 }
 
 @end

--- a/Sources/GPX/OAXmlStreamWriter.mm
+++ b/Sources/GPX/OAXmlStreamWriter.mm
@@ -7,6 +7,7 @@
 //
 
 #import "OAXmlStreamWriter.h"
+#import "OALog.h"
 #include <QFile>
 #include <QBuffer>
 #include <QString>
@@ -210,7 +211,7 @@ NSString * const OAXmlStreamWriterErrorDomain = @"OAXmlStreamWriterError";
                                maxLength:length - totalBytesWritten error:nil];
             if (bytesWritten == -1)
             {
-                NSLog(@"Error writing to output stream");
+                OALog(@"Error writing to output stream");
                 break;
             }
             totalBytesWritten += bytesWritten;
@@ -229,7 +230,7 @@ NSString * const OAXmlStreamWriterErrorDomain = @"OAXmlStreamWriterError";
         }
         else
         {
-            NSLog(@"Could not write all data to output stream");
+            OALog(@"Could not write all data to output stream");
             return NO;
         }
     }

--- a/Sources/Helpers/MissingMapsCalculator/MissingMapsCalculator.mm
+++ b/Sources/Helpers/MissingMapsCalculator/MissingMapsCalculator.mm
@@ -12,6 +12,7 @@
 #import "OARoutingHelper.h"
 #import "OARouteProvider.h"
 #import "OAWorldRegion.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Utilities.h>
 #include <binaryRead.h>
@@ -225,7 +226,7 @@ static const double DISTANCE_SKIP = 10000;
     self.mapsToUpdate = [self convert:[mapsToUpdate copy]];
     self.potentiallyUsedMaps = [self convert:[usedMaps copy]];
     
-    NSLog(@"Check missing maps %lu points %.2f sec", [pointsToCheck count], ([NSDate timeIntervalSinceReferenceDate] - tm));
+    OALog(@"Check missing maps %lu points %.2f sec", [pointsToCheck count], ([NSDate timeIntervalSinceReferenceDate] - tm));
     
     return YES;
 }

--- a/Sources/Helpers/OADayNightHelper.m
+++ b/Sources/Helpers/OADayNightHelper.m
@@ -13,6 +13,7 @@
 #import "SunriseSunset.h"
 #import "OALocationServices.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 @implementation OADayNightHelper
 {
@@ -99,7 +100,7 @@
     if (_lastNightMode != nightMode)
     {
         _lastNightMode = nightMode;
-        NSLog(@"Sunrise/sunset setting to day: %@", nightMode ? @"NO" : @"YES");
+        OALog(@"Sunrise/sunset setting to day: %@", nightMode ? @"NO" : @"YES");
         if (!_firstCall)
             [[[OsmAndApp instance] dayNightModeObservable] notifyEvent];
     }

--- a/Sources/Helpers/OAFavoritesHelper.mm
+++ b/Sources/Helpers/OAFavoritesHelper.mm
@@ -25,6 +25,7 @@
 #import "OAFavoritesSettingsItem.h"
 #import "OAPluginsHelper.h"
 #import "OsmAndSharedWrapper.h"
+#import "OALog.h"
 
 #import <EventKit/EventKit.h>
 #import "OsmAnd_Maps-Swift.h"
@@ -64,7 +65,7 @@ static NSOperationQueue *_favQueue;
         NSError *error = nil;
         [[NSFileManager defaultManager] moveItemAtPath:oldfFavoritesFilename toPath:favoritesLegacyFilename error:&error];
         if (error)
-            NSLog(@"Error moving file: %@ to %@ - %@", oldfFavoritesFilename, favoritesLegacyFilename, [error localizedDescription]);
+            OALog(@"Error moving file: %@ to %@ - %@", oldfFavoritesFilename, favoritesLegacyFilename, [error localizedDescription]);
     }
 
     // Move legacy favorites backup folder to new location
@@ -74,7 +75,7 @@ static NSOperationQueue *_favQueue;
         NSError *error = nil;
         [[NSFileManager defaultManager] moveItemAtPath:oldFavoritesBackupPath toPath:app.favoritesBackupPath error:&error];
         if (error)
-            NSLog(@"Error moving dir: %@ to %@ - %@", oldFavoritesBackupPath, app.favoritesBackupPath, [error localizedDescription]);
+            OALog(@"Error moving dir: %@ to %@ - %@", oldFavoritesBackupPath, app.favoritesBackupPath, [error localizedDescription]);
     }
 
     BOOL legacyFavoritesExists = [[NSFileManager defaultManager] fileExistsAtPath:favoritesLegacyFilename];
@@ -708,7 +709,7 @@ static NSOperationQueue *_favQueue;
         archiveWriter.createArchive(&ok, backupFile, filesList, basePath);
     }
     if (!ok)
-        NSLog(@"ERROR: Favorites backup failed");
+        OALog(@"ERROR: Favorites backup failed");
 
     [self.class clearOldBackups:[self.class getBackupFiles] maxCount:BACKUP_MAX_COUNT];
 }
@@ -1080,7 +1081,7 @@ static NSOperationQueue *_favQueue;
             EKEvent *event = [eventStore eventWithIdentifier:plugin.getEventIdentifier];
             NSError *error;
             if (![eventStore removeEvent:event span:EKSpanFutureEvents error:&error])
-                NSLog(@"%@", [error localizedDescription]);
+                OALog(@"%@", [error localizedDescription]);
             else
                 [plugin setEventIdentifier:nil];
         }

--- a/Sources/Helpers/OAGPXImportUIHelper.mm
+++ b/Sources/Helpers/OAGPXImportUIHelper.mm
@@ -14,6 +14,7 @@
 #import "OAKml2Gpx.h"
 #import "OAIndexConstants.h"
 #import "Localization.h"
+#import "OALog.h"
 #import "OAGPXAppearanceCollection.h"
 #import <MBProgressHUD.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
@@ -264,7 +265,7 @@ static UIViewController *parentController;
             {
                 [gpxStr writeToFile:finalFilePath atomically:YES encoding:NSUTF8StringEncoding error:&err];
                 if (err)
-                    NSLog(@"Error creating gpx file");
+                    OALog(@"Error creating gpx file");
 
                 [OAUtilities denyAccessToFile:_importUrl.path removeFromInbox:YES];
 
@@ -433,7 +434,7 @@ static UIViewController *parentController;
         [[OAGPXDatabase sharedDb] removeGpxItem:item withLocalRemove:YES];
     } else
     {
-        NSLog(@"[OAGPXImportUIHelper] -> [ERROR] -> removeFromDB");
+        OALog(@"[OAGPXImportUIHelper] -> [ERROR] -> removeFromDB");
     }
 }
 

--- a/Sources/Helpers/OAGPXUIHelper.mm
+++ b/Sources/Helpers/OAGPXUIHelper.mm
@@ -26,6 +26,7 @@
 #import "OASavingTrackHelper.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "OAAppVersion.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Utilities.h>
 
@@ -721,7 +722,7 @@ hostViewControllerDelegate:(id)hostViewControllerDelegate
         [[NSFileManager defaultManager] copyItemAtPath:sourcePath toPath:destinationPath error:&err];
         if (err)
         {
-            NSLog(@"copyItemAtPath: %@ toPath: %@ ", sourcePath, destinationPath);
+            OALog(@"copyItemAtPath: %@ toPath: %@ ", sourcePath, destinationPath);
             return;
         }
         
@@ -791,13 +792,13 @@ updatedTrackItemСallback:(void (^_Nullable)(OASTrackItem *updatedTrackItem))upd
             BOOL renameToFileResult = [gpx.file renameToToFile:newFile];
             if (!renameToFileResult)
             {
-                NSLog(@"[ERROR] -> OAGPXUIHelper -> renameToFileResult is fail");
+                OALog(@"[ERROR] -> OAGPXUIHelper -> renameToFileResult is fail");
                 return;
             }
             BOOL renameCurrentFileResult = [[OASGpxDbHelper shared] renameCurrentFile:gpx.file newFile:newFile];
             if (!renameCurrentFileResult)
             {
-                NSLog(@"[ERROR] -> OAGPXUIHelper -> renameCurrentFileResult is fail");
+                OALog(@"[ERROR] -> OAGPXUIHelper -> renameCurrentFileResult is fail");
                 return;
             }
             
@@ -852,9 +853,9 @@ updatedTrackItemСallback:(void (^_Nullable)(OASTrackItem *updatedTrackItem))upd
                 OASKFile *file = [[OASKFile alloc] initWithFilePath:newPath];
                 OASKException *exception = [OASGpxUtilities.shared writeGpxFileFile:file gpxFile:doc];
                 if (!exception) {
-                    NSLog(@"writeGpxFileFile result is true");
+                    OALog(@"writeGpxFileFile result is true");
                 } else {
-                    NSLog(@"writeGpxFileFile result is false");
+                    OALog(@"writeGpxFileFile result is false");
                 }
             }
             [OASelectedGPXHelper renameVisibleTrack:oldFilePath newPath:newFilePath];

--- a/Sources/Helpers/OAOcbfHelper.m
+++ b/Sources/Helpers/OAOcbfHelper.m
@@ -28,7 +28,7 @@
         NSError *error = nil;
         [fileManager copyItemAtPath:cachedPathBundle toPath:cachedPathLib error:&error];
         if (error)
-            NSLog(@"Error copying file: %@ to %@ - %@", cachedPathBundle, cachedPathLib, [error localizedDescription]);
+            OALog(@"Error copying file: %@ to %@ - %@", cachedPathBundle, cachedPathLib, [error localizedDescription]);
     }
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
@@ -63,9 +63,9 @@
     }
     @catch (NSException * e)
     {
-        NSLog(@"Error parsing last modified date: %@ - %@", lastModifiedString, [e description]);
+        OALog(@"Error parsing last modified date: %@ - %@", lastModifiedString, [e description]);
     }
-    NSLog(@"lastModifiedServer: %@", lastModifiedServer);
+    OALog(@"lastModifiedServer: %@", lastModifiedServer);
     
     NSDate *lastModifiedLocal = nil;
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -74,7 +74,7 @@
         NSError *error = nil;
         NSDictionary *fileAttributes = [fileManager attributesOfItemAtPath:cachedPathLib error:&error];
         if (error)
-            NSLog(@"Error reading file attributes for: %@ - %@", cachedPathLib, [error localizedDescription]);
+            OALog(@"Error reading file attributes for: %@ - %@", cachedPathLib, [error localizedDescription]);
 
         lastModifiedLocal = [fileAttributes fileModificationDate];
         OALog(@"lastModifiedLocal : %@", lastModifiedLocal);
@@ -107,7 +107,7 @@
                     OALog(@"File modification date updated");
 
                 if (error)
-                    NSLog(@"Error setting file attributes for: %@ - %@", cachedPathLib, [error localizedDescription]);
+                    OALog(@"Error setting file attributes for: %@ - %@", cachedPathLib, [error localizedDescription]);
             }
         }
     }  
@@ -131,13 +131,13 @@
         NSError *error = nil;
         NSDictionary *fileAttributes = [fileManager attributesOfItemAtPath:cachedPathBundle error:&error];
         if (error)
-            NSLog(@"Error reading file attributes for: %@ - %@", cachedPathBundle, [error localizedDescription]);
+            OALog(@"Error reading file attributes for: %@ - %@", cachedPathBundle, [error localizedDescription]);
         
         lastModifiedBundle = [fileAttributes fileModificationDate];
 
         fileAttributes = [fileManager attributesOfItemAtPath:cachedPathLib error:&error];
         if (error)
-            NSLog(@"Error reading file attributes for: %@ - %@", cachedPathLib, [error localizedDescription]);
+            OALog(@"Error reading file attributes for: %@ - %@", cachedPathLib, [error localizedDescription]);
         
         lastModifiedLocal = [fileAttributes fileModificationDate];
 

--- a/Sources/Helpers/OAOperationLog.m
+++ b/Sources/Helpers/OAOperationLog.m
@@ -7,6 +7,7 @@
 //
 
 #import "OAOperationLog.h"
+#import "OALog.h"
 
 @implementation OAOperationLog
 {
@@ -92,14 +93,14 @@
 {
     if (_debug || forceLog)
     {
-        NSLog(@"%@", [NSString stringWithFormat:@"%@ %@", _operationName, message.length > 0 ? message : @""]);
+        OALog(@"%@", [NSString stringWithFormat:@"%@ %@", _operationName, message.length > 0 ? message : @""]);
     }
 }
 
 - (void) logImpl:(NSString *)message forceLog:(BOOL)forceLog
 {
     if (_debug || forceLog)
-        NSLog(@"%@", message);
+        OALog(@"%@", message);
 }
 
 @end

--- a/Sources/Helpers/OAOsmAndContextImpl.mm
+++ b/Sources/Helpers/OAOsmAndContextImpl.mm
@@ -13,6 +13,7 @@
 #import "OASelectedGpxHelper.h"
 #import "OAGPXUIHelper.h"
 #import "OAPOI.h"
+#import "OALog.h"
 
 static NSString * const kGpxRecDir = @"rec";
 static NSString * const kGpxImportDir = @"import";
@@ -177,10 +178,10 @@ static NSString * const kGpxImportDir = @"import";
         if (fileContents) {
             return fileContents;
         } else {
-            NSLog(@"Error reading file %@: %@", filePath, [error localizedDescription]);
+            OALog(@"Error reading file %@: %@", filePath, [error localizedDescription]);
         }
     } else {
-        NSLog(@"File %@ not found in the bundle", name);
+        OALog(@"File %@ not found in the bundle", name);
     }
     return nil;
 }

--- a/Sources/Helpers/OAResourcesInstaller.mm
+++ b/Sources/Helpers/OAResourcesInstaller.mm
@@ -163,7 +163,7 @@ NSString *const OAResourceInstallationFailedNotification = @"OAResourceInstallat
     if (!ok)
     {
         [NSFileManager.defaultManager removeItemAtPath:localPath error:nil];
-        NSLog(@"Failed to install custom obf from the archive");
+        OALog(@"Failed to install custom obf from the archive");
         failed = YES;
     }
     
@@ -180,7 +180,7 @@ NSString *const OAResourceInstallationFailedNotification = @"OAResourceInstallat
     if (!obfArchiveItem.isValid())
     {
         [NSFileManager.defaultManager removeItemAtPath:localPath error:nil];
-        NSLog(@"Custom obf in the archive is not valid");
+        OALog(@"Custom obf in the archive is not valid");
         failed = YES;
     }
     NSString *defaultPath = [OsmAndApp.instance.documentsPath stringByAppendingPathComponent:fileName].stringByDeletingPathExtension;
@@ -192,7 +192,7 @@ NSString *const OAResourceInstallationFailedNotification = @"OAResourceInstallat
     if (!archive.extractItemToFile(obfArchiveItem.name, pathToFile))
     {
         [NSFileManager.defaultManager removeItemAtPath:localPath error:nil];
-        NSLog(@"Failed to extract custom obf from the archive");
+        OALog(@"Failed to extract custom obf from the archive");
         failed = YES;
     }
     else if (hidden && [NSFileManager.defaultManager fileExistsAtPath:defaultPath])
@@ -230,7 +230,7 @@ NSString *const OAResourceInstallationFailedNotification = @"OAResourceInstallat
         if (!ok)
         {
             [NSFileManager.defaultManager removeItemAtPath:localPath error:nil];
-            NSLog(@"Failed to install custom resource from the archive");
+            OALog(@"Failed to install custom resource from the archive");
             return YES;
         }
         for (const auto& archiveItem : constOf(archiveItems))
@@ -244,7 +244,7 @@ NSString *const OAResourceInstallationFailedNotification = @"OAResourceInstallat
         if (!targetArchiveItem.isValid())
         {
             [NSFileManager.defaultManager removeItemAtPath:localPath error:nil];
-            NSLog(@"Custom resource file in the archive is not valid");
+            OALog(@"Custom resource file in the archive is not valid");
             return YES;
         }
         unzippedFilePath = [localPath stringByDeletingPathExtension];
@@ -253,7 +253,7 @@ NSString *const OAResourceInstallationFailedNotification = @"OAResourceInstallat
         if (!archive.extractItemToFile(targetArchiveItem.name, pathToFile))
         {
             [NSFileManager.defaultManager removeItemAtPath:localPath error:nil];
-            NSLog(@"Failed to extract custom resource from the archive");
+            OALog(@"Failed to extract custom resource from the archive");
             return YES;
         }
         resourceId = [resourceId stringByDeletingPathExtension];
@@ -367,7 +367,7 @@ NSString *const OAResourceInstallationFailedNotification = @"OAResourceInstallat
                                     }
                                 }
 
-                                //NSLog(@"found name=%@ bbox=(%f,%f)(%f,%f)", foundRegion.name, foundRegion.bboxTopLeft.latitude, foundRegion.bboxTopLeft.longitude, foundRegion.bboxBottomRight.latitude, foundRegion.bboxBottomRight.longitude);
+                                //OALog(@"found name=%@ bbox=(%f,%f)(%f,%f)", foundRegion.name, foundRegion.bboxTopLeft.latitude, foundRegion.bboxTopLeft.longitude, foundRegion.bboxBottomRight.latitude, foundRegion.bboxBottomRight.longitude);
 
                                 if (foundRegion && foundRegion.superregion && resource->type == OsmAnd::ResourcesManager::ResourceType::MapRegion)
                                 {

--- a/Sources/Helpers/OAResourcesUIHelper.mm
+++ b/Sources/Helpers/OAResourcesUIHelper.mm
@@ -920,7 +920,7 @@ typedef OsmAnd::IncrementalChangesManager::IncrementalUpdate IncrementalUpdate;
     NSURL *url = [NSURL URLWithString:urlString];
     NSURLRequest* request = [NSURLRequest requestWithURL:url];
 
-    NSLog(@"%@", url);
+    OALog(@"%@", url);
 
     id<OADownloadTask> task = [[OsmAndApp instance].downloadsManager downloadTaskWithRequest:request
                                                                                       andKey:[@"resource:" stringByAppendingString:resourceId]
@@ -1337,7 +1337,7 @@ includeHidden:(BOOL)includeHidden
             NSURL *url = [NSURL URLWithString:item.downloadUrl];
             NSURLRequest *request = [NSURLRequest requestWithURL:url];
 
-            NSLog(@"%@", url);
+            OALog(@"%@", url);
 
             OsmAndAppInstance app = [OsmAndApp instance];
             id<OADownloadTask> task = [app.downloadsManager downloadTaskWithRequest:request
@@ -1630,7 +1630,7 @@ includeHidden:(BOOL)includeHidden
         NSURL *url = [NSURL URLWithString:urlString];
         NSURLRequest *request = [NSURLRequest requestWithURL:url];
 
-        NSLog(@"%@", url);
+        OALog(@"%@", url);
         NSString* name = [self.class titleOfResourceType:item.resourceType
                                                 inRegion:item.worldRegion
                                           withRegionName:YES
@@ -1666,7 +1666,7 @@ includeHidden:(BOOL)includeHidden
         NSURL *url = [NSURL URLWithString:urlString];
         NSURLRequest *request = [NSURLRequest requestWithURL:url];
 
-        NSLog(@"%@", url);
+        OALog(@"%@", url);
 
         NSString* name = [self.class titleOfResource:item.resource
                                             inRegion:item.worldRegion
@@ -1734,7 +1734,7 @@ includeHidden:(BOOL)includeHidden
     NSURL *url = [NSURL URLWithString:urlString];
     NSURLRequest* request = [NSURLRequest requestWithURL:url];
 
-    NSLog(@"%@", url);
+    OALog(@"%@", url);
 
     OsmAndAppInstance app = [OsmAndApp instance];
     id<OADownloadTask> task = [app.downloadsManager downloadTaskWithRequest:request
@@ -2350,7 +2350,7 @@ includeHidden:(BOOL)includeHidden
 + (void)onlineCalculateRequestWithRouteCalculationResult:(OARouteCalculationResult *)routeCalculationResult
                                               completion:(LocationArrayCallback)completion
 {
-    NSLog(@"onlineCalculateRequestStartPoint start");
+    OALog(@"onlineCalculateRequestStartPoint start");
     NSURLSession *session = [NSURLSession sharedSession];
     
     NSString *routeUrlString = @"https://maptile.osmand.net/routing/route";
@@ -2373,10 +2373,10 @@ includeHidden:(BOOL)includeHidden
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        NSLog(@"onlineCalculateRequestStartPoint finish");
+        OALog(@"onlineCalculateRequestStartPoint finish");
         if (error)
         {
-            NSLog(@"Error: %@", error);
+            OALog(@"Error: %@", error);
             if (completion)
             {
                 completion(nil, [NSError errorWithDomain:@"OnlineCalculateRequestErrorDomain" code:1 userInfo:@{NSLocalizedDescriptionKey: error.localizedDescription}]);
@@ -2393,7 +2393,7 @@ includeHidden:(BOOL)includeHidden
                     {
                         @try
                         {
-                            NSLog(@"Response: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                            OALog(@"Response: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
                             NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
                             NSArray *features = json[@"features"];
                             NSMutableArray *locationArray = [NSMutableArray array];
@@ -2415,7 +2415,7 @@ includeHidden:(BOOL)includeHidden
                                     }
                                 }
                             }
-                            NSLog(@"Coordinates array: %@", locationArray);
+                            OALog(@"Coordinates array: %@", locationArray);
                             if (completion)
                             {
                                 completion([locationArray copy], nil);
@@ -2423,28 +2423,28 @@ includeHidden:(BOOL)includeHidden
                         }
                         @catch (NSException *e)
                         {
-                            NSLog(@"NSException: %@", e.reason);
+                            OALog(@"NSException: %@", e.reason);
                             if (completion)
                             {
                                 completion(nil, [NSError errorWithDomain:@"OnlineCalculateRequestErrorDomain" code:2 userInfo:@{NSLocalizedDescriptionKey: e.reason}]);
                             }
                         }
                     } else {
-                        NSLog(@"Error: No data received");
+                        OALog(@"Error: No data received");
                         if (completion)
                         {
                             completion(nil, [NSError errorWithDomain:@"OnlineCalculateRequestErrorDomain" code:3 userInfo:@{NSLocalizedDescriptionKey: @"Error: No data received"}]);
                         }
                     }
                 } else {
-                    NSLog(@"Error: Unexpected HTTP status code: %ld", (long)httpResponse.statusCode);
+                    OALog(@"Error: Unexpected HTTP status code: %ld", (long)httpResponse.statusCode);
                     if (completion)
                     {
                         completion(nil, [NSError errorWithDomain:@"OnlineCalculateRequestErrorDomain" code:4 userInfo:@{NSLocalizedDescriptionKey: @"Error: Unexpected HTTP status code"}]);
                     }
                 }
             } else {
-                NSLog(@"Error: Unexpected response type");
+                OALog(@"Error: Unexpected response type");
                 if (completion)
                 {
                     completion(nil, [NSError errorWithDomain:@"OnlineCalculateRequestErrorDomain" code:5 userInfo:@{NSLocalizedDescriptionKey: @"Error: Unexpected response type"}]);

--- a/Sources/Helpers/OAReverseGeocoder.mm
+++ b/Sources/Helpers/OAReverseGeocoder.mm
@@ -9,6 +9,7 @@
 #import "OAReverseGeocoder.h"
 #import "OsmAndApp.h"
 #import "OAAppSettings.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Search/ReverseGeocoder.h>
 #include <OsmAndCore/RoadLocator.h>
@@ -86,7 +87,7 @@
 
 - (void) testAddressSearch:(NSString *)query lat:(double)lat lon:(double)lon
 {
-    NSLog(@"\n--- Start search: %@ ---", query);
+    OALog(@"\n--- Start search: %@ ---", query);
     
     OsmAndAppInstance app = [OsmAndApp instance];
     const auto& obfsCollection = app.resourcesManager->obfsCollection;
@@ -121,10 +122,10 @@
             name = res.address->getName(lang, transliterate).toNSString();
         }
         OsmAnd::LatLon pos = OsmAnd::Utilities::convert31ToLatLon(res.address->position31);
-        NSLog(@">> %@ (%f km)", name, OsmAnd::Utilities::distance(lon, lat, pos.longitude, pos.latitude) / 1000);
+        OALog(@">> %@ (%f km)", name, OsmAnd::Utilities::distance(lon, lat, pos.longitude, pos.latitude) / 1000);
     }
     
-    NSLog(@"+++ Finish search +++\n");
+    OALog(@"+++ Finish search +++\n");
 }
 
 @end

--- a/Sources/Helpers/OASavingTrackHelper.mm
+++ b/Sources/Helpers/OASavingTrackHelper.mm
@@ -185,49 +185,49 @@
                 const char *sql_stmt = [[NSString stringWithFormat:@"ALTER TABLE %@ ADD COLUMN %@ text", POINT_NAME, POINT_COL_COLOR] UTF8String];
                 if (sqlite3_exec(tracksDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_COLOR, POINT_NAME, errMsg);
+                    OALog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_COLOR, POINT_NAME, errMsg);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
 
                 sql_stmt = [[NSString stringWithFormat:@"ALTER TABLE %@ ADD COLUMN %@ text", POINT_NAME, POINT_COL_CATEGORY] UTF8String];
                 if (sqlite3_exec(tracksDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_CATEGORY, POINT_NAME, errMsg);
+                    OALog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_CATEGORY, POINT_NAME, errMsg);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
 
                 sql_stmt = [[NSString stringWithFormat:@"ALTER TABLE %@ ADD COLUMN %@ text", POINT_NAME, POINT_COL_DESCRIPTION] UTF8String];
                 if (sqlite3_exec(tracksDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_DESCRIPTION, POINT_NAME, errMsg);
+                    OALog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_DESCRIPTION, POINT_NAME, errMsg);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
 
                 sql_stmt = [[NSString stringWithFormat:@"ALTER TABLE %@ ADD COLUMN %@ text", POINT_NAME, POINT_COL_ICON] UTF8String];
                 if (sqlite3_exec(tracksDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_ICON, POINT_NAME, errMsg);
+                    OALog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_ICON, POINT_NAME, errMsg);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
 
                 sql_stmt = [[NSString stringWithFormat:@"ALTER TABLE %@ ADD COLUMN %@ text", POINT_NAME, POINT_COL_BACKGROUND] UTF8String];
                 if (sqlite3_exec(tracksDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_BACKGROUND, POINT_NAME, errMsg);
+                    OALog(@"Failed to add column - %@, for table - %@ | error: %s", POINT_COL_BACKGROUND, POINT_NAME, errMsg);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
 
                 sql_stmt = [[NSString stringWithFormat:@"ALTER TABLE %@ ADD COLUMN %@ double", TRACK_NAME, TRACK_COL_HEADING] UTF8String];
                 if (sqlite3_exec(tracksDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to add column - %@, for table - %@ | error: %s", TRACK_COL_HEADING, TRACK_NAME, errMsg);
+                    OALog(@"Failed to add column - %@, for table - %@ | error: %s", TRACK_COL_HEADING, TRACK_NAME, errMsg);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
 
                 sql_stmt = [[NSString stringWithFormat:@"ALTER TABLE %@ ADD COLUMN %@ text", TRACK_NAME, TRACK_COL_PLUGINS_INFO] UTF8String];
                 if (sqlite3_exec(tracksDB, sql_stmt, NULL, NULL, &errMsg) != SQLITE_OK)
                 {
-                    NSLog(@"Failed to add column - %@, for table - %@ | error: %s", TRACK_COL_PLUGINS_INFO, TRACK_NAME, errMsg);
+                    OALog(@"Failed to add column - %@, for table - %@ | error: %s", TRACK_COL_PLUGINS_INFO, TRACK_NAME, errMsg);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
 
@@ -438,7 +438,7 @@
                 }
                 
             } else {
-                NSLog(@"[ERROR] -> OASavingTrackHelper | save gpx");
+                OALog(@"[ERROR] -> OASavingTrackHelper | save gpx");
             }
         }
         
@@ -948,7 +948,7 @@
             
             int res = sqlite3_step(statement);
             if (res != SQLITE_OK && res != SQLITE_DONE)
-                NSLog(@"updatePointCoordinates failed: sqlite3_step=%d", res);
+                OALog(@"updatePointCoordinates failed: sqlite3_step=%d", res);
 
             sqlite3_finalize(statement);
             
@@ -988,7 +988,7 @@
 
             int res = sqlite3_step(statement);
             if (res != SQLITE_OK && res != SQLITE_DONE)
-                NSLog(@"doUpdatePointsLat failed: sqlite3_step=%d", res);
+                OALog(@"doUpdatePointsLat failed: sqlite3_step=%d", res);
 
             sqlite3_finalize(statement);
             

--- a/Sources/Helpers/OAUtilities.m
+++ b/Sources/Helpers/OAUtilities.m
@@ -15,6 +15,7 @@
 #import "OrderedDictionary.h"
 #import "OAFileNameTranslationHelper.h"
 #import "OAOsmAndFormatter.h"
+#import "OALog.h"
 #import "OAColors.h"
 #import "OASvgHelper.h"
 #import <UIKit/UIDevice.h>
@@ -2720,7 +2721,7 @@ static const double d180PI = 180.0 / M_PI_2;
             return [[NSMutableAttributedString alloc] initWithData:[modifiedFontHtml dataUsingEncoding:NSUTF8StringEncoding] options:@{NSDocumentTypeDocumentAttribute:NSHTMLTextDocumentType, NSCharacterEncodingDocumentAttribute:@(NSUTF8StringEncoding)} documentAttributes:nil error:nil];
         }
     } @catch (NSException *exception) {
-        NSLog(@"Failed to attributedStringFromHtmlString from: %@ %@", html, exception);
+        OALog(@"Failed to attributedStringFromHtmlString from: %@ %@", html, exception);
         return [[NSAttributedString alloc] initWithString:@""];
     }
 }
@@ -2773,7 +2774,7 @@ static const double d180PI = 180.0 / M_PI_2;
     vm_statistics_data_t vm_stat;
     if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &host_size) != KERN_SUCCESS)
     {
-        NSLog(@"Failed to fetch vm statistics");
+        OALog(@"Failed to fetch vm statistics");
         return 0;
     }
     /* Stats in bytes */

--- a/Sources/Helpers/OAWebImagesCacheHelper.mm
+++ b/Sources/Helpers/OAWebImagesCacheHelper.mm
@@ -10,6 +10,7 @@
 #import "OAWebImagesCacheHelper.h"
 #import "OADownloadMode.h"
 #import "OsmAndApp.h"
+#import "OALog.h"
 
 #import <sqlite3.h>
 #import "OsmAnd_Maps-Swift.h"
@@ -217,7 +218,7 @@
             char *errMsg;
             if (sqlite3_exec(_database, [@"CREATE TABLE IF NOT EXISTS images (key TEXT, image_base64_data TEXT, timestamp INTEGER);" UTF8String], NULL, NULL, &errMsg) != SQLITE_OK)
             {
-                NSLog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
+                OALog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
             }
             if (errMsg != NULL) sqlite3_free(errMsg);
             sqlite3_close(_database);

--- a/Sources/Helpers/OAWikiArticleHelper.mm
+++ b/Sources/Helpers/OAWikiArticleHelper.mm
@@ -20,6 +20,7 @@
 #import "Localization.h"
 #import "OAUtilities.h"
 #import "OAWikiLanguagesWebViewContoller.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Utilities.h>
 #include <OsmAndCore/ResourcesManager.h>
@@ -193,7 +194,7 @@
         }
         @catch (NSException *exception)
         {
-            NSLog(@"%@", [exception reason]);
+            OALog(@"%@", [exception reason]);
         }
     }
     return regionsByLocation;

--- a/Sources/Helpers/OAWikiImageHelper.mm
+++ b/Sources/Helpers/OAWikiImageHelper.mm
@@ -16,6 +16,7 @@
 #import "OAPOI.h"
 #import "OAAbstractCard.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 typedef NS_ENUM(NSInteger, EOAWikiImageType) {
     EOAWikiImageTypeWikimedia = 0,
@@ -175,22 +176,22 @@ typedef void(^OAWikiImageHelperOtherImages)(NSMutableArray<OAAbstractCard *> *ca
                     }
                     catch(NSException *e)
                     {
-                        NSLog(@"OsmandApi photos json serialising error: %@", e.reason);
+                        OALog(@"OsmandApi photos json serialising error: %@", e.reason);
                     }
                 }
                 else
                 {
-                    NSLog(@"OsmandApi photos error parsing json: %@", error);
+                    OALog(@"OsmandApi photos error parsing json: %@", error);
                 }
             }
             else
             {
-                NSLog(@"OsmandApi photos error: %@", error);
+                OALog(@"OsmandApi photos error: %@", error);
             }
         }
         else
         {
-            NSLog(@"Error retrieving OsmandApi photos: %@", error);
+            OALog(@"Error retrieving OsmandApi photos: %@", error);
         }
         [self runCallback:cards];
     }] resume];
@@ -291,22 +292,22 @@ typedef void(^OAWikiImageHelperOtherImages)(NSMutableArray<OAAbstractCard *> *ca
                     }
                     catch(NSException *e)
                     {
-                        NSLog(@"Wikidata photos json serialising error: %@", e.reason);
+                        OALog(@"Wikidata photos json serialising error: %@", e.reason);
                     }
                 }
                 else
                 {
-                    NSLog(@"Wikidata photos error parsing json: %@", error);
+                    OALog(@"Wikidata photos error parsing json: %@", error);
                 }
             }
             else
             {
-                NSLog(@"Wikidata photos error: %@", error);
+                OALog(@"Wikidata photos error: %@", error);
             }
         }
         else
         {
-            NSLog(@"Error retrieving Wikidata photos: %@", error);
+            OALog(@"Error retrieving Wikidata photos: %@", error);
         }
         dispatch_async(dispatch_get_main_queue(), ^{
             [self readyToAddWithType:EOAWikiImageTypeWikidata cards:cards];
@@ -365,22 +366,22 @@ typedef void(^OAWikiImageHelperOtherImages)(NSMutableArray<OAAbstractCard *> *ca
                     }
                     catch(NSException *e)
                     {
-                        NSLog(@"Wikimedia photos json serialising error: %@", e.reason);
+                        OALog(@"Wikimedia photos json serialising error: %@", e.reason);
                     }
                 }
                 else
                 {
-                    NSLog(@"Wikimedia photos error parsing json: %@", error);
+                    OALog(@"Wikimedia photos error parsing json: %@", error);
                 }
             }
             else
             {
-                NSLog(@"Wikimedia photos error: %@", error);
+                OALog(@"Wikimedia photos error: %@", error);
             }
         }
         else
         {
-            NSLog(@"Error retrieving Wikimedia photos: %@", error);
+            OALog(@"Error retrieving Wikimedia photos: %@", error);
         }
         if (ready)
         {

--- a/Sources/Helpers/OAXmlImportHandler.mm
+++ b/Sources/Helpers/OAXmlImportHandler.mm
@@ -12,6 +12,7 @@
 #import "OsmAndApp.h"
 #import "OAFileImportHelper.h"
 #import "Localization.h"
+#import "OALog.h"
 
 #include <OsmAndCore.h>
 #include <OsmAndCore/Utilities.h>
@@ -125,7 +126,7 @@ typedef NS_ENUM(NSInteger, EOAXmlFileType) {
             default:
             {
                 [OAUtilities denyAccessToFile:destPath removeFromInbox:YES];
-                NSLog(@"Could not import: %@", destPath);
+                OALog(@"Could not import: %@", destPath);
             }
         }
     }

--- a/Sources/Helpers/OpenLocationCode.swift
+++ b/Sources/Helpers/OpenLocationCode.swift
@@ -218,29 +218,29 @@ public struct OpenLocationCodeArea {
 /// // Encode a location with default code length.
 /// NSString *code = [OLCConverter encodeLatitude:37.421908
 ///                                     longitude:-122.084681];
-/// NSLog(@"Open Location Code: %@", code);
-/// 
+/// OALog(@"Open Location Code: %@", code);
+///
 /// // Encode a location with specific code length.
 /// NSString *code10Digit = [OLCConverter encodeLatitude:37.421908
 ///                                            longitude:-122.084681
 ///                                           codeLength:10];
-/// NSLog(@"Open Location Code: %@", code10Digit);
-/// 
+/// OALog(@"Open Location Code: %@", code10Digit);
+///
 /// // Decode a full code:
 /// OLCArea *coord = [OLCConverter decode:@"849VCWC8+Q48"];
-/// NSLog(@"Center is %.6f, %.6f", coord.latitudeCenter, coord.longitudeCenter);
-/// 
+/// OALog(@"Center is %.6f, %.6f", coord.latitudeCenter, coord.longitudeCenter);
+///
 /// // Attempt to trim the first characters from a code:
 /// NSString *shortCode = [OLCConverter shortenCode:@"849VCWC8+Q48"
 ///                                        latitude:37.4
 ///                                       longitude:-122.0];
-/// NSLog(@"Short Code: %@", shortCode);
-/// 
+/// OALog(@"Short Code: %@", shortCode);
+///
 /// // Recover the full code from a short code:
 /// NSString *recoveredCode = [OLCConverter recoverNearestWithShortcode:@"CWC8+Q48"
 ///                                                   referenceLatitude:37.4
 ///                                                  referenceLongitude:-122.1];
-/// NSLog(@"Recovered Full Code: %@", recoveredCode);
+/// OALog(@"Recovered Full Code: %@", recoveredCode);
 /// ```
 ///
 public class OpenLocationCode {

--- a/Sources/Helpers/OpenLocationCodeObjCBridge.swift
+++ b/Sources/Helpers/OpenLocationCodeObjCBridge.swift
@@ -108,29 +108,29 @@ import Foundation
 /// // Encode a location with default code length.
 /// NSString *code = [OLCConverter encodeLatitude:37.421908
 ///                                     longitude:-122.084681];
-/// NSLog(@"Open Location Code: %@", code);
-/// 
+/// OALog(@"Open Location Code: %@", code);
+///
 /// // Encode a location with specific code length.
 /// NSString *code10Digit = [OLCConverter encodeLatitude:37.421908
 ///                                            longitude:-122.084681
 ///                                           codeLength:10];
-/// NSLog(@"Open Location Code: %@", code10Digit);
-/// 
+/// OALog(@"Open Location Code: %@", code10Digit);
+///
 /// // Decode a full code:
 /// OLCArea *coord = [OLCConverter decode:@"849VCWC8+Q48"];
-/// NSLog(@"Center is %.6f, %.6f", coord.latitudeCenter, coord.longitudeCenter);
+/// OALog(@"Center is %.6f, %.6f", coord.latitudeCenter, coord.longitudeCenter);
 /// 
 /// // Attempt to trim the first characters from a code:
 /// NSString *shortCode = [OLCConverter shortenCode:@"849VCWC8+Q48"
 ///                                        latitude:37.4
 ///                                       longitude:-122.0];
-/// NSLog(@"Short Code: %@", shortCode);
-/// 
+/// OALog(@"Short Code: %@", shortCode);
+///
 /// // Recover the full code from a short code:
 /// NSString *recoveredCode = [OLCConverter recoverNearestWithShortcode:@"CWC8+Q48"
 ///                                                   referenceLatitude:37.4
 ///                                                  referenceLongitude:-122.1];
-/// NSLog(@"Recovered Full Code: %@", recoveredCode);
+/// OALog(@"Recovered Full Code: %@", recoveredCode);
 /// ```
 ///
 @objc public class OLCConverter: NSObject {

--- a/Sources/Helpers/OrderedDictionary.m
+++ b/Sources/Helpers/OrderedDictionary.m
@@ -31,6 +31,7 @@
 //
 
 #import "OrderedDictionary.h"
+#import "OALog.h"
 
 
 #pragma GCC diagnostic ignored "-Wobjc-missing-property-synthesis"
@@ -55,28 +56,28 @@
 
 + (instancetype)dictionaryWithContentsOfFile:(__unused NSString *)path
 {
-    NSLog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
+    OALog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
     [self doesNotRecognizeSelector:_cmd];
     return nil;
 }
 
 + (instancetype)dictionaryWithContentsOfURL:(__unused NSURL *)url
 {
-    NSLog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
+    OALog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
     [self doesNotRecognizeSelector:_cmd];
     return nil;
 }
 
 - (instancetype)initWithContentsOfFile:(__unused NSString *)path
 {
-    NSLog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
+    OALog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
     [self doesNotRecognizeSelector:_cmd];
     return nil;
 }
 
 - (instancetype)initWithContentsOfURL:(__unused NSURL *)url
 {
-    NSLog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
+    OALog(@"OrderedDictionary does not support loading from a plist file. Use NSKeyedArchiver instead.");
     [self doesNotRecognizeSelector:_cmd];
     return nil;
 }

--- a/Sources/Helpers/SharedLibHelpers/OASharedUtil.m
+++ b/Sources/Helpers/SharedLibHelpers/OASharedUtil.m
@@ -9,6 +9,7 @@
 #import "OASharedUtil.h"
 #import "OsmAndApp.h"
 #import "OAXmlFactory.h"
+#import "OALog.h"
 #import "OAOsmAndContextImpl.h"
 #import <OsmAndShared/OsmAndShared.h>
 
@@ -23,17 +24,17 @@
 // Temporary test code
 + (void) testGpxReadWrite:(NSString *)inputFile outputFile:(NSString *)outputFile
 {
-    NSLog(@"GPX TEST - READ");
+    OALog(@"GPX TEST - READ");
 
     OASKFile *file = [[OASKFile alloc] initWithFilePath:inputFile];
     OASGpxFile *gpxFile = [OASGpxUtilities.shared loadGpxFileFile:file];
 
-    NSLog(@"GPX TEST - WRITE");
+    OALog(@"GPX TEST - WRITE");
 
     file = [[OASKFile alloc] initWithFilePath:outputFile];
     [OASGpxUtilities.shared writeGpxFileFile:file gpxFile:gpxFile];
 
-    NSLog(@"GPX TEST - DONE");
+    OALog(@"GPX TEST - DONE");
 }
 
 

--- a/Sources/OsmAnd Maps-Bridging-Header.h
+++ b/Sources/OsmAnd Maps-Bridging-Header.h
@@ -66,6 +66,7 @@
 #import "OALocationIcon.h"
 #import "OrderedDictionary.h"
 #import "OAMapActions.h"
+#import "OALog.h"
 
 // Widgets
 #import "OAMapWidgetRegistry.h"

--- a/Sources/OsmEdit/OAOpenStreetMapRemoteUtil.mm
+++ b/Sources/OsmEdit/OAOpenStreetMapRemoteUtil.mm
@@ -28,6 +28,7 @@
 #import "OANetworkUtilities.h"
 #import "OAURLSessionProgress.h"
 #import "OAGPXDatabase.h"
+#import "OALog.h"
 #import "OsmAndApp.h"
 #import "OsmAnd_Maps-Swift.h"
 
@@ -118,7 +119,7 @@ static const NSString* URL_TO_UPLOAD_GPX = @"https://api.openstreetmap.org/api/0
 
 -(NSString *)sendRequest:(NSString *)url requestMethod:(NSString *)requestMethod requestBody:(NSString *)requestBody userOperation:(NSString *)userOperation doAuthenticate:(BOOL)doAuthenticate
 {
-    NSLog(@"Sending request: %@", url);
+    OALog(@"Sending request: %@", url);
     NSURL *urlObj = [[NSURL alloc] initWithString:url];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:urlObj
                                                                              cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
@@ -284,7 +285,7 @@ static const NSString* URL_TO_UPLOAD_GPX = @"https://api.openstreetmap.org/api/0
         NSString *response = [self sendRequest:[NSString stringWithFormat:@"%@%@%ld%@", BASE_URL, @"api/0.6/changeset/", _changeSetId, @"/close"]
                                 requestMethod:@"PUT" requestBody:@"" userOperation:OALocalizedString(@"closing_changeset")
                                 doAuthenticate:YES];
-        NSLog(@"Response: %@", response);
+        OALog(@"Response: %@", response);
         _changeSetId = NO_CHANGESET_ID;
     }
 }
@@ -327,7 +328,7 @@ static const NSString* URL_TO_UPLOAD_GPX = @"https://api.openstreetmap.org/api/0
     NSString *res = [self sendRequest:[NSString stringWithFormat:@"%@%@%ld%@", BASE_URL, @"api/0.6/changeset/", _changeSetId, @"/upload"]
                        requestMethod:@"POST" requestBody:xmlString userOperation:OALocalizedString(@"commiting_node")
                       doAuthenticate:YES];
-    NSLog(@"Response: %@", res);
+    OALog(@"Response: %@", res);
     if (res) {
         if (CREATE == action) {
             long long newId = [entity getId];

--- a/Sources/OsmEdit/OAOsmBugsDBHelper.m
+++ b/Sources/OsmEdit/OAOsmBugsDBHelper.m
@@ -9,6 +9,7 @@
 #import "OAOsmBugsDBHelper.h"
 #import "OABackupHelper.h"
 
+
 #import "OALog.h"
 #import "OAOsmNotePoint.h"
 #import "OAOsmPoint.h"

--- a/Sources/OsmEdit/OAOsmBugsRemoteUtil.m
+++ b/Sources/OsmEdit/OAOsmBugsRemoteUtil.m
@@ -10,6 +10,7 @@
 #import "OAOsmNotePoint.h"
 #import "OAOsmBugResult.h"
 #import "OAAppSettings.h"
+#import "OALog.h"
 #import "OsmAnd_Maps-Swift.h"
 
 #define GET @"GET"
@@ -68,7 +69,7 @@ static const NSString* USERS_API_BASE_URL = @"https://api.openstreetmap.org/api/
 
 -(OAOsmBugResult *) editingPOI:(NSString *)url requestMethod:(NSString *)requestMethod userOperation:(NSString *)userOperation anonymous:(BOOL) anonymous
 {
-    NSLog(@"Sending request: %@", url);
+    OALog(@"Sending request: %@", url);
     NSURL *urlObj = [[NSURL alloc] initWithString:url];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:urlObj
                                                            cachePolicy:NSURLRequestReloadIgnoringLocalCacheData

--- a/Sources/OsmEdit/OsmData/OAOsmBaseStorage.m
+++ b/Sources/OsmEdit/OsmData/OAOsmBaseStorage.m
@@ -14,6 +14,7 @@
 #import "OAEntityInfo.h"
 #import "OrderedDictionary.h"
 #import "OAEntityInfo.h"
+#import "OALog.h"
 
 // called from libxml functions
 @interface OAOsmBaseStorage (LibXMLParserMethods)
@@ -278,7 +279,7 @@ defaultAttributeCount:(int)defaultAttributeCount attributes:(xmlSAX2Attributes *
         else
         {
             // this situation could be logged as unhandled
-            NSLog(@"%@", @"Bad entity type from OSC request");
+            OALog(@"%@", @"Bad entity type from OSC request");
         }
         
         if (_currentParsedEntity)

--- a/Sources/POI/OAPOIHelper.mm
+++ b/Sources/POI/OAPOIHelper.mm
@@ -24,6 +24,7 @@
 #import "OAResultMatcher.h"
 #import "Localization.h"
 #import "OANativeUtilities.h"
+#import "OALog.h"
 
 #include <OsmAndCore/CommonTypes.h>
 #include <OsmAndCore/Data/DataCommonTypes.h>
@@ -127,7 +128,7 @@ static NSArray<NSString *> *const kNameTagPrefixes = @[@"name", @"int_name", @"n
 {
     OAPOICategory *pc = [self getPoiCategoryByName:@"user_defined_other"];
     if (!pc)
-        NSLog(@"!!! 'user_defined_other' category not found");
+        OALog(@"!!! 'user_defined_other' category not found");
 
     _otherPoiCategory = pc;
 }
@@ -198,7 +199,7 @@ static NSArray<NSString *> *const kNameTagPrefixes = @[@"name", @"int_name", @"n
         
         if (!_phrases)
         {
-            NSLog(@"ERROR: Not found phrases translation file at path: %@", [NSString stringWithFormat:@"phrases/%@/phrases.xml", fullLanguageCode]);
+            OALog(@"ERROR: Not found phrases translation file at path: %@", [NSString stringWithFormat:@"phrases/%@/phrases.xml", fullLanguageCode]);
             NSString *primaryLanguageCode = [OAUtilities currentLang];
             _phrases = [self loadPhraseFileForLanguage:primaryLanguageCode];
         }

--- a/Sources/Plugins/OAOnlinePlugin.mm
+++ b/Sources/Plugins/OAOnlinePlugin.mm
@@ -14,6 +14,7 @@
 #import <MBProgressHUD.h>
 #import "OASettingsItem.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 @interface OAOnlinePlugin()
 
@@ -106,7 +107,7 @@
 {
     if (_osfUrl.length == 0) 
     {
-        NSLog(@"Cannot install online plugin. OSF url is empty for %@", self.getId);
+        OALog(@"Cannot install online plugin. OSF url is empty for %@", self.getId);
         return;
     }
 

--- a/Sources/Plugins/OAPluginsHelper.mm
+++ b/Sources/Plugins/OAPluginsHelper.mm
@@ -35,6 +35,7 @@
 #import "OAAppVersion.h"
 #import "OAOnlinePlugin.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 @implementation OAPluginsHelper
 
@@ -163,7 +164,7 @@ static NSMutableArray<OAPlugin *> *allPlugins;
     }
     @catch (NSException *e)
     {
-        NSLog(@"Plugin initialization failed %@ reason=%@", [plugin getId], e.reason);
+        OALog(@"Plugin initialization failed %@ reason=%@", [plugin getId], e.reason);
     }
 }
 

--- a/Sources/Purchases/OAIAPHelper.mm
+++ b/Sources/Purchases/OAIAPHelper.mm
@@ -17,6 +17,7 @@
 #import "OAObservable.h"
 #import "OAAppSettings.h"
 #import "OAProducts.h"
+#import "OALog.h"
 #import <AFNetworking/AFNetworkReachabilityManager.h>
 
 NSString *const OAIAPProductsRequestSucceedNotification = @"OAIAPProductsRequestSucceedNotification";
@@ -175,7 +176,7 @@ static OASubscriptionState *EXPIRED;
         [[NSUserDefaults standardUserDefaults] setInteger:kFreeMapsAvailableTotal forKey:@"freeMapsAvailable"];
     }
 
-    NSLog(@"Free maps available: %d", freeMaps);
+    OALog(@"Free maps available: %d", freeMaps);
     return freeMaps;
 }
 
@@ -188,7 +189,7 @@ static OASubscriptionState *EXPIRED;
     [[NSUserDefaults standardUserDefaults] setInteger:--freeMaps forKey:@"freeMapsAvailable"];
     [[NSUserDefaults standardUserDefaults] synchronize];
     
-    NSLog(@"Free maps left: %d", freeMaps);
+    OALog(@"Free maps left: %d", freeMaps);
 }
 
 + (void) increaseFreeMapsCount:(int)count
@@ -201,7 +202,7 @@ static OASubscriptionState *EXPIRED;
     [[NSUserDefaults standardUserDefaults] setInteger:freeMaps forKey:@"freeMapsAvailable"];
     [[NSUserDefaults standardUserDefaults] synchronize];
     
-    NSLog(@"Free maps left: %d", freeMaps);
+    OALog(@"Free maps left: %d", freeMaps);
 }
 
 + (BOOL) isPaidVersion
@@ -679,7 +680,7 @@ static OASubscriptionState *EXPIRED;
 
 - (void) buyProduct:(OAProduct *)product
 {
-    NSLog(@"Buying %@...", product.productIdentifier);
+    OALog(@"Buying %@...", product.productIdentifier);
     
     // test - emulate purchasing
     if (TEST_LOCAL_PURCHASE)
@@ -763,7 +764,7 @@ static OASubscriptionState *EXPIRED;
                          if (map)
                          {
                              NSString *userId = [map objectForKey:@"userid"];
-                             NSLog(@"UserId = %@", userId);
+                             OALog(@"UserId = %@", userId);
                              if (userId.length > 0)
                              {
                                  [self applyUserPreferences:map];
@@ -819,7 +820,7 @@ static OASubscriptionState *EXPIRED;
 
 - (void) launchPurchase:(OASubscription *)subscription
 {
-    NSLog(@"Launching purchase flow for live updates subscription");
+    OALog(@"Launching purchase flow for live updates subscription");
     OAPaymentDiscount *paymentDiscount = nil;
     if (_settings.eligibleForSubscriptionOffer && subscription.discounts.count > 0)
     {
@@ -861,7 +862,7 @@ static OASubscriptionState *EXPIRED;
 
 - (void) productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response
 {
-    NSLog(@"Loaded list of products...");
+    OALog(@"Loaded list of products...");
     _productsRequest = nil;
     BOOL isPaidVersion = [self.class isPaidVersion];
     BOOL isOsmAndProAvailable = [self.class isOsmAndProAvailable];
@@ -870,7 +871,7 @@ static OASubscriptionState *EXPIRED;
     {
         if (skProduct)
         {
-            NSLog(@"Found product: %@ %@ %0.2f",
+            OALog(@"Found product: %@ %@ %0.2f",
                   skProduct.productIdentifier,
                   skProduct.localizedTitle,
                   skProduct.price.floatValue);
@@ -1055,17 +1056,17 @@ static OASubscriptionState *EXPIRED;
 {
     if (request == _productsRequest)
     {
-        NSLog(@"Products request did finish OK");
+        OALog(@"Products request did finish OK");
     }
     else if (request == _receiptRequest)
     {
-        NSLog(@"Receipt request did finish OK");
+        OALog(@"Receipt request did finish OK");
         _receiptRequest = nil;
         [self getActiveProducts:_activeProductsCompletionHandler];
     }
     else
     {
-        NSLog(@"SKRequest did finish OK");
+        OALog(@"SKRequest did finish OK");
     }
 }
 
@@ -1079,7 +1080,7 @@ static OASubscriptionState *EXPIRED;
     else
         requestName = @"Unknown";
 
-    NSLog(@"%@ request did fail with error: %@", requestName, error.localizedDescription);
+    OALog(@"%@ request did fail with error: %@", requestName, error.localizedDescription);
     
     if (request == _productsRequest)
     {
@@ -1181,11 +1182,11 @@ static OASubscriptionState *EXPIRED;
             {
                 if (![self productsLoaded])
                 {
-                    NSLog(@"Cannot completeTransaction - %@. Products are not loaded yet.", transaction.payment.productIdentifier);
+                    OALog(@"Cannot completeTransaction - %@. Products are not loaded yet.", transaction.payment.productIdentifier);
                 }
                 else
                 {
-                    NSLog(@"completeTransaction - %@", transaction.payment.productIdentifier);
+                    OALog(@"completeTransaction - %@", transaction.payment.productIdentifier);
                     NSString *productId = transaction.payment.productIdentifier;
                     NSString *transactionId = transaction.originalTransaction ? transaction.originalTransaction.transactionIdentifier : transaction.transactionIdentifier;
                     [self provideContentForProductIdentifier:productId transactionId:transactionId];
@@ -1206,11 +1207,11 @@ static OASubscriptionState *EXPIRED;
             {
                 if (![self productsLoaded])
                 {
-                    NSLog(@"Cannot restoreTransaction - %@. Products are not loaded yet.", transaction.originalTransaction.payment.productIdentifier);
+                    OALog(@"Cannot restoreTransaction - %@. Products are not loaded yet.", transaction.originalTransaction.payment.productIdentifier);
                 }
                 else
                 {
-                    NSLog(@"restoreTransaction - %@", transaction.originalTransaction.payment.productIdentifier);
+                    OALog(@"restoreTransaction - %@", transaction.originalTransaction.payment.productIdentifier);
                 }
             }
             [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
@@ -1221,7 +1222,7 @@ static OASubscriptionState *EXPIRED;
 - (void) deferredTransaction:(SKPaymentTransaction *)transaction
 {
     @synchronized (self) {
-        NSLog(@"Transaction deferred state: %@", transaction.payment.productIdentifier);
+        OALog(@"Transaction deferred state: %@", transaction.payment.productIdentifier);
         [[NSNotificationCenter defaultCenter] postNotificationName:OAIAPProductPurchaseDeferredNotification object:transaction.payment.productIdentifier userInfo:nil];
     }
 }
@@ -1234,11 +1235,11 @@ static OASubscriptionState *EXPIRED;
             if (transaction.payment && transaction.payment.productIdentifier)
             {
                 NSString *productIdentifier = transaction.payment.productIdentifier;
-                NSLog(@"failedTransaction - %@", productIdentifier);
+                OALog(@"failedTransaction - %@", productIdentifier);
                 [self logTransactionType:@"failed" productIdentifier:productIdentifier];
                 if (transaction.error && transaction.error.code != SKErrorPaymentCancelled)
                 {
-                    NSLog(@"Transaction error: %@", transaction.error.localizedDescription);
+                    OALog(@"Transaction error: %@", transaction.error.localizedDescription);
                     [[NSNotificationCenter defaultCenter] postNotificationName:OAIAPProductPurchaseFailedNotification object:productIdentifier userInfo:@{@"error" : [NSString stringWithFormat:@"failedTransaction %@ - %@", productIdentifier, transaction.error.localizedDescription]}];
                 }
                 else
@@ -1357,7 +1358,7 @@ static OASubscriptionState *EXPIRED;
     OAProduct *product = [self product:productIdentifier];
     if (product)
     {
-        NSLog(@"%@ product purchased.", product.localizedTitle);
+        OALog(@"%@ product purchased.", product.localizedTitle);
 
         // test - emulate purchase
         if (TEST_LOCAL_PURCHASE)
@@ -1407,7 +1408,7 @@ static OASubscriptionState *EXPIRED;
             NSData *receipt = [self getLocalReceipt];
             if (!receipt || !transactionId)
             {
-                NSLog(@"Error: No local receipt or transaction");
+                OALog(@"Error: No local receipt or transaction");
                 NSMutableString *errorText = [NSMutableString string];
                 if (!receipt)
                     [errorText appendString:@" (no receipt)"];
@@ -1451,7 +1452,7 @@ static OASubscriptionState *EXPIRED;
                      {
                          @try
                          {
-                             NSLog([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                             OALog([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
                              NSMutableDictionary *map = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
                              if (map)
                              {
@@ -1465,7 +1466,7 @@ static OASubscriptionState *EXPIRED;
                                  else
                                  {
                                      errorStr = [NSString stringWithFormat:@"Purchase subscription failed: %@ (userId=%@ response=%@)", [map objectForKey:@"error"], _settings.billingUserId.get, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
-                                     NSLog(errorStr);
+                                     OALog(errorStr);
                                  }
                              }
                          }
@@ -1550,7 +1551,7 @@ static OASubscriptionState *EXPIRED;
     if (!receipt || _restoringPurchases)
     {
         if (!_restoringPurchases)
-            NSLog(@"No local receipt. Requesting new one...");
+            OALog(@"No local receipt. Requesting new one...");
         _restoringPurchases = NO;
         _activeProductsCompletionHandler = onComplete;
         _receiptRequest = [[SKReceiptRefreshRequest alloc] initWithReceiptProperties:nil];
@@ -1576,7 +1577,7 @@ static OASubscriptionState *EXPIRED;
              {
                  @try
                  {
-                     NSLog([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                     OALog([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
                      NSMutableDictionary *map = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
                      if (map)
                      {
@@ -1721,7 +1722,7 @@ static OASubscriptionState *EXPIRED;
              {
                  @try
                  {
-                     NSLog([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                     OALog([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
                      NSMutableDictionary *map = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
                      if (map)
                      {
@@ -1907,7 +1908,7 @@ static OASubscriptionState *EXPIRED;
                 }
                 else
                 {
-                    NSLog(@"Subscription validation json error");
+                    OALog(@"Subscription validation json error");
                 }
             }
             alreadyFinished = YES;

--- a/Sources/QuickAction/OAMapButtonsHelper.m
+++ b/Sources/QuickAction/OAMapButtonsHelper.m
@@ -36,6 +36,7 @@
 #import "OAShowHideMapillaryAction.h"
 #import "OAPluginsHelper.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 static NSString * const kType = @"type";
 static NSString * const kName = @"name";
@@ -360,7 +361,7 @@ static QuickActionType *TYPE_INTERFACE;
                 }
                 @catch (NSException *e)
                 {
-                    NSLog(@"%@", e.reason);
+                    OALog(@"%@", e.reason);
                 }
             }
         }

--- a/Sources/Router/Colorization/OARouteColorize.mm
+++ b/Sources/Router/Colorization/OARouteColorize.mm
@@ -15,6 +15,7 @@
 #import "OsmAnd_Maps-Swift.h"
 #import <CoreLocation/CoreLocation.h>
 #import "OsmAndSharedWrapper.h"
+#import "OALog.h"
 
 static CGFloat const defaultBase = 17.2;
 static CGFloat const maxCorrectElevationDistance = 100.0; // in meters
@@ -59,7 +60,7 @@ static CGFloat const minDifferenceSlope = 0.05; //5%
 {
     if (!gpxFile.hasTrkPt)
     {
-        NSLog(@"GPX file is not consist of track points");
+        OALog(@"GPX file is not consist of track points");
         return nil;
     }
     self = [super init];
@@ -145,7 +146,7 @@ static CGFloat const minDifferenceSlope = 0.05; //5%
     
     NSMutableArray<NSNumber *> *slopes = [NSMutableArray arrayWithCapacity:elevations.count];
     if (_latitudes.count != _longitudes.count || _latitudes.count != elevations.count) {
-        NSLog(@"Sizes of arrays latitudes, longitudes and values are not match");
+        OALog(@"Sizes of arrays latitudes, longitudes and values are not match");
         return slopes;
     }
     
@@ -320,7 +321,7 @@ static CGFloat const minDifferenceSlope = 0.05; //5%
         double diff = distances[closestMaxIndex].doubleValue - distances[closestMaxIndex - 1].doubleValue;
         double coef = (maxDist - distances[closestMaxIndex - 1].doubleValue) / diff;
         if (coef > 1 || coef < 0)
-            NSLog(@"Coefficient fo max must be 0..1 , coef=%f", coef);
+            OALog(@"Coefficient fo max must be 0..1 , coef=%f", coef);
 
         result[1] = @((1 - coef) * elevations[closestMaxIndex - 1].doubleValue + coef * elevations[closestMaxIndex].doubleValue);
     }
@@ -329,11 +330,11 @@ static CGFloat const minDifferenceSlope = 0.05; //5%
         double diff = distances[closestMinIndex + 1].doubleValue - distances[closestMinIndex].doubleValue;
         double coef = (minDist - distances[closestMinIndex].doubleValue) / diff;
         if (coef > 1 || coef < 0)
-            NSLog(@"Coefficient for min must be 0..1 , coef=%f", coef);
+            OALog(@"Coefficient for min must be 0..1 , coef=%f", coef);
         result[0] = @((1 - coef) * elevations[closestMinIndex].doubleValue + coef * elevations[closestMinIndex + 1].doubleValue);
     }
     if (isnan(result[0].doubleValue) || isnan(result[1].doubleValue))
-        NSLog(@"Elevations weren't calculated");
+        OALog(@"Elevations weren't calculated");
     return result;
 }
 

--- a/Sources/Router/GPX/OATspAnt.m
+++ b/Sources/Router/GPX/OATspAnt.m
@@ -7,6 +7,7 @@
 //
 
 #import "OATspAnt.h"
+#import "OALog.h"
 
 // Algorithm parameters:
 // original amount of trail
@@ -64,7 +65,7 @@ static int maxIterations = 500;
 
 - (void)visitTown:(int)town
 {
-    //NSLog(@"town = %d", town);
+    //OALog(@"town = %d", town);
 
     self.tour[*_currentIndex + 1] = [NSNumber numberWithInt:town];
     self.visited[town] = @YES;
@@ -392,8 +393,8 @@ double bitsToDouble(uint64_t bitPattern)
         iteration++;
     }
     // Subtract n because we added one to edges on load
-    NSLog(@"Best tour length: %f", bestTourLength - n * 0.1);
-    NSLog(@"Best tour: %@", [self tourToString:bestTour]);
+    OALog(@"Best tour length: %f", bestTourLength - n * 0.1);
+    OALog(@"Best tour: %@", [self tourToString:bestTour]);
     return [self alignAnswer:[bestTour copy]];
 }
 
@@ -456,7 +457,7 @@ double bitsToDouble(uint64_t bitPattern)
     }
     [mixStr appendString:@"]"];
     
-    NSLog(@"%@", mixStr);
+    OALog(@"%@", mixStr);
     
     //		ans = new TspHeldKarp().readInput(sh, true).solve();
     CLLocation *end = farest;
@@ -501,14 +502,14 @@ double bitsToDouble(uint64_t bitPattern)
     for (int i = 0; i < ans.count; i++)
         [log appendFormat:@"%d ", order[i]];
     
-    NSLog(@"%@", log);
+    OALog(@"%@", log);
     
     log = [NSMutableString string];
     [log appendString:@"Result dist: "];
     for (int i = 1; i < ans.count - 1; i++)
         [log appendFormat:@"%f ", dist[i]];
     
-    NSLog(@"%@", log);
+    OALog(@"%@", log);
 }
 
 @end

--- a/Sources/Router/OARouteImporter.mm
+++ b/Sources/Router/OARouteImporter.mm
@@ -8,6 +8,7 @@
 
 #import "OARouteImporter.h"
 #import "OAGPXDocumentPrimitives.h"
+#import "OALog.h"
 
 #include <routeDataResources.h>
 #include <routeSegmentResult.h>
@@ -154,7 +155,7 @@
         }
         catch (const std::exception &ex)
         {
-            NSLog(@"%s", ex.what());
+            OALog(@"%s", ex.what());
         }
     }
     return route;

--- a/Sources/Router/OARouteProvider.mm
+++ b/Sources/Router/OARouteProvider.mm
@@ -29,6 +29,7 @@
 #import "CLLocation+Extension.h"
 #import "OsmAndSharedWrapper.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 #include <precalculatedRouteDirection.h>
 #include <routePlannerFrontEnd.h>
@@ -703,7 +704,7 @@
     long memoryLimit = (0.1 * ([NSProcessInfo processInfo].physicalMemory / mb));
     // make visible
     long memoryTotal = (long) ([NSProcessInfo processInfo].physicalMemory / mb);
-    NSLog(@"Use %ld MB of %ld MB, free memory: %ld MB", memoryLimit, memoryTotal, (long)(freeMemory / mb));
+    OALog(@"Use %ld MB of %ld MB, free memory: %ld MB", memoryLimit, memoryTotal, (long)(freeMemory / mb));
     
     string routingProfile = derivedProfile == "default" ? params.mode.getRoutingProfile.UTF8String : derivedProfile;
     auto cf = config->build(routingProfile, params.start.course >= 0.0 ? params.start.course / 180.0 * M_PI : NO_DIRECTION, memoryLimit, paramsR);
@@ -1666,7 +1667,7 @@
     if (params.start && params.end)
     {
 //        params.calculationProgress->routeCalculationStartTime = time;
-        NSLog(@"Start finding route from %@ to %@ using %@", params.start, params.end, [OARouteService getName:(EOARouteService)params.mode.getRouterService]);
+        OALog(@"Start finding route from %@ to %@ using %@", params.start, params.end, [OARouteService getName:(EOARouteService)params.mode.getRouterService]);
         try
         {
             OARouteCalculationResult *res = nil;
@@ -1713,14 +1714,14 @@
 
             if (res)
             {
-                NSLog(@"Finding route contained %d points for %.3f s", (int)[res getImmutableAllLocations].count, [[NSDate date] timeIntervalSince1970] - time);
+                OALog(@"Finding route contained %d points for %.3f s", (int)[res getImmutableAllLocations].count, [[NSDate date] timeIntervalSince1970] - time);
             }
 
             return res;
         }
         catch (NSException *e)
         {
-            NSLog(@"Failed to find route %@", e.reason);
+            OALog(@"Failed to find route %@", e.reason);
         }
     }
     return [[OARouteCalculationResult alloc] initWithErrorMessage:nil];

--- a/Sources/Router/OARoutingHelper.mm
+++ b/Sources/Router/OARoutingHelper.mm
@@ -37,6 +37,7 @@
 #import <OsmAndCore/Utilities.h>
 #import "OsmAndSharedWrapper.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OALog.h"
 
 #include <routeSegmentResult.h>
 
@@ -453,7 +454,7 @@ static BOOL _isDeviatedFromRoute = false;
         {
             if (newDist < dist)
             {
-                NSLog(@"Processed by distance : (new) %f (old) %f", newDist, dist);
+                OALog(@"Processed by distance : (new) %f (old) %f", newDist, dist);
                 processed = true;
             }
         }
@@ -463,7 +464,7 @@ static BOOL _isDeviatedFromRoute = false;
             if (dist > posTolerance)
             {
                 processed = true;
-                NSLog(@"Processed by distance : %f %f", newDist, dist);
+                OALog(@"Processed by distance : %f %f", newDist, dist);
             }
             else
             {
@@ -482,7 +483,7 @@ static BOOL _isDeviatedFromRoute = false;
                     double diffToNext = ABS(degreesDiff(bearingMotion, bearingRouteNext));
                     if (diff > diffToNext)
                     {
-                        NSLog(@"Processed point bearing deltas : %f %f", diff, diffToNext);
+                        OALog(@"Processed point bearing deltas : %f %f", diff, diffToNext);
                         processed = true;
                     }
                 }
@@ -712,7 +713,7 @@ static BOOL _isDeviatedFromRoute = false;
                 }
                 if (distOrth > allowableDeviation)
                 {
-                    NSLog(@"Recalculate route, because correlation  : %f", distOrth);
+                    OALog(@"Recalculate route, because correlation  : %f", distOrth);
                     _isDeviatedFromRoute = true;
                     calculateRoute = ![_settings.disableOffrouteRecalc get];
                 }
@@ -725,7 +726,7 @@ static BOOL _isDeviatedFromRoute = false;
             if (allowableDeviation > 0 && wrongMovementDirection && !isStraight
                 && ([currentLocation distanceFromLocation:routeNodes[currentRoute]] > allowableDeviation) && ![_settings.disableWrongDirectionRecalc get])
             {
-                NSLog(@"Recalculate route, because wrong movement direction: %f", [currentLocation distanceFromLocation:routeNodes[currentRoute]]);
+                OALog(@"Recalculate route, because wrong movement direction: %f", [currentLocation distanceFromLocation:routeNodes[currentRoute]]);
                 _isDeviatedFromRoute = true;
                 calculateRoute = true;
             }

--- a/Sources/Router/OATransportRoutingHelper.mm
+++ b/Sources/Router/OATransportRoutingHelper.mm
@@ -18,6 +18,7 @@
 #import "QuadRect.h"
 #import "OARouteProvider.h"
 #import "OARootViewController.h"
+#import "OALog.h"
 
 #include <OsmAndCore/Utilities.h>
 #include <transportRoutingObjects.h>
@@ -832,7 +833,7 @@
         {
             [listener newRouteIsCalculated:YES];
         }
-        NSLog(@"Public transport routes calculated: %ld", res.size());
+        OALog(@"Public transport routes calculated: %ld", res.size());
     });
 }
 
@@ -882,7 +883,7 @@
 
 - (void) showMessage:(NSString *)msg
 {
-    NSLog(@"Public Transport error: %@", msg);
+    OALog(@"Public Transport error: %@", msg);
 }
 
 

--- a/Sources/Search/OASearchUICore.mm
+++ b/Sources/Search/OASearchUICore.mm
@@ -23,6 +23,7 @@
 #import "OAPOIBaseType.h"
 #import "OAStreet.h"
 #import "OAResultMatcher.h"
+#import "OALog.h"
 
 #include <OsmAndCore.h>
 #include <OsmAndCore/Utilities.h>
@@ -529,7 +530,7 @@ const static NSArray<NSNumber *> *compareStepValues = @[@(EOATopVisible),
         OASearchResultCollection *collection = [[OASearchResultCollection alloc] initWithPhrase:sphrase];
         [collection addSearchResults:[rm getRequestResults] resortAll:resortAll removeDuplicates:removeDuplicates];
 
-        NSLog(@">> Shallow Search phrase %@ %d", [_phrase toString], (int)([rm getRequestResults].count));
+        OALog(@">> Shallow Search phrase %@ %d", [_phrase toString], (int)([rm getRequestResults].count));
 
         return collection;
     }
@@ -653,7 +654,7 @@ const static NSArray<NSNumber *> *compareStepValues = @[@(EOATopVisible),
     _searchActive = YES;
     OASearchPhrase *phrase = [_phrase generateNewPhrase:text settings:_searchSettings];
     _phrase = phrase;
-    NSLog(@"> Search phrase %@", [_phrase toString]);
+    OALog(@"> Search phrase %@", [_phrase toString]);
     
     dispatch_async(_taskQueue, ^{
         @try
@@ -706,7 +707,7 @@ const static NSArray<NSNumber *> *compareStepValues = @[@(EOATopVisible),
             {
                 OASearchResultCollection *collection = [[OASearchResultCollection alloc] initWithPhrase:phrase];
                 [collection addSearchResults:[rm getRequestResults] resortAll:YES removeDuplicates:YES];
-                NSLog(@">> Search phrase %@ %d", [phrase toString], (int)([rm getRequestResults].count));
+                OALog(@">> Search phrase %@ %d", [phrase toString], (int)([rm getRequestResults].count));
                 _currentSearchResult = collection;
                 [rm searchFinished:phrase];
                 if (_onResultsComplete)
@@ -715,7 +716,7 @@ const static NSArray<NSNumber *> *compareStepValues = @[@(EOATopVisible),
         }
         @catch (NSException *e)
         {
-            NSLog(@"OASearchUICore.search error %@", e);
+            OALog(@"OASearchUICore.search error %@", e);
         }
         @finally
         {
@@ -810,7 +811,7 @@ const static NSArray<NSNumber *> *compareStepValues = @[@(EOATopVisible),
         }
         catch (NSException *e)
         {
-            NSLog(@"OASearchUICore.searchInBackground error %@", e);
+            OALog(@"OASearchUICore.searchInBackground error %@", e);
         }
 
         if ([api isSearchDone:phrase])

--- a/Sources/Views/OAFreeMemoryView.m
+++ b/Sources/Views/OAFreeMemoryView.m
@@ -10,6 +10,7 @@
 #import "Localization.h"
 #import "OsmAnd_Maps-Swift.h"
 #import "GeneratedAssetSymbols.h"
+#import "OALog.h"
 
 @implementation OAFreeMemoryView
 {
@@ -105,7 +106,7 @@
         deviceMemoryCapacity = [fileSystemSizeInBytes unsignedLongLongValue];
         if (deviceMemoryCapacity <= 0)
         {
-            NSLog(@"Error obtaining dvice memory capacity");
+            OALog(@"Error obtaining dvice memory capacity");
             deviceMemoryCapacity = 1;
         }
         
@@ -122,7 +123,7 @@
     }
     else
     {
-        NSLog(@"Error Obtaining File System Info: Domain = %@, Code = %ld", [error domain], (long)[error code]);
+        OALog(@"Error Obtaining File System Info: Domain = %@, Code = %ld", [error domain], (long)[error code]);
     }
 
     unsigned long long docSize = [OAUtilities folderSize:[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject]];
@@ -140,7 +141,7 @@
     double sum = _sysVal + _appVal + _freeVal;
     if (sum > 1.5 || sum <= 0)
     {
-        NSLog(@"Incorrect storage calculation (total:%llu, system:%llu, free:%llu, doc:%llu)", capValue, systemValue, availValue, docValue);
+        OALog(@"Incorrect storage calculation (total:%llu, system:%llu, free:%llu, doc:%llu)", capValue, systemValue, availValue, docValue);
         _sysVal = 0;
         _appVal = 0;
         _freeVal = 1;

--- a/Sources/Voice/OATTSCommandPlayerImpl.mm
+++ b/Sources/Voice/OATTSCommandPlayerImpl.mm
@@ -14,6 +14,7 @@
 #import "OAAppSettings.h"
 #import "OARootViewController.h"
 #import "Localization.h"
+#import "OALog.h"
 
 #include <JavaScriptCore/JavaScriptCore.h>
 
@@ -92,7 +93,7 @@
                 [OAUtilities showToast:OALocalizedString(@"download_persian_voice_alert_title") details:details duration:4 inView:OARootViewController.instance.view];
             });
         }
-        NSLog(@"[OATTSCommandPlayerImpl] Invalid or unsupported locale identifier: %@, using current system language", voiceProvider);
+        OALog(@"[OATTSCommandPlayerImpl] Invalid or unsupported locale identifier: %@, using current system language", voiceProvider);
         return [AVSpeechSynthesisVoice voiceWithLanguage:[AVSpeechSynthesisVoice currentLanguageCode]];
     }
 }


### PR DESCRIPTION
Founded some trouble with writing log file on device.

- Deleted old log in random order. Sometimes deleted the latest log. Fixed.

- it didn't write many logs to the file. From Swift and C++ by example. Fixed.

```
Before:

Objc NSLog	  |		2024-12-02 22:11:10.250 OsmAnd Maps[9719:1258334]  !!!!! Objc NSLog SeneDelegate AppLaunchEventStart

----------


After:

Objc NSLog	  |		2024-12-02 22:02:19.519 OsmAnd Maps[9678:1252484]  !!!!! Objc NSLog SceneDelegate AppLaunchEventStart

Objc OALog	  |		INFO: 2024-12-02 22:02:19.519  [MainTread 259]   !!!!! Objc OALog SceneDelegate AppLaunchEventStart

Swift print()      |		!!!!! SwiftPrint addWidgetLayerDecorator

Swift OALog	  |		INFO: 2024-12-02 22:31:32.054  [MainTread 259]   !!!!! Swift OALog() addWidgetLayerDecorator

cpp printp	  |		!!!!! cpp printp MapRenderer::setZoom()

cpp std::cout     |		!!!!! cpp std::cout MapRenderer::setZoom()

----------
```

[old Dec 02, 2024 22:11.log](https://github.com/user-attachments/files/17982536/old.Dec.02.2024.22.11.log)
[new Dec 02, 2024 22:02:19.log](https://github.com/user-attachments/files/17982537/new.Dec.02.2024.22.02.19.log)

- Improved New OALog version output. Now it prints more information about thread:

```
before:
OsmAnd Maps[9678:1252484]

after:
[MainTread 259]
[Tread 11779]
[Tread 12345 Background]
```

- OALog now has option to show custom log level. Not only INFO.

```
OALog(@"Hello world")
INFO: 2024-12-02 22:02:19.519  [MainTread 259]  Hello world

OALogWithLevel(EOALogError, @"Hello world")
ERROR: 2024-12-02 22:02:19.519  [MainTread 259]  Hello world

levels:
EOALogVerbose,
EOALogDebug,
EOALogInfo,
EOALogWarning,
EOALogError
```

- OALog now can be used from Swift. Just use the same syntax like usual.
```OALog("Hello world")```
