### PR TITLE
Unite search results by osmid / wikidata

### DIFF
--- a/Sources/Search/OASearchUICore.mm
+++ b/Sources/Search/OASearchUICore.mm
@@ -372,13 +372,8 @@ const static NSArray<NSNumber *> *compareStepValues = @[@(EOATopVisible),
         {
             OAPOI *that = (OAPOI *)sr.object;
             int64_t osmId = [that getOsmId];
-            NSNumber * osmIdObj = osmId == -1 ? nil : @(osmId);
+            NSNumber * osmIdObj = osmId < 0 ? nil : @(osmId);
             NSString *wikidata = [that getWikidata];
-
-            if (osmIdObj != nil && [osmIdObj longLongValue] < 0)
-            {
-                osmIdObj = nil; // do not merge synthetic osmId such as wiki
-            }
 
             if (that.isRouteTrack)
             {


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/23892
Java code [uniteSearchResultsByOsmIdOrWikidata ](https://github.com/osmandapp/OsmAnd/blob/55724c0966fff6e4045210c4e1906cf9b7c7586b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java#L337)

Combine by wikidata ([Le Phare](https://www.openstreetmap.org/way/108358489)):
<img width="400" src="https://github.com/user-attachments/assets/092bd4cd-2eb5-4398-9516-d734fe8ec51c" /> <img width="400" src="https://github.com/user-attachments/assets/af28d977-6af8-4e92-b755-7ddff5613086" />

Combine by osm_id ([Fuel and liquid gas store](https://www.openstreetmap.org/way/451454731)):
<img width="400" src="https://github.com/user-attachments/assets/bd3d4f2c-8050-4f08-bc8d-f6080d23270f" /> <img width="400" src="https://github.com/user-attachments/assets/4c94ebf6-2f3b-46c0-83f0-12bd0ff43095" />

