### PR TITLE
Fix matching in sorting by search result weights

### DIFF
--- a/Sources/Search/OASearchResult.mm
+++ b/Sources/Search/OASearchResult.mm
@@ -29,6 +29,7 @@
 #include <commonOsmAndCore.h>
 #include <OsmAndCore/ICU.h>
 #include <OsmAndCore/Utilities.h>
+#include <OsmAndCore/CollatorStringMatcher.h>
 
 #define MAX_TYPE_WEIGHT 10.0
 #define HYPHEN "-"
@@ -213,7 +214,10 @@
     }
     QStringList localResultNames;
     for (NSString *localResultName : localResultNamesArray)
-        localResultNames.append(QString::fromNSString(localResultName));
+    {
+        QString qs = QString::fromNSString(localResultName);
+        localResultNames.append(OsmAnd::CollatorStringMatcher::alignChars(qs));
+    }
 
     BOOL wordMatched;
     if (searchPhraseNames.isEmpty())


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/24244#issuecomment-4023050259

Sorting for ``Київська вулиця`` and ``Киівська вулиця`` was different.