### PR TITLE
wpt empty tags fix

### DIFF
--- a/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
@@ -263,7 +263,7 @@
 
 - (void)setGroup:(NSString *)groupName color:(UIColor *)color save:(BOOL)save
 {
-    _gpxWpt.point.category = groupName;
+    _gpxWpt.point.category = groupName.length > 0 ? groupName : nil;
     OASInt *colorToSave = [[OASInt alloc] initWithInt:[color toARGBNumber]];
     [_gpxWpt.point setColorColor:colorToSave];
     _gpxWpt.color = color;
@@ -300,14 +300,14 @@
 
 - (void)savePoint:(OAPointEditingData *)data newPoint:(BOOL)newPoint
 {
-    [_gpxWpt.point setName:data.name];
-    [_gpxWpt.point setDesc:data.descr];
+    [_gpxWpt.point setName:data.name.length > 0 ? data.name : nil];
+    [_gpxWpt.point setDesc:data.descr.length > 0 ? data.descr : nil];
     [self setGroup:data.category color:data.color save:NO];
     [_gpxWpt.point setIconNameIconName:data.icon];
     [_gpxWpt.point setBackgroundTypeBackType:data.backgroundIcon];
     
     auto extension = _gpxWpt.point.getExtensionsToWrite;
-    extension[ADDRESS_EXTENSION_KEY] = data.address;
+    extension[ADDRESS_EXTENSION_KEY] = data.address.length > 0 ? data.address : nil;
     _gpxWpt.point.extensions = extension;
     
     _gpxWpt.docPath = _gpxFileName;


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-Issues/issues/2869#issuecomment-2631306907)

adding point with empty fields

<img width="492" alt="Screenshot 2025-02-10 at 20 43 56" src="https://github.com/user-attachments/assets/2c258eb7-dd54-4051-881b-0b8cdca747ef" />

before:

<img width="647" alt="Screenshot 2025-02-10 at 20 44 42" src="https://github.com/user-attachments/assets/422b63c3-a33f-459b-901f-8221f5d6d98e" />

after:

<img width="646" alt="Screenshot 2025-02-10 at 20 28 00" src="https://github.com/user-attachments/assets/6cd4eb61-3109-423c-9732-6c94e0668c2f" />
