### PR TITLE
fix getCompositeIcon crash

### DIFF
--- a/Sources/Controllers/Map/Layers/OAFavoritesLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAFavoritesLayer.mm
@@ -166,11 +166,11 @@
 
     UIImage *shadowImage = [OATargetInfoViewController getIcon:[NSString stringWithFormat:@"ic_bg_point_%@_bottom", background]];
     if (!shadowImage)
-        shadowImage = [OAUtilities tintImageWithColor:[UIImage imageNamed:@"circle"] color:color];
+        shadowImage = [OAUtilities tintImageWithColor:[UIImage imageNamed:DEFAULT_ICON_SHAPE_KEY] color:color];
     
     UIImage *colorFilledImage = [OAUtilities tintImageWithColor:[UIImage imageNamed:[NSString stringWithFormat:@"ic_bg_point_%@_center", background]] color:color];
     if (!colorFilledImage)
-        colorFilledImage = [OAUtilities tintImageWithColor:[UIImage imageNamed:@"circle"] color:color];
+        colorFilledImage = [OAUtilities tintImageWithColor:[UIImage imageNamed:DEFAULT_ICON_SHAPE_KEY] color:color];
     
     UIImage *innerImage = [OAUtilities tintImageWithColor:[OATargetInfoViewController getIcon:icon size:innerImageCenterRect.size] color:UIColor.whiteColor];
     if (!innerImage)

--- a/Sources/Controllers/Map/Layers/OAGPXLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAGPXLayer.mm
@@ -1908,7 +1908,7 @@ colorizationScheme:(int)colorizationScheme
         return [OAFavoritesLayer getImageWithColor:point.color background:point.point.getBackgroundType icon:[@"mx_" stringByAppendingString:point.point.getIconName]];
     }
     OAFavoriteColor *def = [OADefaultFavorite nearestFavColor:OADefaultFavorite.builtinColors.firstObject];
-    return [OAFavoritesLayer getImageWithColor:def.color background:@"circle" icon:[@"mx_" stringByAppendingString:DEFAULT_ICON_NAME_KEY]];
+    return [OAFavoritesLayer getImageWithColor:def.color background:DEFAULT_ICON_SHAPE_KEY icon:[@"mx_" stringByAppendingString:DEFAULT_ICON_NAME_KEY]];
 }
 
 - (void) setPointVisibility:(id)object hidden:(BOOL)hidden

--- a/Sources/Controllers/Map/Layers/OAOsmEditsLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAOsmEditsLayer.mm
@@ -179,7 +179,7 @@
                 if (isNew)
                 {
                     bitmap = [OACompoundIconUtils createCompositeIconWithcolor:UIColorFromARGB(color_osm_edit)
-                                                                     shapeName:@"circle"
+                                                                     shapeName:DEFAULT_ICON_SHAPE_KEY
                                                                       iconName:type.name
                                                                     isFullSize:YES
                                                                           icon:type.icon
@@ -193,7 +193,7 @@
         if (!bitmap)
         {
             bitmap = [OACompoundIconUtils createCompositeIconWithcolor:UIColorFromARGB(color_osm_edit) 
-                                                             shapeName:@"circle"
+                                                             shapeName:DEFAULT_ICON_SHAPE_KEY
                                                               iconName:@"ic_custom_poi"
                                                             isFullSize:YES
                                                                   icon:[UIImage imageNamed:@"ic_custom_poi"]
@@ -370,7 +370,7 @@
 - (void)getOsmNoteBitmap:(sk_sp<SkImage> &)bitmap
 {
     UIImage *img = [UIImage mapSvgImageNamed:@"mx_special_information"];
-    bitmap = [OACompoundIconUtils createCompositeIconWithcolor:UIColorFromARGB(color_osm_edit) shapeName:@"circle" iconName:@"special_information" isFullSize:YES icon:img scale:_textSize];
+    bitmap = [OACompoundIconUtils createCompositeIconWithcolor:UIColorFromARGB(color_osm_edit) shapeName:DEFAULT_ICON_SHAPE_KEY iconName:@"special_information" isFullSize:YES icon:img scale:_textSize];
 }
 
 - (UIImage *) getPointIcon:(id)point

--- a/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
@@ -71,7 +71,7 @@
             _iconName = poiIconName;
         
         [p setIconNameIconName:_iconName];
-        [p setBackgroundTypeBackType:@"circle"];
+        [p setBackgroundTypeBackType:DEFAULT_ICON_SHAPE_KEY];
         [p setAddressAddress:address];
         NSDictionary<NSString *, NSString *> *extensions = [poi toTagValue:PRIVATE_PREFIX osmPrefix:OSM_PREFIX_KEY];
         [[p getExtensionsToWrite] addEntriesFromDictionary:extensions];

--- a/Sources/GPX/OAGPXDocumentPrimitives.h
+++ b/Sources/GPX/OAGPXDocumentPrimitives.h
@@ -21,6 +21,7 @@
 #define CREATION_TIME_EXTENSION @"creation_date"
 #define PICKUP_DATE_EXTENSION @"pickup_date"
 #define DEFAULT_ICON_NAME_KEY @"special_star"
+#define DEFAULT_ICON_SHAPE_KEY @"circle"
 #define PROFILE_TYPE_EXTENSION_KEY @"profile"
 
 #define PRIVATE_PREFIX @"amenity_"

--- a/Sources/Helpers/OAFavoritesHelper.mm
+++ b/Sources/Helpers/OAFavoritesHelper.mm
@@ -1089,6 +1089,13 @@ static NSOperationQueue *_favQueue;
 
 + (UIImage *) getCompositeIcon:(NSString *)icon backgroundIcon:(NSString *)backgroundIcon color:(UIColor *)color
 {
+    if (!icon)
+        icon = DEFAULT_ICON_NAME_KEY;
+    if (!backgroundIcon)
+        backgroundIcon = DEFAULT_ICON_SHAPE_KEY;
+    if (!color)
+        color = [OADefaultFavorite getDefaultColor];
+    
     UIImage *resultImg;
     NSString *backgrounfIconName = [@"bg_point_" stringByAppendingString:backgroundIcon];
     UIImage *backgroundImg = [UIImage imageNamed:backgrounfIconName];

--- a/Sources/Models/OAFavoriteItem.mm
+++ b/Sources/Models/OAFavoriteItem.mm
@@ -388,7 +388,7 @@ static NSArray<OASpecialPointType *> *_values = @[_home, _work, _parking];
     if (!self.favorite->getIcon().isNull())
         _icon = self.favorite->getIcon().toNSString();
     else
-        _icon = @"special_star";
+        _icon = DEFAULT_ICON_NAME_KEY;
     return _icon;
 }
 
@@ -411,7 +411,7 @@ static NSArray<OASpecialPointType *> *_values = @[_home, _work, _parking];
             return _backgroundIcon;
         }
     }
-    _backgroundIcon = @"circle";
+    _backgroundIcon = DEFAULT_ICON_SHAPE_KEY;
     return _backgroundIcon;
 }
 

--- a/Sources/Models/OAGpxWptItem.mm
+++ b/Sources/Models/OAGpxWptItem.mm
@@ -107,8 +107,8 @@
 
 - (UIImage *) getCompositeIcon
 {
-    NSString *iconName = _point.getIconName ?: @"special_star";
-    NSString *backgroundIconName = _point.getBackgroundType ?: @"circle";
+    NSString *iconName = _point.getIconName ?: DEFAULT_ICON_NAME_KEY;
+    NSString *backgroundIconName = _point.getBackgroundType ?: DEFAULT_ICON_SHAPE_KEY;
     return [OAFavoritesHelper getCompositeIcon:iconName backgroundIcon:backgroundIconName color:UIColorFromRGBA([_point getColor])];
 }
 


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4207)

crash:  OsmAnd Maps: +[OAFavoritesHelper getCompositeIcon:backgroundIcon:color:] + 80
<img width="1728" alt="Screenshot 2024-12-17 at 17 50 55" src="https://github.com/user-attachments/assets/c70cd852-76fc-49bb-a165-fd9e1ab8832a" />

Can't reproduce. I just added initing with default values from another getCompositeIcon() method. I think it should fix the problem.
<img width="1130" alt="Screenshot 2024-12-17 at 18 04 54" src="https://github.com/user-attachments/assets/791ebc48-d198-4f82-9135-96e0488ecb50" />
