### PR TITLE
route_shileds_text_size_fix

### DIFF
--- a/Sources/Controllers/Map/OANetworkRouteDrawable.h
+++ b/Sources/Controllers/Map/OANetworkRouteDrawable.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable UIImage *) getIcon;
 
-+ (UIImage *) getIconByAmenityShieldTags:(OAPOI *)amenity;
++ (UIImage *) getIconByAmenityShieldTags:(OAPOI *)amenity textSize:(float)textSize;
 
 @end
 

--- a/Sources/Controllers/Map/OANetworkRouteDrawable.mm
+++ b/Sources/Controllers/Map/OANetworkRouteDrawable.mm
@@ -26,6 +26,7 @@
 {
     OARouteKey *_routeKey;
     BOOL _isNight;
+    float _textSize;
     OAMapRendererEnvironment *_env;
 }
 
@@ -35,9 +36,15 @@
     if (self) {
         _routeKey = routeKey;
         _isNight = OADayNightHelper.instance.isNightMode;
+        _textSize = 12;
         _env = OARootViewController.instance.mapPanel.mapViewController.mapRendererEnv;
     }
     return self;
+}
+
+- (void)setTextSize:(float)textSize
+{
+    _textSize = textSize;
 }
 
 - (UIImage *)getIcon
@@ -104,9 +111,8 @@
     evaluationResult.getBooleanValue(env->styleBuiltinValueDefs->id_OUTPUT_TEXT_BOLD, bold);
     textStyle.setBold(bold);
 
-    float textSize = 12;
-    evaluationResult.getFloatValue(env->styleBuiltinValueDefs->id_OUTPUT_TEXT_SIZE, textSize);
-    textStyle.setSize(textSize);
+    evaluationResult.getFloatValue(env->styleBuiltinValueDefs->id_OUTPUT_TEXT_SIZE, _textSize);
+    textStyle.setSize(_textSize);
 
     const auto rasterizer = OsmAnd::TextRasterizer::getDefault();
     const auto textImage = rasterizer->rasterize(text, textStyle);
@@ -117,7 +123,7 @@
     return nil;
 }
 
-+ (UIImage *) getIconByAmenityShieldTags:(OAPOI *)amenity
++ (UIImage *) getIconByAmenityShieldTags:(OAPOI *)amenity textSize:(float)textSize
 {
     NSMutableDictionary<NSString *, NSString *> *shieldTags = [NSMutableDictionary new];
     for (NSString *tag in amenity.values.allKeys)
@@ -129,6 +135,7 @@
     if (shieldRouteKey)
     {
         OANetworkRouteDrawable *drawable = [[OANetworkRouteDrawable alloc] initWithRouteKey:shieldRouteKey];
+        [drawable setTextSize:textSize];
         return drawable.getIcon;
     }
     return nil;

--- a/Sources/Controllers/TargetMenu/Search/OAQuickSearchTableController.mm
+++ b/Sources/Controllers/TargetMenu/Search/OAQuickSearchTableController.mm
@@ -764,7 +764,7 @@
                     
                     if ([poi isRouteTrack])
                     {
-                        UIImage *shieldIcon = [OANetworkRouteDrawable getIconByAmenityShieldTags:poi];
+                        UIImage *shieldIcon = [OANetworkRouteDrawable getIconByAmenityShieldTags:poi textSize:18];
                         if (shieldIcon)
                             cell.titleIcon.image = shieldIcon;
                     }


### PR DESCRIPTION
[issue with bug](https://github.com/osmandapp/OsmAnd-Issues/issues/2917#issuecomment-3274403876)
[previous pr](https://github.com/osmandapp/OsmAnd-iOS/pull/4838)

before / after:

<img width="1136" height="908" alt="Screenshot 2025-09-15 at 15 02 43" src="https://github.com/user-attachments/assets/163677db-440c-4cd7-b38b-ee3c4cf97553" />
<img width="1136" height="908" alt="Screenshot 2025-09-15 at 15 09 32" src="https://github.com/user-attachments/assets/5239a86c-55a6-452a-998c-f38294999498" />
