### PR TITLE
Endless spinner rotation in Maps & Recouces search

### DIFF
--- a/Sources/Helpers/OALocationParser.mm
+++ b/Sources/Helpers/OALocationParser.mm
@@ -518,16 +518,17 @@ static NSString *kRTLMark = @"\u200f";  // right-to-right mark
 + (NSString *)prepareLatLonWithDecimalCommas:(NSString *)ll
 {
     static const int DIGITS_BEFORE_COMMA = 1, DIGITS_AFTER_COMMA = 3;
-    for (int i = DIGITS_BEFORE_COMMA, first = -1; i < ll.length - DIGITS_AFTER_COMMA; i++) {
-        if (ll.length > i && [ll characterAtIndex:i] == ',') {
+    int length = (int)ll.length;
+    for (int i = DIGITS_BEFORE_COMMA, first = -1; i < length - DIGITS_AFTER_COMMA; i++) {
+        if (length > i && [ll characterAtIndex:i] == ',') {
             int before = 0, after = 0;
             for (int j = i - 1; j >= i - DIGITS_BEFORE_COMMA && j >= 0; j--) {
-                if (j >= 0 && j < ll.length && [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[ll characterAtIndex:j]]) {
+                if (j >= 0 && j < length && [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[ll characterAtIndex:j]]) {
                     before++;
                 }
             }
-            for (int j = i + 1; j <= i + DIGITS_AFTER_COMMA && j < ll.length && before >= DIGITS_BEFORE_COMMA; j++) {
-                if (j >= 0 && j < ll.length && [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[ll characterAtIndex:j]]) {
+            for (int j = i + 1; j <= i + DIGITS_AFTER_COMMA && j < length && before >= DIGITS_BEFORE_COMMA; j++) {
+                if (j >= 0 && j < length && [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[ll characterAtIndex:j]]) {
                     after++;
                 }
             }


### PR DESCRIPTION
The problem was that NSString.length is NSUInteger. When the value is less than DIGITS_AFTER_COMMA the difference is negative and the loop reaches NSUIntegerMax iterations.