### PR TITLE
Wpt tags fix

### DIFF
--- a/Sources/Controllers/TargetMenu/Favorites/OAFavoriteViewController.mm
+++ b/Sources/Controllers/TargetMenu/Favorites/OAFavoriteViewController.mm
@@ -56,7 +56,9 @@
 
 - (void) acquireOriginObject
 {
-    _originObject = [OAPOIHelper findPOIByOriginName:_favorite.getAmenityOriginName lat:_favorite.getLatitude lon:_favorite.getLongitude];
+    NSString *originName = _favorite.getAmenityOriginName;
+    if (originName && originName.length > 0)
+        _originObject = [OAPOIHelper findPOIByOriginName:_favorite.getAmenityOriginName lat:_favorite.getLatitude lon:_favorite.getLongitude];
     if (!_originObject)
         _originObject = [_favorite getAmenity];
 }

--- a/Sources/Controllers/TargetMenu/GPX/OAGPXWptViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/OAGPXWptViewController.mm
@@ -64,7 +64,9 @@
 
 - (void) acquireOriginObject
 {
-    _originObject = [OAPOIHelper findPOIByOriginName:_wpt.getAmenityOriginName lat:_wpt.point.getLatitude lon:_wpt.point.getLongitude];
+    NSString *originName = _wpt.getAmenityOriginName;
+    if (originName && originName.length > 0)
+        _originObject = [OAPOIHelper findPOIByOriginName:originName lat:_wpt.point.getLatitude lon:_wpt.point.getLongitude];
     if (!_originObject)
         _originObject = [_wpt getAmenity];
 }

--- a/Sources/Controllers/TargetMenu/PointEditing/OAFavoriteEditingHandler.mm
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAFavoriteEditingHandler.mm
@@ -60,7 +60,10 @@
         [_favorite setIcon:_iconName];
         [_favorite setColor:favCol.color];
         [_favorite setAmenity:poi];
-        [_favorite setAmenityOriginName:poi.toStringEn];
+        
+        NSString *originName = poi.toStringEn;
+        if (originName.length > 0)
+            [_favorite setAmenityOriginName:originName];
     }
     return self;
 }

--- a/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
@@ -75,7 +75,10 @@
         [p setAddressAddress:address];
         NSDictionary<NSString *, NSString *> *extensions = [poi toTagValue:PRIVATE_PREFIX osmPrefix:OSM_PREFIX_KEY];
         [[p getExtensionsToWrite] addEntriesFromDictionary:extensions];
-        [p setAmenityOriginNameOriginName:poi.toStringEn];
+        
+        NSString *originName = poi.toStringEn;
+        if (originName.length > 0)
+            [p setAmenityOriginNameOriginName:originName];
 
         wpt.color = color;
         wpt.point = p;

--- a/Sources/POI/OAPOI.mm
+++ b/Sources/POI/OAPOI.mm
@@ -389,7 +389,10 @@ static NSArray<NSString *> *const HIDDEN_EXTENSIONS = @[
     NSString *nameEn = self.localizedNames[@"en"] ? self.localizedNames[@"en"] : @"";
     NSString *type = self.type.category.name ? self.type.category.name : @"";
     NSString *subType = self.type.name ? self.type.name : @"";
-    return [NSString stringWithFormat:@"Amenity:%@: %@:%@", nameEn, type, subType];
+    if (nameEn.length == 0 && type.length == 0 && subType.length == 0)
+        return @"";
+    else
+        return [NSString stringWithFormat:@"Amenity:%@: %@:%@", nameEn, type, subType];
 }
 
 - (NSDictionary<NSString *, NSString *> *) toTagValue:(NSString *)privatePrefix osmPrefix:(NSString *)osmPrefix

--- a/Sources/POI/OAPOI.mm
+++ b/Sources/POI/OAPOI.mm
@@ -474,7 +474,7 @@ static NSArray<NSString *> *const HIDDEN_EXTENSIONS = @[
                     {
                         [res appendString:SEPARATOR];
                     }
-                    [res appendString:poiType.value ? poiType.value : poiType.name];
+                    [res appendString:poiType.value ?: poiType.name];
                 }
                 result[categoryName] = res;
             }

--- a/Sources/POI/OAPOI.mm
+++ b/Sources/POI/OAPOI.mm
@@ -474,7 +474,7 @@ static NSArray<NSString *> *const HIDDEN_EXTENSIONS = @[
                     {
                         [res appendString:SEPARATOR];
                     }
-                    [res appendString:poiType.name];
+                    [res appendString:poiType.value ? poiType.value : poiType.name];
                 }
                 result[categoryName] = res;
             }
@@ -528,8 +528,9 @@ static NSArray<NSString *> *const HIDDEN_EXTENSIONS = @[
             else
             {
                 NSString *shortKey = [key componentsSeparatedByString:@":"].lastObject;
+                NSString *trimmedKey = [key stringByReplacingOccurrencesOfString:COLLAPSABLE_PREFIX withString:@""];
                 if (![HIDDEN_EXTENSIONS containsObject:shortKey] && ![HIDDEN_EXTENSIONS containsObject:key] && map[key].length > 0)
-                    additionalInfo[key] = map[key];
+                    additionalInfo[trimmedKey] = map[key];
             }
         }
         if (!type)


### PR DESCRIPTION
[issue](url)

Don't write to file amenity_origin tag if it is empty.

Tags - before:

<img width="1200" alt="Screenshot 2025-01-29 at 15 41 26" src="https://github.com/user-attachments/assets/cf0bc921-f90c-4a21-b70b-aa1210916e73" />

Tags - after:

<img width="1200" alt="Screenshot 2025-01-29 at 15 39 43" src="https://github.com/user-attachments/assets/63413ccf-a040-465b-9485-83e3c9a33c10" />

---

Context menu fix.

Original POI:

<img width="1136" alt="Screenshot 2025-01-29 at 17 07 47" src="https://github.com/user-attachments/assets/114ebbce-2572-4d2d-b10a-1b2f058b1fc3" />

Waypoint without map - before:

<img width="1136" alt="Screenshot 2025-01-29 at 17 10 32" src="https://github.com/user-attachments/assets/b4361fd0-859c-4c89-9894-b1e6f536ecb1" />

Waypoint without map - after:

<img width="1136" alt="Screenshot 2025-01-29 at 17 49 21" src="https://github.com/user-attachments/assets/01ca2419-779c-4095-9420-357961d50b60" />





