### PR TITLE
crash_fix_OAMultipleResourceItem

### DIFF
--- a/Sources/Helpers/OAResourcesUIHelper.mm
+++ b/Sources/Helpers/OAResourcesUIHelper.mm
@@ -517,8 +517,16 @@ typedef OsmAnd::IncrementalChangesManager::IncrementalUpdate IncrementalUpdate;
             [resourceItems addObject:item];
             if ([item isKindOfClass:OALocalResourceItem.class])
             {
-                self.size += ((OALocalResourceItem *) item).resource->size;
-                self.sizePkg += [OsmAndApp instance].resourcesManager->getResourceInRepository(item.resourceId)->packageSize;
+                uint64_t size = ((OALocalResourceItem *) item).resource->size;
+                self.size += size;
+                
+                if (!item.resourceId.isNull() && !item.resourceId.isEmpty())
+                {
+                    const auto res = [OsmAndApp instance].resourcesManager->getResourceInRepository(item.resourceId);
+                    if (res != nullptr)
+                        size = res->packageSize;
+                }
+                self.sizePkg += size;
             }
             else if ([item isKindOfClass:OARepositoryResourceItem.class])
             {


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/5048)

- [x] OsmAnd Maps: -[OAMultipleResourceItem initWithType:items:] + 968  
xcode://organizer/crashes/downloadPoint?adamId=934850257&platformId=iOS&installPlatformId=iOS&analyticsPointId=CbWzuedMzTFCbGZMG0Tnn&bundleId=net.osmand.maps