### PR TITLE
Increase radius for search POI from relation

### DIFF
--- a/Sources/Controllers/Map/Layers/OAPOILayer.mm
+++ b/Sources/Controllers/Map/Layers/OAPOILayer.mm
@@ -45,7 +45,8 @@
 #include <OsmAndCore/Map/BillboardRasterMapSymbol.h>
 #include <OsmAndCore/Map/IOnPathMapSymbol.h>
 
-#define kPoiSearchRadius 50
+#define kPoiSearchRadius 50 // AMENITY_SEARCH_RADIUS
+#define kPoiSearchRadiusForRelation 500 // AMENITY_SEARCH_RADIUS_FOR_RELATION
 #define kTrackSearchDelta 40
 
 const QString TAG_POI_LAT_LON = QStringLiteral("osmand_poi_lat_lon");
@@ -536,7 +537,8 @@ const QString TAG_POI_LAT_LON = QStringLiteral("osmand_poi_lat_lon");
                 const LatLon l = [self parsePoiLatLon:tags[TAG_POI_LAT_LON]];
                 point31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(l.lat, l.lon));
             }
-            auto bbox31 = (OsmAnd::AreaI)OsmAnd::Utilities::boundingBox31FromAreaInMeters(kPoiSearchRadius, point31);
+            int searchRadius = obfMapObject->id.isIdFromRelation() ? kPoiSearchRadiusForRelation : kPoiSearchRadius;
+            auto bbox31 = (OsmAnd::AreaI)OsmAnd::Utilities::boundingBox31FromAreaInMeters(searchRadius, point31);
             BOOL amenityFound = obfsDataInterface->findAmenityByObfMapObject(obfMapObject, &amenity, &bbox31);
 
             bool isRoute = !OsmAnd::NetworkRouteKey::getRouteKeys(tags).isEmpty();


### PR DESCRIPTION
Item from issue [Click on Relation POIs: issue with clicks on university POIs](https://github.com/osmandapp/OsmAnd/issues/21993):
 _Bug that relation close to original object was not found in POI - search radius should be increased_
 
 Code porting [from Android](https://github.com/osmandapp/OsmAnd/blob/64282a2ab7c9b061462c6ea8135f41fc45463214/OsmAnd/src/net/osmand/plus/views/layers/MapSelectionHelper.java#L721)