### PR TITLE
poi_lost_fields_quickfix_2

### DIFF
--- a/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
@@ -581,6 +581,7 @@
             
         if (targetPoint)
         {
+            [targetPoint initAdderssIfNeeded];
             [OARootViewController.instance.mapPanel showContextMenuWithPoints:@[targetPoint]];
         }
     }

--- a/Sources/Data/OATargetPoint.h
+++ b/Sources/Data/OATargetPoint.h
@@ -91,4 +91,6 @@ typedef NS_ENUM(NSInteger, OATargetPointType)
 @property (nonatomic) NSInteger sortIndex;
 @property (nonatomic) NSString* symbolGroupId;
 
+- (void)initAdderssIfNeeded;
+
 @end

--- a/Sources/Data/OATargetPoint.m
+++ b/Sources/Data/OATargetPoint.m
@@ -9,10 +9,47 @@
 #import "OATargetPoint.h"
 #import "OAPointDescription.h"
 #import "OAUtilities.h"
+#import "OAReverseGeocoder.h"
+#import "Localization.h"
+#import "OAPOI.h"
 
 @implementation OATargetPoint
 {
     OAPointDescription *_pd;
+}
+
+- (void)initAdderssIfNeeded
+{
+    if (self.addressFound)
+        return;
+    
+    NSString *addressString = nil;
+    BOOL isAddressFound = NO;
+    NSString *formattedTargetName = nil;
+    NSString *roadTitle = [[OAReverseGeocoder instance] lookupAddressAtLat:_location.latitude lon:_location.longitude];
+    if (!roadTitle || roadTitle.length == 0)
+    {
+        addressString = OALocalizedString(@"map_no_address");
+    }
+    else
+    {
+        addressString = roadTitle;
+        isAddressFound = YES;
+    }
+    
+    if (isAddressFound || addressString)
+    {
+        formattedTargetName = addressString;
+    }
+    else
+    {
+        formattedTargetName = [OAPointDescription getLocationName:_location.latitude lon:_location.longitude sh:NO];
+    }
+    
+    if (NSStringIsEmpty(_title))
+        _title = formattedTargetName;
+    _titleAddress = roadTitle;
+    _addressFound = isAddressFound;
 }
 
 - (OAPointDescription *) pointDescription

--- a/Sources/POI/OAPOI.mm
+++ b/Sources/POI/OAPOI.mm
@@ -508,7 +508,10 @@ static NSArray<NSString *> *const HIDDEN_EXTENSIONS = @[
         _values[tag] = value;
         
         if ([tag isEqualToString:OPENING_HOURS_TAG])
+        {
             self.openingHours = value;
+            self.hasOpeningHours = YES;
+        }
     }
 }
 
@@ -793,7 +796,10 @@ static NSArray<NSString *> *const HIDDEN_EXTENSIONS = @[
             if (subType)
                 amenity.subType = subType;
             if (openingHours)
+            {
                 amenity.openingHours = openingHours;
+                amenity.hasOpeningHours = YES;
+            }
             [amenity setValues:additionalInfo];
         }
     }


### PR DESCRIPTION
review for https://github.com/osmandapp/OsmAnd-Issues/issues/2917

added time and adders in header.

before / after: 
<img width="1136" height="1141" alt="Screenshot 2025-08-15 at 14 24 07" src="https://github.com/user-attachments/assets/36f466e6-7afd-41c6-88c3-7d7e80b65893" />
<img width="1136" height="1141" alt="Screenshot 2025-08-15 at 15 22 38" src="https://github.com/user-attachments/assets/21672dd6-6686-44d3-adb6-e4e40cd90195" />
