### PR TITLE
fix animations settings export

### DIFF
--- a/Sources/Helpers/OAAppSettings.m
+++ b/Sources/Helpers/OAAppSettings.m
@@ -3888,10 +3888,10 @@ static NSString *kMapScaleKey = @"MAP_SCALE";
         [_globalPreferences setObject:_settingUseAnalytics forKey:@"use_analytics"];
         [_globalPreferences setObject:_showDownloadMapDialog forKey:@"show_download_map_dialog"];
         
-        _animateMyLocation = [OACommonBoolean withKey:animateMyLocationKey defValue:YES];
-        _doNotUseAnimations = [OACommonBoolean withKey:doNotUseAnimationsKey defValue:NO];
+        _animateMyLocation = [[OACommonBoolean withKey:animateMyLocationKey defValue:YES] makeProfile];
+        _doNotUseAnimations = [[OACommonBoolean withKey:doNotUseAnimationsKey defValue:NO] makeProfile];
         [_profilePreferences setObject:_animateMyLocation forKey:@"animate_my_location"];
-        [_profilePreferences setObject:_animateMyLocation forKey:@"do_not_use_animations"];
+        [_profilePreferences setObject:_doNotUseAnimations forKey:@"do_not_use_animations"];
         
         _liveUpdatesPurchased = [[OACommonBoolean withKey:liveUpdatesPurchasedKey defValue:NO] makeGlobal];
         _settingOsmAndLiveEnabled = [[[OACommonBoolean withKey:settingOsmAndLiveEnabledKey defValue:NO] makeGlobal] makeShared];


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4214)

synced this settings:
```
public final OsmandPreference<Boolean> ANIMATE_MY_LOCATION = new BooleanPreference(this, "animate_my_location", true).makeProfile().cache();
public final OsmandPreference<Boolean> DO_NOT_USE_ANIMATIONS = new BooleanPreference(this, "do_not_use_animations", false).makeProfile().cache();
```

<img width="1728" alt="Screenshot 2025-01-14 at 12 35 35" src="https://github.com/user-attachments/assets/2e8d772f-1190-4530-af8e-2d7f8f6c5692" />
