### PR TITLE
cloud_logout_crashfix_5.1

### DIFF
--- a/Sources/Backup/OABackupHelper.h
+++ b/Sources/Backup/OABackupHelper.h
@@ -85,7 +85,7 @@ static inline BOOL backupDebugLogs()
 - (void) deleteAllFiles:(NSArray<OAExportSettingsType *> *)types listener:(id<OAOnDeleteFilesListener>)listener;
 - (void) deleteOldFiles:(NSArray<OAExportSettingsType *> *)types;
 - (void) deleteOldFiles:(NSArray<OAExportSettingsType *> *)types listener:(id<OAOnDeleteFilesListener>)listener;
-- (void) deleteAccount:(NSString *)email token:(NSString *)token;
+- (NSError *) deleteAccount:(NSString *)email token:(NSString *)token;
 - (void) checkCode:(NSString *)email token:(NSString *)token;
 - (void) sendCode:(NSString *)email action:(NSString *)action;
 - (NSString *)downloadFile:(NSString *)filePath

--- a/Sources/Backup/OABackupImporter.m
+++ b/Sources/Backup/OABackupImporter.m
@@ -93,8 +93,16 @@
 
 - (void)main
 {
-    __strong id<OAOnDownloadFileListener> listener = _onDownloadFileListener;
-    _error = [OABackupHelper.sharedInstance downloadFile:_filePath remoteFile:_remoteFile listener:listener];
+    @try
+    {
+        __strong id<OAOnDownloadFileListener> listener = _onDownloadFileListener;
+        _error = [OABackupHelper.sharedInstance downloadFile:_filePath remoteFile:_remoteFile listener:listener];
+    }
+    @catch (NSException *exception)
+    {
+        _error = exception.reason;
+        NSLog(@"Error in OAFileDownloadTask.main(): %@", exception.reason);
+    }
 }
 
 @end

--- a/Sources/Controllers/Cloud/DeleteAccountViewController.swift
+++ b/Sources/Controllers/Cloud/DeleteAccountViewController.swift
@@ -281,9 +281,12 @@ final class DeleteAccountViewController: OABaseButtonsViewController, OAOnDelete
             status = .running
             updateUIAnimated { _ in
                 self.updateProgress(0)
-                self.backupHelper?.deleteAccount(OAAppSettings.sharedManager().backupUserEmail.get(), token: self.token)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    self.updateProgress(0.3)
+                if let error = self.backupHelper?.deleteAccount(OAAppSettings.sharedManager().backupUserEmail.get(), token: self.token) {
+                    self.updateProgress(1)
+                } else {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        self.updateProgress(0.3)
+                    }
                 }
             }
         }

--- a/Sources/Controllers/Cloud/OABackupTypesViewController.mm
+++ b/Sources/Controllers/Cloud/OABackupTypesViewController.mm
@@ -226,7 +226,14 @@
                                                            style:UIAlertActionStyleDestructive
                                                          handler:^(UIAlertAction * _Nonnull action)
                                                          {
-                                                             [_backupHelper deleteAllFiles:@[type] listener:self];
+                                                            @try
+                                                            {
+                                                                [_backupHelper deleteAllFiles:@[type] listener:self];
+                                                            }
+                                                            @catch (NSException *exception)
+                                                            {
+                                                                NSLog(@"Error in showClearTypeScreen() -> deleteAllFiles(): %@", exception.reason);
+                                                            }
                                                          }
     ];
 

--- a/Sources/Controllers/Cloud/OABaseBackupTypesViewController.mm
+++ b/Sources/Controllers/Cloud/OABaseBackupTypesViewController.mm
@@ -365,7 +365,14 @@
 
 - (void)onDeleteTypeData:(OAExportSettingsType *)settingsType
 {
-    [_backupHelper deleteAllFiles:@[settingsType] listener:self];
+    @try
+    {
+        [_backupHelper deleteAllFiles:@[settingsType] listener:self];
+    }
+    @catch (NSException *exception)
+    {
+        NSLog(@"Error in onDeleteTypeData() -> deleteAllFiles(): %@", exception.reason);
+    }
 }
 
 #pragma mark - OABackupTypesDelegate

--- a/Sources/Controllers/Cloud/OACloudAccountLoginViewController.m
+++ b/Sources/Controllers/Cloud/OACloudAccountLoginViewController.m
@@ -239,7 +239,14 @@
             }
             else
             {
-                [_backupHelper sendCode:email action:@"delete"];
+                @try
+                {
+                    [_backupHelper sendCode:email action:@"delete"];
+                }
+                @catch (NSException *exception)
+                {
+                    NSLog(@"Error in continueButtonPressed() -> sendCode(): %@", exception.reason);
+                }
             }
             _continuePressed = YES;
             [self updateScreen];

--- a/Sources/Controllers/Cloud/OACloudAccountVerificationViewController.m
+++ b/Sources/Controllers/Cloud/OACloudAccountVerificationViewController.m
@@ -197,9 +197,20 @@
     if ([BackupUtils isTokenValid:token])
     {
         if (_sourceType == EOACloudScreenSourceDeleteAccount)
-            [_backupHelper checkCode:[[OAAppSettings sharedManager].backupUserEmail get] token:token];
+        {
+            @try
+            {
+                [_backupHelper checkCode:[[OAAppSettings sharedManager].backupUserEmail get] token:token];
+            }
+            @catch (NSException *exception)
+            {
+                NSLog(@"Error in continueButtonPressed() -> checkCode(): %@", exception.reason);
+            }
+        }
         else
+        {
             [_backupHelper registerDevice:token];
+        }
     }
     else
     {

--- a/Sources/Controllers/Cloud/OADeleteAllVersionsBackupViewController.mm
+++ b/Sources/Controllers/Cloud/OADeleteAllVersionsBackupViewController.mm
@@ -364,10 +364,17 @@
 {
     BOOL isProgressOfDeleteAll = _screenType == EOADeleteAllDataProgressBackupScreenType;
     BOOL isProgressOfRemoveOld = _screenType == EOARemoveOldVersionsProgressBackupScreenType;
-    if (isProgressOfDeleteAll)
-        [[OABackupHelper sharedInstance] deleteAllFiles:nil listener:self];
-    else if (isProgressOfRemoveOld)
-        [[OABackupHelper sharedInstance] deleteOldFiles:nil listener:self];
+    @try
+    {
+        if (isProgressOfDeleteAll)
+            [[OABackupHelper sharedInstance] deleteAllFiles:nil listener:self];
+        else if (isProgressOfRemoveOld)
+            [[OABackupHelper sharedInstance] deleteOldFiles:nil listener:self];
+    }
+    @catch (NSException *exception)
+    {
+        NSLog(@"Error in deleteBackupFiles(): %@", exception.reason);
+    }
 }
 
 - (void)updateAfterFinished


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-Issues/issues/3065)

should be fixed:
- [x] [5136 Cloud logout crash testflight_feedback (20).zip](https://github.com/user-attachments/files/21426196/testflight_feedback.20.zip) (@nnngrach)
- [x] [5131 Purchases testflight_feedback (22).zip](https://github.com/user-attachments/files/21426197/testflight_feedback.22.zip) - @nnngrach

AI responce:

> The issue is that exceptions thrown in NSOperation's main method on background threads don't get caught by the try/catch block in the calling thread. When you call addOperations:waitUntilFinished:, the operations run on background threads, and exceptions from those threads don't propagate back to the main thread's try/catch.

Video explanation: 

https://github.com/user-attachments/assets/e6a7697f-63f2-4d04-aa14-ff3a37c15ce7