### PR TITLE
Fix "Search more" button in poi context menu show empty list. Rework Search field phrase trimming to one last word.

### DIFF
--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -1214,22 +1214,24 @@ typedef enum
 
         if ([object isKindOfClass:[OAPOICategory class]])
         {
-            if (NSStringIsEmpty(objectLocalizedName))
-            {
-                objectLocalizedName = ((OAPOICategory *) object).nameLocalized;
-            }
+            OAPOICategory *c = ((OAPOICategory *) object);
+            objectLocalizedName = c.nameLocalized;
             phrase = [searchUICore resetPhrase:[NSString stringWithFormat:@"%@ ", objectLocalizedName]];
         }
         else if ([object isKindOfClass:[OAPOIUIFilter class]])
         {
             OAPOIUIFilter *filter = (OAPOIUIFilter *) object;
             filterByName = [filter.filterId isEqualToString:BY_NAME_FILTER_ID] || [filter.filterId hasPrefix:topIndexBrandPrefix];
-            if (NSStringIsEmpty(objectLocalizedName))
-            {
-                objectLocalizedName = filterByName ? filter.filterByName : filter.name;
-            }
+            objectLocalizedName = filterByName ? filter.filterByName : filter.name;
             phrase = [searchUICore resetPhrase];
         }
+        
+        if (!NSStringIsEmpty(searchQuery))
+        {
+            //Restore state after returning from "Show on map".
+            objectLocalizedName = searchQuery;
+        }
+        searchQuery = [NSString stringWithFormat:@"%@ ", objectLocalizedName.trim];
 
         if (phrase)
         {
@@ -1240,12 +1242,6 @@ typedef enum
             sr.priorityDistance = 0;
             sr.objectType = EOAObjectTypePoiType;
             [searchUICore selectSearchResult:sr];
-        }
-        
-        if (NSStringIsEmpty(objectLocalizedName))
-        {
-            searchQuery = [NSString stringWithFormat:@"%@ ",
-                           filterByName ? ((OAPOIUIFilter *) object).filterByName : objectLocalizedName.trim];
         }
     }
 


### PR DESCRIPTION
[current issue](https://github.com/osmandapp/OsmAnd/issues/20506#issuecomment-3631857751)

[related issue](https://github.com/osmandapp/OsmAnd/issues/22089#issuecomment-3233847418)

before / after (photo):

<img height="300" alt="Screenshot 2026-01-08 at 01 25 35" src="https://github.com/user-attachments/assets/8e4e15e3-a2c3-417a-baa3-2a5e6cd74010" />    <img height="300" alt="Screenshot 2026-01-08 at 01 25 56" src="https://github.com/user-attachments/assets/b8488c55-8b2f-4f9d-98e6-524fb36e2e46" />

before (video):

https://github.com/user-attachments/assets/7c557de6-2778-4004-9608-3dc0cd3e5b0f

after (video):

https://github.com/user-attachments/assets/f064ad1e-70c0-4a79-a90b-43502e3656ef

---

Search more button - test point:

https://www.openstreetmap.org/way/1294840099#map=20/53.8693260/-1.7048201


Previous search field resetting [bug](https://github.com/osmandapp/OsmAnd-iOS/pull/4907) -  test point:

https://www.openstreetmap.org/node/1539266304#map=21/49.4522200/11.0695000

phrase: "turm de sinne"

