### PR TITLE
[5.3] Fix insufficient shield zoom in TopTextView (ios)

### DIFF
--- a/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
+++ b/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
@@ -698,8 +698,8 @@ static int stackViewLeadingToRefViewPadding = 16;
         const auto& tp = object->region->quickGetEncodingRule(i);
         if (tp.getTag() == "highway" || tp.getTag() == "route")
         {
-            textEvaluator.setIntegerValue(env->styleBuiltinValueDefs->id_INPUT_MINZOOM, 13);
-            textEvaluator.setIntegerValue(env->styleBuiltinValueDefs->id_INPUT_MAXZOOM, 13);
+            textEvaluator.setIntegerValue(env->styleBuiltinValueDefs->id_INPUT_MINZOOM, 16);
+            textEvaluator.setIntegerValue(env->styleBuiltinValueDefs->id_INPUT_MAXZOOM, 16);
             textEvaluator.setStringValue(env->styleBuiltinValueDefs->id_INPUT_TAG, QString::fromStdString(tp.getTag()));
             textEvaluator.setStringValue(env->styleBuiltinValueDefs->id_INPUT_VALUE, QString::fromStdString(tp.getValue()));
         }


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/issues/24828