### PR TITLE
Translation invisible symbols bugfix

### DIFF
--- a/Scripts/add_translations.swift
+++ b/Scripts/add_translations.swift
@@ -521,12 +521,18 @@ class IOSWriter {
                 }
                 var newString = string
                 var newValue = currentValue
-                if let androidValue = keysToUpdate[key], let updatedString = replaceValueText(newValue: filterUnsafeChars(androidValue), inFullString: string),
-                            updatedString != string  {
+
+                if let androidValue = keysToUpdate[key],
+                    let updatedString = replaceValueText(newValue: filterUnsafeChars(androidValue), inFullString: strippingZeroWidth(string)),
+                    updatedString != string  {
+                    
                     updatedStringsCount += 1
                     newValue = androidValue
                     newString = updatedString
-                    // print("Update key ! \(string)  \(currentValue) -> \(androidValue)?? ")
+                    
+                    if DEBUG {
+                        print("Update key ! \(string)  \(currentValue) -> \(androidValue)?? ")
+                    }
                 }
                 
                 if ALLOW_TO_HAVE_ENGLISH_NAMES ||
@@ -612,9 +618,16 @@ class IOSWriter {
             result = String(result.dropLast())
             result = result + "\\\""
         }
+        
+        result = strippingZeroWidth(result)
+        
         return result
     }
     
+    static func strippingZeroWidth(_ s: String) -> String {
+        let zeroWidth: Set<Unicode.Scalar> = ["\u{200B}", "\u{200C}", "\u{200D}", "\u{FEFF}"]
+        return String(s.unicodeScalars.filter { !zeroWidth.contains($0) })
+    }
 }
 
 


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4814#issuecomment-3406526877)

fixed bug with invisuble symbols:

<img width="810" height="120" alt="Screenshot 2025-10-17 at 15 49 45" src="https://github.com/user-attachments/assets/9e0cdcd0-991d-4f8c-9f32-8a1c1ae3b23f" />

---

before/after:

<img width="597" height="546" alt="Screenshot 2025-10-17 at 16 46 32" src="https://github.com/user-attachments/assets/3bbd9122-ea86-4970-a951-e48e0a52198f" />

---

<img width="619" height="551" alt="Screenshot 2025-10-17 at 16 50 35" src="https://github.com/user-attachments/assets/084fabd3-be89-4ded-bb0f-35f1c4bfd266" />
