### PR TITLE
Fix empty results and crossroads

### DIFF
--- a/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
+++ b/Sources/Controllers/TargetMenu/Search/OAQuickSearchViewController.mm
@@ -1547,7 +1547,14 @@ typedef BOOL(^OASearchFinishedCallback)(OASearchPhrase *phrase);
     [self showWaitingIndicator];
     [self runCoreSearch:text updateResult:updateResult searchMore:searchMore onSearchStarted:nil onPublish:^(OASearchResultCollection *res, BOOL append) {
         [self updateSearchResult:res append:append];
-    } onSearchFinished:nil];
+    } onSearchFinished:^BOOL(OASearchPhrase *phrase) {
+        OASearchWord * lastSelectedWord = [[self.searchUICore getPhrase] getLastSelectedWord];
+        if (_tableController != nil && [_tableController isShowResult] && [self isResultEmpty] && lastSelectedWord != nil)
+        {
+            [_tableController showOnMap:lastSelectedWord.result searchType:_tableController.searchType delegate:_tableController.delegate];
+        }
+        return YES;
+    }];
 }
 
 - (void) runCoreSearch:(NSString *)text updateResult:(BOOL)updateResult searchMore:(BOOL)searchMore onSearchStarted:(OASearchStartedCallback)onSearchStarted onPublish:(OAPublishCallback)onPublish onSearchFinished:(OASearchFinishedCallback)onSearchFinished
@@ -2147,6 +2154,11 @@ typedef BOOL(^OASearchFinishedCallback)(OASearchPhrase *phrase);
     [self.searchHelper refreshCustomPoiFilters];
     [self reloadCategories];
     return removed;
+}
+
+- (BOOL) isResultEmpty
+{
+    return ![self getResultCollection] || [[self getResultCollection] getCurrentSearchResults].count == 0;
 }
 
 @end

--- a/Sources/Search/OASearchCoreFactory.mm
+++ b/Sources/Search/OASearchCoreFactory.mm
@@ -2124,8 +2124,10 @@
                     continue;
                 
                 OASearchResult *res = [[OASearchResult alloc] initWithPhrase:phrase];
-                if ((![streetMatch matches:street->nativeName.toNSString()] && ![streetMatch matchesMap:[OASearchCoreFactory getAllNames:street->localizedNames nativeName:street->nativeName]]) || ![phrase isSearchTypeAllowed:EOAObjectTypeStreetIntersection])
+                if (![self matchAddressName:phrase parent:nil res:res fullMatch:false])
+                {
                     continue;
+                }
                 
                 res.otherNames = [OASearchCoreFactory getAllNames:street->localizedNames nativeName:street->nativeName];
                 res.localeName = street->getName(lang, transliterate).toNSString();


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/19059#issuecomment-3542249171

For reviewer. Android code:
[matchAddressName](https://github.com/osmandapp/OsmAnd/blob/91e3ed090873a0998fb4a4b609283d85609f400c/OsmAnd-java/src/main/java/net/osmand/search/core/SearchCoreFactory.java#L1793)
[onSearchFinished lambda](https://github.com/osmandapp/OsmAnd/blob/1d8663f235124e70a7c31cbe27e5f2eab456afb0/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java#L888)