### PR TITLE
osm_online_note_contex_menu_fix

### DIFF
--- a/Sources/Controllers/Map/Helpers/OAMapSelectionHelper.mm
+++ b/Sources/Controllers/Map/Helpers/OAMapSelectionHelper.mm
@@ -101,10 +101,6 @@ static NSString *TAG_POI_LAT_LON = @"osmand_poi_lat_lon";
     
     for (OAMapLayer *layer in layers)
     {
-        // Android doesn't have that layer here
-        if ([layer isKindOfClass:OAGPXRecLayer.class])
-            continue;
-        
         if ([layer conformsToProtocol:@protocol(OAContextMenuProvider)])
         {
             id<OAContextMenuProvider> provider = ((id<OAContextMenuProvider>)layer);

--- a/Sources/Controllers/Map/Helpers/OAMapSelectionHelper.mm
+++ b/Sources/Controllers/Map/Helpers/OAMapSelectionHelper.mm
@@ -102,8 +102,7 @@ static NSString *TAG_POI_LAT_LON = @"osmand_poi_lat_lon";
     for (OAMapLayer *layer in layers)
     {
         // Android doesn't have that layer here
-        if ([layer isKindOfClass:OAOsmBugsLayer.class] ||
-            [layer isKindOfClass:OAGPXRecLayer.class])
+        if ([layer isKindOfClass:OAGPXRecLayer.class])
             continue;
         
         if ([layer conformsToProtocol:@protocol(OAContextMenuProvider)])

--- a/Sources/Core/OAOsmNotesMapLayerProvider.h
+++ b/Sources/Core/OAOsmNotesMapLayerProvider.h
@@ -106,5 +106,7 @@ public:
     virtual void obtainDataAsync(const IMapDataProvider::Request& request,
                                  const IMapDataProvider::ObtainDataAsyncCallback callback,
                                  const bool collectMetric = false) override;
+    
+    QList<std::shared_ptr<const OAOnlineOsmNote>> getNotesCache() const;
 };
 

--- a/Sources/Core/OAOsmNotesMapLayerProvider.mm
+++ b/Sources/Core/OAOsmNotesMapLayerProvider.mm
@@ -80,6 +80,11 @@ bool OAOsmNotesMapLayerProvider::queryOsmNotes(const OsmAnd::AreaI &bbox31, cons
     return data.size() > 0 ? parseResponse(data, bbox31, zoom) : false;
 }
 
+QList<std::shared_ptr<const OAOnlineOsmNote>> OAOsmNotesMapLayerProvider::getNotesCache() const
+{
+    return _notesCache;
+}
+
 bool OAOsmNotesMapLayerProvider::parseResponse(const QByteArray &buffer,
                                                const OsmAnd::AreaI &bbox31,
                                                const OsmAnd::ZoomLevel &zoom)


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4853)

Before - Testflight r5.0:

<img width="200" height="2436" alt="IMG_0409" src="https://github.com/user-attachments/assets/1e99d6a5-c01b-49ed-a1f8-7f1bed91b25a" />

Before - master:

<img width="958" height="911" alt="Screenshot 2025-09-04 at 22 11 47" src="https://github.com/user-attachments/assets/129692ff-c8b9-4731-8ec3-aa05e9cc6adc" />

After - fix:

<img width="958" height="909" alt="Screenshot 2025-09-05 at 01 19 43" src="https://github.com/user-attachments/assets/9b668609-a8f4-4f39-a34c-5be291405c36" />
