### PR TITLE
poi_component_fix_nautical_row_blinking

### DIFF
--- a/Sources/Controllers/Cells/OACollectionSingleLineTableViewCell.m
+++ b/Sources/Controllers/Cells/OACollectionSingleLineTableViewCell.m
@@ -67,45 +67,40 @@
               forCellWithReuseIdentifier:cellIdentifier];
     }
 
-    [self.collectionView performBatchUpdates:^{
-        for (NSInteger i = 0; i < self.collectionView.numberOfSections; i ++)
-        {
-            [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:i]];
+    [self.collectionView reloadData];
+    UICollectionViewScrollDirection scrollDirection = [_collectionHandler getScrollDirection];
+    BOOL isHorizontal = scrollDirection == UICollectionViewScrollDirectionHorizontal;
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+        layout.scrollDirection = scrollDirection;
+        CGSize itemSize = [_collectionHandler getItemSize];
+        if (itemSize.width == 0) {
+            layout.estimatedItemSize = CGSizeMake(50, itemSize.height);
+            layout.itemSize = UICollectionViewFlowLayoutAutomaticSize;
+        } else {
+            layout.itemSize = itemSize;
         }
-    } completion:^(BOOL finished) {
-        UICollectionViewScrollDirection scrollDirection = [_collectionHandler getScrollDirection];
-        BOOL isHorizontal = scrollDirection == UICollectionViewScrollDirectionHorizontal;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            
-            UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-            layout.scrollDirection = scrollDirection;
-            CGSize itemSize = [_collectionHandler getItemSize];
-            if (itemSize.width == 0) {
-                layout.estimatedItemSize = CGSizeMake(50, itemSize.height);
-                layout.itemSize = UICollectionViewFlowLayoutAutomaticSize;
-            } else {
-                layout.itemSize = itemSize;
-            }
-            CGFloat spacing = [_collectionHandler getSpacing];
-            layout.minimumLineSpacing = spacing;
-            layout.minimumInteritemSpacing = spacing;
-            
-            [self.collectionView setCollectionViewLayout:layout animated:!_disableAnimationsOnStart];
+        CGFloat spacing = [_collectionHandler getSpacing];
+        layout.minimumLineSpacing = spacing;
+        layout.minimumInteritemSpacing = spacing;
+        
+        [self.collectionView setCollectionViewLayout:layout animated:!_disableAnimationsOnStart];
 
-            NSIndexPath *selectedIndexPath = [_collectionHandler getSelectedIndexPath];
-            if (selectedIndexPath.row != NSNotFound
-                && (_forceScrollOnStart || ![self.collectionView.indexPathsForVisibleItems containsObject:selectedIndexPath])
-                && selectedIndexPath.section < [collectionHandler sectionsCount]
-                && selectedIndexPath.row < [collectionHandler itemsCount:selectedIndexPath.section])
-            {
-                [self.collectionView scrollToItemAtIndexPath:selectedIndexPath
-                                            atScrollPosition:isHorizontal
-                    ? UICollectionViewScrollPositionCenteredHorizontally
-                    : UICollectionViewScrollPositionCenteredVertically
-                                                    animated:!_disableAnimationsOnStart];
-            }
-        });
-    }];
+        NSIndexPath *selectedIndexPath = [_collectionHandler getSelectedIndexPath];
+        if (selectedIndexPath.row != NSNotFound
+            && (_forceScrollOnStart || ![self.collectionView.indexPathsForVisibleItems containsObject:selectedIndexPath])
+            && selectedIndexPath.section < [collectionHandler sectionsCount]
+            && selectedIndexPath.row < [collectionHandler itemsCount:selectedIndexPath.section])
+        {
+            [self.collectionView scrollToItemAtIndexPath:selectedIndexPath
+                                        atScrollPosition:isHorizontal
+                ? UICollectionViewScrollPositionCenteredHorizontally
+                : UICollectionViewScrollPositionCenteredVertically
+                                                animated:!_disableAnimationsOnStart];
+        }
+    });
 }
 
 - (CGFloat)getLeftInsetToView:(UIView *)view


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/3942#issuecomment-2782751569)

video before:
when nautical row appears it for a while shows icons from disappearing at top row.

<img width="200" alt="Screenshot 2025-04-11 at 20 46 31" src="https://github.com/user-attachments/assets/f3dd1b51-444c-4793-8c8b-4833c7e6a2be" />
<img width="200" alt="Screenshot 2025-04-11 at 20 46 35" src="https://github.com/user-attachments/assets/bfdb46a7-299d-44b0-8b85-48285e607967" />
<img width="200" alt="Screenshot 2025-04-11 at 20 46 41" src="https://github.com/user-attachments/assets/65fc2c84-64dc-4572-a20b-ecf9f3d39a83" />

https://github.com/user-attachments/assets/de2d4031-ab64-470c-8d62-008e849cab49

---

video after: 
nautical row appears without lags.

<img width="200" alt="Screenshot 2025-04-11 at 20 50 27" src="https://github.com/user-attachments/assets/88b0e981-da2a-4a8e-a996-79d4f25b56cd" />

https://github.com/user-attachments/assets/8c6af08f-f23d-440e-b325-77fe2ac79483




