### PR TITLE
Show map object tags in original order

### DIFF
--- a/Sources/POI/OARenderedObject.mm
+++ b/Sources/POI/OARenderedObject.mm
@@ -80,11 +80,11 @@
         renderedObject.localizedNames = names;
         
         MutableOrderedDictionary<NSString *, NSString *> *parsedTags = [MutableOrderedDictionary new];
-        const auto tags = obfMapObject->getResolvedAttributes();
+        const auto tags = obfMapObject->getResolvedAttributesListPairs();
         for (auto i = tags.begin(); i != tags.end(); ++i)
         {
-            NSString *key = i.key().toNSString();
-            NSString *value = i.value().toNSString();
+            NSString *key = i->first.toNSString();
+            NSString *value = i->second.toNSString();
             parsedTags[key] = value;
         }
         renderedObject.tags = parsedTags;


### PR DESCRIPTION
Don't change the order of tags of map objects