### PR TITLE
add estimated time span info

### DIFF
--- a/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Resources/Localizations/en.lproj/Localizable.strings
@@ -794,6 +794,7 @@
 "time_of_day" = "Time of day";
 "shared_string_distance" = "Distance";
 "shared_string_time_span" = "Time span";
+"shared_string_estimated_time_span" = "Estimated time span";
 "shared_string_start_time" = "Start time";
 "shared_string_end_time" = "End time";
 "shared_string_time_moving" = "Time moving";

--- a/Sources/Controllers/MyPlaces/TracksSortModeHelper.swift
+++ b/Sources/Controllers/MyPlaces/TracksSortModeHelper.swift
@@ -139,7 +139,12 @@ import OsmAndShared
         let date = TracksSortModeHelper.dateFormatter.string(from: track.lastModifiedTime)
         let creationDate = TracksSortModeHelper.dateFormatter.string(from: track.creationDate)
         let distance = OAOsmAndFormatter.getFormattedDistance(track.totalDistance) ?? localizedString("shared_string_not_available")
-        let time = OAOsmAndFormatter.getFormattedTimeInterval(TimeInterval(track.timeSpan / 1000), shortFormat: true) ?? localizedString("shared_string_not_available")
+        
+        var time = localizedString("shared_string_not_available")
+        if let analysis = track.getAnalysis(), analysis.isTimeSpecified() {
+            time = OAOsmAndFormatter.getFormattedTimeInterval(TimeInterval(analysis.getDurationInSeconds()), shortFormat: true)
+        }
+        
         let waypointCount = "\(track.wptPoints)"
         let fullString = NSMutableAttributedString()
         let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.preferredFont(forTextStyle: .footnote), .foregroundColor: UIColor.textColorSecondary]

--- a/Sources/Controllers/MyPlaces/TracksViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksViewController.swift
@@ -331,6 +331,15 @@ final class TracksViewController: OACompoundViewController, UITableViewDelegate,
     
     fileprivate func createRowFor(track: GpxDataItem, section: OATableSectionData) {
         let trackRow = section.createNewRow()
+    
+        if let trackItem = currentFolder.getFlattenedTrackItems().first(where: { $0.gpxFilePath == track.gpxFilePath }) {
+            if let file = trackItem.getFile() {
+                let gpxFile = GpxUtilities.shared.loadGpxFile(file: file)
+                let analysis = gpxFile.getAnalysis(fileTimestamp: Int64(track.creationDate.timeIntervalSince1970))
+                track.setAnalysis(analysis: analysis)
+            }
+        }
+        
         let fileName = track.gpxFileName
         trackRow.cellType = OASimpleTableViewCell.reuseIdentifier
         trackRow.key = trackKey

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/MenuBuilder/OATrackMenuTabSegments.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/MenuBuilder/OATrackMenuTabSegments.mm
@@ -253,8 +253,10 @@
     {
         if (types.firstObject.integerValue == GPXDataSetTypeAltitude && types.lastObject.integerValue == GPXDataSetTypeSpeed)
         {
+            BOOL hasExptationTime = analysis.expectedRouteDuration > 0;
+            
             titles[@"top_left_title_string_value"] = OALocalizedString(@"shared_string_distance");
-            titles[@"top_right_title_string_value"] = OALocalizedString(@"shared_string_time_span");
+            titles[@"top_right_title_string_value"] = OALocalizedString(hasExptationTime ? @"shared_string_estimated_time_span":  @"shared_string_time_span");
             titles[@"bottom_left_title_string_value"] = OALocalizedString(@"shared_string_start_time");
             titles[@"bottom_right_title_string_value"] = OALocalizedString(@"shared_string_end_time");
             
@@ -267,9 +269,17 @@
                                                                   !joinSegments && track && track.generalTrack
                                                                   ? analysis.totalDistanceWithoutGaps : analysis.totalDistance];
             
-            descriptions[@"top_right_description_string_value"] = [OAOsmAndFormatter getFormattedTimeInterval:
-                                                                   !joinSegments && track && track.generalTrack
-                                                                   ? analysis.timeSpanWithoutGaps / 1000 : analysis.timeSpan / 1000 shortFormat:YES];
+            if (hasExptationTime)
+            {
+                descriptions[@"top_right_description_string_value"] = [OAOsmAndFormatter getFormattedTimeInterval:analysis.expectedRouteDuration / 1000 shortFormat:YES];
+            }
+            else
+            {
+                descriptions[@"top_right_description_string_value"] = [OAOsmAndFormatter getFormattedTimeInterval:
+                                                                       !joinSegments && track && track.generalTrack
+                                                                       ? analysis.timeSpanWithoutGaps / 1000 : analysis.timeSpan / 1000 shortFormat:YES];
+                
+            }
             
             NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
             [dateFormatter setDateFormat:@"HH:mm, MM-dd-yy"];


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3956)

Show estimated duration on second line
<img width="887" alt="Screenshot 2024-12-16 at 18 23 43" src="https://github.com/user-attachments/assets/575fdb37-44c9-4349-8b47-3515af8bce54" />

Show estimated time span on Track tab 
Rename Time span to "Estimated time span" (for estimated time span)
(no this feature in android yet)
<img width="873" alt="Screenshot 2024-12-16 at 20 25 26" src="https://github.com/user-attachments/assets/fa21e1d5-f808-4375-8855-bceec61cf41b" />

Tracks not from Plan Route still shows "Time span" label
<img width="515" alt="Screenshot 2024-12-16 at 20 25 58" src="https://github.com/user-attachments/assets/f5395239-b82b-4498-89b1-bca9079c5f28" />

