### PR TITLE
crash fixes

### DIFF
--- a/Sources/Controllers/Map/Widgets/OATextInfoWidget.mm
+++ b/Sources/Controllers/Map/Widgets/OATextInfoWidget.mm
@@ -562,7 +562,7 @@ NSString * const kSizeStylePref = @"simple_widget_size";
 
 - (void) setTextNoUpdateVisibility:(NSString *)text subtext:(NSString *)subtext
 {
-    if ([_text isEqualToString:text] && [_subtext isEqualToString:subtext])
+    if (NSStringsEqual(_text, text) && NSStringsEqual(_subtext, subtext))
         return;
     if (text.length == 0 && subtext.length == 0)
     {

--- a/Sources/Helpers/OAUtilities.h
+++ b/Sources/Helpers/OAUtilities.h
@@ -43,16 +43,26 @@ static inline UIColor * colorFromARGB(NSInteger rgbValue)
     return UIColorFromARGB(rgbValue);
 }
 
-static inline BOOL NSStringIsEmpty(NSString * _Nullable string) {
+static inline BOOL NSStringIsEmpty(NSString * _Nullable string)
+{
     return !string || string.length == 0;
 }
 
-static inline BOOL NSArrayIsEmpty(NSArray * _Nullable array) {
+static inline BOOL NSArrayIsEmpty(NSArray * _Nullable array)
+{
     return !array || array.count == 0;
 }
 
-static inline BOOL NSDictionaryIsEmpty(NSDictionary * _Nullable dictionary) {
+static inline BOOL NSDictionaryIsEmpty(NSDictionary * _Nullable dictionary)
+{
     return !dictionary || dictionary.count == 0;
+}
+
+static inline BOOL NSStringsEqual(NSString * _Nullable a, NSString * _Nullable b)
+{
+    if (a == nil || b == nil)
+        return a == b;
+    return [a isEqualToString:b];
 }
 
 static inline void executeOnMainThread(dispatch_block_t block)

--- a/Sources/Plugins/ExternalSensorsPlugin/BLE/DeviceHelper.swift
+++ b/Sources/Plugins/ExternalSensorsPlugin/BLE/DeviceHelper.swift
@@ -102,7 +102,9 @@ final class DeviceHelper: NSObject {
                 device.deviceType = savedDevice.deviceType
                 device.setPeripheral(peripheral: peripheral)
                 device.configure()
-                device.addObservers()
+                executeOnMainThread({
+                    device.addObservers()
+                })
                 return device
             } else {
                 return nil


### PR DESCRIPTION
- Replaced direct NSString comparisons with NSStringsEqual(_Nullable a, _Nullable b)
  to safely handle nil values.
- Fixes crash caused by redundant updates in the widget panel when _subtext or text is nil.
- Fix crash: addObservers