### PR TITLE
Рage in Maps and Resources is not updated after downloading the map

### DIFF
--- a/Sources/Controllers/Resources/OAManageResourcesViewController.mm
+++ b/Sources/Controllers/Resources/OAManageResourcesViewController.mm
@@ -646,6 +646,8 @@ static BOOL _repositoryUpdated = NO;
 
         [_refreshRepositoryProgressHUD hide:YES];
     }
+
+    [_freeMemoryView update];
 }
 
 - (void)updateMultipleResources
@@ -2935,7 +2937,15 @@ static BOOL _repositoryUpdated = NO;
 
     if ([item isKindOfClass:[OALocalResourceItem class]])
     {
-        [self offerDeleteResourceOf:item];
+        [self offerDeleteResourceOf:item executeAfterSuccess:^{
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (_downloadingCellResourceHelper)
+                    [_downloadingCellResourceHelper cleanCellCache];
+                if (_downloadingCellMultipleResourceHelper)
+                    [_downloadingCellMultipleResourceHelper cleanCellCache];
+                [tableView reloadData];
+            });
+        }];
         [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
     }
 }

--- a/Sources/Controllers/Resources/OAManageResourcesViewController.mm
+++ b/Sources/Controllers/Resources/OAManageResourcesViewController.mm
@@ -646,8 +646,6 @@ static BOOL _repositoryUpdated = NO;
 
         [_refreshRepositoryProgressHUD hide:YES];
     }
-
-    [_freeMemoryView update];
 }
 
 - (void)updateMultipleResources
@@ -2937,13 +2935,17 @@ static BOOL _repositoryUpdated = NO;
 
     if ([item isKindOfClass:[OALocalResourceItem class]])
     {
+        __weak __typeof(self) weakSelf = self;
         [self offerDeleteResourceOf:item executeAfterSuccess:^{
             dispatch_async(dispatch_get_main_queue(), ^{
-                if (_downloadingCellResourceHelper)
-                    [_downloadingCellResourceHelper cleanCellCache];
-                if (_downloadingCellMultipleResourceHelper)
-                    [_downloadingCellMultipleResourceHelper cleanCellCache];
-                [tableView reloadData];
+                __strong __typeof(weakSelf) strongSelf = weakSelf;
+                if (strongSelf) {
+                    if (strongSelf->_downloadingCellResourceHelper)
+                        [strongSelf->_downloadingCellResourceHelper cleanCellCache];
+                    if (strongSelf->_downloadingCellMultipleResourceHelper)
+                        [strongSelf->_downloadingCellMultipleResourceHelper cleanCellCache];
+                    [tableView reloadData];
+                }
             });
         }];
         [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];

--- a/Sources/Helpers/DownloadingCellHelper/DownloadingCellBaseHelper.swift
+++ b/Sources/Helpers/DownloadingCellHelper/DownloadingCellBaseHelper.swift
@@ -346,6 +346,8 @@ class DownloadingCellBaseHelper: NSObject {
     
     func cleanCellCache() {
         cells.removeAll()
+        statuses.removeAll()
+        progresses.removeAll()
     }
     
     @objc func refreshDownloadingContent() {

--- a/Sources/Views/OAFreeMemoryView.h
+++ b/Sources/Views/OAFreeMemoryView.h
@@ -12,7 +12,4 @@
 
 - (instancetype) initWithFrame:(CGRect)frame localResourcesSize:(unsigned long long)localResourcesSize;
 
-- (void) update;
-- (void) setLocalResourcesSize:(unsigned long long)size;
-
 @end

--- a/Sources/Views/OAFreeMemoryView.m
+++ b/Sources/Views/OAFreeMemoryView.m
@@ -21,6 +21,7 @@
     double _freeVal;
 
     unsigned long long _localResourcesSize;
+    DirectoryObserver *_directoryObserver;
 }
 
 - (instancetype) initWithFrame:(CGRect)frame localResourcesSize:(unsigned long long)localResourcesSize
@@ -69,8 +70,14 @@
     [self addSubview:_freeMemLabel];
     
     [self update];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(memInfoDidChange:) name:@"DiskUsageChangedNotification" object:nil];
+
+    NSString *dataPath = [[OsmAndApp instance] documentsPath];
+    _directoryObserver = [[DirectoryObserver alloc] init:dataPath notificationName:@"DiskUsageChangedNotification"];
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(memInfoDidChange:)
+     name:@"DiskUsageChangedNotification" object:nil];
+    [_directoryObserver startObserving];
 }
 
 - (void) dealloc

--- a/Sources/Views/OAFreeMemoryView.m
+++ b/Sources/Views/OAFreeMemoryView.m
@@ -71,7 +71,7 @@
     
     [self update];
 
-    NSString *dataPath = [[OsmAndApp instance] documentsPath];
+    NSString *dataPath = [[[OsmAndApp instance] documentsPath] stringByAppendingPathComponent:RESOURCES_DIR];
     _directoryObserver = [[DirectoryObserver alloc] init:dataPath notificationName:@"DiskUsageChangedNotification"];
     [[NSNotificationCenter defaultCenter]
      addObserver:self

--- a/Sources/Views/OAFreeMemoryView.m
+++ b/Sources/Views/OAFreeMemoryView.m
@@ -147,6 +147,7 @@
     }
     NSString *deviceMemoryAvailableStr = [NSByteCountFormatter stringFromByteCount:deviceMemoryAvailable countStyle:NSByteCountFormatterCountStyleFile];
     _freeMemLabel.text = [NSString stringWithFormat:OALocalizedString(@"free"), deviceMemoryAvailableStr];
+    [_freeMemLabel sizeToFit];
 }
 
 - (void) drawRect:(CGRect)rect


### PR DESCRIPTION
Added `freeMemoryView` reload during `updateContent`. 
Clear `statuses` and `progresses` during `cleanCellCache` so that cells are configured during reload.
Added `tableView.reloadData` when deleting a map with a swipe.

video after fix:

https://github.com/user-attachments/assets/f4f66083-1857-468e-b7b2-fbce216acede

