### PR TITLE
always show detail screen for long text in context menu

### DIFF
--- a/Sources/Controllers/TargetMenu/POI/OAPOIViewController.mm
+++ b/Sources/Controllers/TargetMenu/POI/OAPOIViewController.mm
@@ -596,6 +596,9 @@ static const NSArray<NSString *> *kPrefixTags = @[@"start_date"];
                     textPrefix = translatedKey;
                 else
                     textPrefix = [OAUtilities capitalizeFirstLetter:convertedKey];
+                
+                if (!pt && !pType && !poiType)
+                    isText = YES;
             }
         }
 


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4334)

video: 

https://github.com/user-attachments/assets/445d04d4-6bae-4154-9e9e-cda6ae162e75

