### PR TITLE
street name widget ref overlay fix

### DIFF
--- a/Sources/Controllers/Map/Widgets/OATopTextView.mm
+++ b/Sources/Controllers/Map/Widgets/OATopTextView.mm
@@ -62,6 +62,7 @@
 @property (weak, nonatomic) IBOutlet UIButton *waypointButtonRemove;
 
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *exitRefTextContainerWidthConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *stackViewLeadingConstraint;
 
 @end
 
@@ -101,6 +102,9 @@
     UIButton *_shadowButton;
     UIButton *_shadowWaypointButton;
 }
+
+static int stackViewLeadingDefaultValue = 2;
+static int stackViewLeadingToRefViewPadding = 16;
 
 - (instancetype) init
 {
@@ -220,6 +224,8 @@
         _shieldIcon.frame = shieldFrame;
     }
     CGRect exitRefFrame = _exitRefTextContainer.frame;
+    
+    self.stackViewLeadingConstraint.constant = stackViewLeadingDefaultValue;
     if (showExit)
     {
         CGSize size = [OAUtilities calculateTextBounds:_exitRefText.text width:w font:[UIFont systemFontOfSize:17 weight:UIFontWeightSemibold]];
@@ -231,6 +237,8 @@
             self.exitRefTextContainerWidthConstraint.constant = size.width;
         else
             self.exitRefTextContainerWidthConstraint.constant = 40;
+        
+        self.stackViewLeadingConstraint.constant = self.exitRefTextContainerWidthConstraint.constant + stackViewLeadingToRefViewPadding;
     }
     
     CGFloat margin = _turnView.subviews.count > 0 ? 4 + _turnView.bounds.size.width + 2 : 2;

--- a/Sources/Views/XibViews/OATopTextView.xib
+++ b/Sources/Views/XibViews/OATopTextView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -215,6 +215,7 @@
                 <outlet property="exitRefTextContainer" destination="3ov-dr-SOd" id="yHV-0g-beC"/>
                 <outlet property="exitRefTextContainerWidthConstraint" destination="c2u-Jf-ukc" id="xpu-nB-UGX"/>
                 <outlet property="shieldIcon" destination="Z8c-N6-WrV" id="AtL-uY-5pa"/>
+                <outlet property="stackViewLeadingConstraint" destination="wqD-d3-ul6" id="fYy-2t-Lqb"/>
                 <outlet property="turnView" destination="7DR-I9-K8G" id="0nc-tE-Svh"/>
                 <outlet property="waypointButtonMore" destination="6Px-uI-aHL" id="sPB-gq-CHR"/>
                 <outlet property="waypointButtonRemove" destination="hXh-NU-GkP" id="iG5-5x-aCQ"/>


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4184)

With Ref before/after (fixed)
<img width="965" alt="Screenshot 2024-12-20 at 15 05 11" src="https://github.com/user-attachments/assets/c641faf0-030a-4451-acaf-a8dd176933a8" />
<img width="965" alt="Screenshot 2024-12-20 at 15 09 17" src="https://github.com/user-attachments/assets/bbefccd1-bacf-4b3f-a138-5af936ef033d" />

Without Ref before/after (no changes)
<img width="965" alt="Screenshot 2024-12-20 at 15 06 11" src="https://github.com/user-attachments/assets/412dc372-61c4-4539-9172-ff9c8799486f" />
<img width="965" alt="Screenshot 2024-12-20 at 15 10 19" src="https://github.com/user-attachments/assets/b509a65d-14cf-40eb-8ae3-4143ab25fe48" />

Navigation from 
48.14183° N, 13.99145° E     
to   
48.14850 13.97646


