### PR TITLE
Fix search querry resetting

### DIFF
--- a/Sources/Controllers/Panels/OAMapPanelViewController.h
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.h
@@ -234,6 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) openSearch;
 - (void) openSearch:(nullable NSObject *)object location:(nullable CLLocation *)location;
+- (void) openSearch:(NSObject *)object location:(CLLocation *)location searchQuery:(NSString *)searchQuery;
 - (void) openSearch:(OAQuickSearchType)searchType;
 - (void) openSearch:(OAQuickSearchType)searchType location:(nullable CLLocation *)location tabIndex:(NSInteger)tabIndex;
 - (void) openSearch:(OAQuickSearchType)searchType location:(nullable CLLocation *)location tabIndex:(NSInteger)tabIndex searchQuery:(nullable NSString *)searchQuery object:(nullable NSObject *)object;

--- a/Sources/Controllers/Panels/OAMapPanelViewController.h
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.h
@@ -234,7 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) openSearch;
 - (void) openSearch:(nullable NSObject *)object location:(nullable CLLocation *)location;
-- (void) openSearch:(NSObject *)object location:(CLLocation *)location searchQuery:(NSString *)searchQuery;
+- (void) openSearch:(nullable NSObject *)object location:(nullable CLLocation *)location searchQuery:(nullable NSString *)searchQuery;
 - (void) openSearch:(OAQuickSearchType)searchType;
 - (void) openSearch:(OAQuickSearchType)searchType location:(nullable CLLocation *)location tabIndex:(NSInteger)tabIndex;
 - (void) openSearch:(OAQuickSearchType)searchType location:(nullable CLLocation *)location tabIndex:(NSInteger)tabIndex searchQuery:(nullable NSString *)searchQuery object:(nullable NSObject *)object;

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -1127,6 +1127,11 @@ typedef enum
     [self openSearch:OAQuickSearchType::REGULAR location:location tabIndex:1 searchQuery:@"" object:object];
 }
 
+- (void) openSearch:(NSObject *)object location:(CLLocation *)location searchQuery:(NSString *)searchQuery
+{
+    [self openSearch:OAQuickSearchType::REGULAR location:location tabIndex:1 searchQuery:searchQuery object:object];
+}
+
 - (void) openSearch:(OAQuickSearchType)searchType
 {
     [self openSearch:searchType location:nil tabIndex:-1];
@@ -1208,14 +1213,20 @@ typedef enum
 
         if ([object isKindOfClass:[OAPOICategory class]])
         {
-            objectLocalizedName = ((OAPOICategory *) object).nameLocalized;
+            if (NSStringIsEmpty(objectLocalizedName))
+            {
+                objectLocalizedName = ((OAPOICategory *) object).nameLocalized;
+            }
             phrase = [searchUICore resetPhrase:[NSString stringWithFormat:@"%@ ", objectLocalizedName]];
         }
         else if ([object isKindOfClass:[OAPOIUIFilter class]])
         {
             OAPOIUIFilter *filter = (OAPOIUIFilter *) object;
             filterByName = [filter.filterId isEqualToString:BY_NAME_FILTER_ID] || [filter.filterId hasPrefix:topIndexBrandPrefix];
-            objectLocalizedName = filterByName ? filter.filterByName : filter.name;
+            if (NSStringIsEmpty(objectLocalizedName))
+            {
+                objectLocalizedName = filterByName ? filter.filterByName : filter.name;
+            }
             phrase = [searchUICore resetPhrase];
         }
 
@@ -1229,9 +1240,12 @@ typedef enum
             sr.objectType = EOAObjectTypePoiType;
             [searchUICore selectSearchResult:sr];
         }
-
-        searchQuery = [NSString stringWithFormat:@"%@ ",
-                filterByName ? ((OAPOIUIFilter *) object).filterByName : objectLocalizedName.trim];
+        
+        if (NSStringIsEmpty(objectLocalizedName))
+        {
+            searchQuery = [NSString stringWithFormat:@"%@ ",
+                           filterByName ? ((OAPOIUIFilter *) object).filterByName : objectLocalizedName.trim];
+        }
     }
 
     if (searchQuery)

--- a/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
+++ b/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
@@ -2119,7 +2119,7 @@ typedef BOOL(^OASearchFinishedCallback)(OASearchPhrase *phrase);
     if (filter)
     {
         [[OARootViewController instance].mapPanel hideToolbar:_searchToolbarViewController];
-        [[OARootViewController instance].mapPanel openSearch:filter location:[[CLLocation alloc] initWithLatitude:_searchLocation.latitude longitude:_searchLocation.longitude]];
+        [[OARootViewController instance].mapPanel openSearch:filter location:[[CLLocation alloc] initWithLatitude:_searchLocation.latitude longitude:_searchLocation.longitude] searchQuery:_searchQuery ?: @""];
     }
     else
     {


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/22089#issuecomment-3233847418)

before: "turm de sinne" -> "sinne" 
after: "turm de sinne" -> "turm de sinne" 

video:

https://github.com/user-attachments/assets/fac4aad6-60d9-40c4-a0c6-778802cb5ea9

test point:
49.452215 11.069502
https://www.openstreetmap.org/node/1539266304#map=19/49.452215/11.069502

test phrase:
"turm de sinne"