### PR TITLE
Hover added to Drawer in Main menu #5408

### DIFF
--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -1620,6 +1620,7 @@
 		CA4EDE42AAD38F5BB5B4C6B1 /* OASegmentedSlider.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA4EDBF84C09652F36648561 /* OASegmentedSlider.mm */; };
 		CA4EDE42CED78CB3617A9FFB /* OACollectionViewFlowLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4ED6B983C859FE4CF11CA1 /* OACollectionViewFlowLayout.m */; };
 		CA4EDF67F88C1EDA037C0E3B /* OAWeatherToolbar.mm in Sources */ = {isa = PBXBuildFile; fileRef = CA4EDD1F641FDF3A3C7BB25C /* OAWeatherToolbar.mm */; };
+		CE2AAB2B2FBF281000A5D22E /* CancelableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2AAB2A2FBF281000A5D22E /* CancelableScrollView.swift */; };
 		D1A0B0012F50000100A0B001 /* OpeningHoursParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0AFFE2F50000100A0B001 /* OpeningHoursParserTest.swift */; };
 		D1A0B0032F50000100A0B001 /* OpeningHoursParserTestSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0002F50000100A0B001 /* OpeningHoursParserTestSupport.mm */; };
 		DA0132D42A1E0AB500920C14 /* WidgetsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0132D32A1E0AB500920C14 /* WidgetsListViewController.swift */; };
@@ -5548,6 +5549,7 @@
 		CA4EDFA46B3B672B32035B7F /* OASubscriptionCardView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OASubscriptionCardView.mm; sourceTree = "<group>"; };
 		CA4EDFFD2EBD6CFA86AF69F1 /* OADeleteOldFilesCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OADeleteOldFilesCommand.h; sourceTree = "<group>"; };
 		CC99B1D5FA05EDFE17BF38B8 /* libPods-OsmAnd Maps.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OsmAnd Maps.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE2AAB2A2FBF281000A5D22E /* CancelableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelableScrollView.swift; sourceTree = "<group>"; };
 		D1A0AFFE2F50000100A0B001 /* OpeningHoursParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpeningHoursParserTest.swift; sourceTree = "<group>"; };
 		D1A0AFFF2F50000100A0B001 /* OpeningHoursParserTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpeningHoursParserTestSupport.h; sourceTree = "<group>"; };
 		D1A0B0002F50000100A0B001 /* OpeningHoursParserTestSupport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OpeningHoursParserTestSupport.mm; sourceTree = "<group>"; };
@@ -13729,6 +13731,7 @@
 				DA5A806526C563A500F274C7 /* OARoutingProgressView.m */,
 				DA5A805226C563A500F274C7 /* OAScrollView.h */,
 				DA5A806A26C563A500F274C7 /* OAScrollView.m */,
+				CE2AAB2A2FBF281000A5D22E /* CancelableScrollView.swift */,
 				CA4EDD14CA25B1A6AEB53FE3 /* OASegmentedSlider.h */,
 				CA4EDBF84C09652F36648561 /* OASegmentedSlider.mm */,
 				DA9F841A29CC96EF00127DAE /* OAShapeLayer.h */,
@@ -18076,6 +18079,7 @@
 				DA5A839026C563A800F274C7 /* OAOsmAndLiveSelectionViewController.mm in Sources */,
 				DA5A83C626C563A800F274C7 /* OAActionConfigurationViewController.mm in Sources */,
 				DA5A812226C563A700F274C7 /* OAIAPHelper.mm in Sources */,
+				CE2AAB2B2FBF281000A5D22E /* CancelableScrollView.swift in Sources */,
 				DA5A853C26C563A900F274C7 /* OAReverseGeocoder.mm in Sources */,
 				05DACD7F2C1CAF470023FAD9 /* OASharedUtil.m in Sources */,
 				DA5A853426C563A900F274C7 /* OASettingsExporter.mm in Sources */,

--- a/Sources/Controllers/Panels/OAOptionsPanelBlackViewController.m
+++ b/Sources/Controllers/Panels/OAOptionsPanelBlackViewController.m
@@ -40,7 +40,7 @@
 
 @interface OAOptionsPanelBlackViewController () <UINavigationControllerDelegate>
 
-@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
+@property (weak, nonatomic) IBOutlet CancelableScrollView *scrollView;
 @property (weak, nonatomic) IBOutlet UIButton *menuButtonMaps;
 @property (weak, nonatomic) IBOutlet UIButton *menuButtonMyData;
 @property (weak, nonatomic) IBOutlet UIButton *menuButtonMyWaypoints;

--- a/Sources/Views/CancelableScrollView.swift
+++ b/Sources/Views/CancelableScrollView.swift
@@ -1,0 +1,33 @@
+//
+//  CancelableScrollView.swift
+//  OsmAnd Maps
+//
+//  Created by Vitaliy on 21.05.2026.
+//  Copyright © 2026 OsmAnd. All rights reserved.
+//
+
+import UIKit
+
+/// Custom UIScrollView subclass used to fine-tune touch handling behavior for interactive controls inside scrollable menus.
+/// It disables touch delays and adjusts content touch cancellation rules to ensure that scrolling gestures take priority
+/// over embedded UI elements such as buttons. This provides a more responsive and predictable interaction experience,
+/// especially in dense UI layouts like side panels and CarPlay-style interfaces where both scrolling and tapping coexist.
+final class CancelableScrollView: UIScrollView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        delaysContentTouches = false
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        delaysContentTouches = false
+    }
+
+    override func touchesShouldCancel(in view: UIView) -> Bool {
+        if view is UIControl {
+            return true
+        }
+        return super.touchesShouldCancel(in: view)
+    }
+}

--- a/Sources/Views/CancelableScrollView.swift
+++ b/Sources/Views/CancelableScrollView.swift
@@ -8,10 +8,8 @@
 
 import UIKit
 
-/// Custom UIScrollView subclass used to fine-tune touch handling behavior for interactive controls inside scrollable menus.
-/// It disables touch delays and adjusts content touch cancellation rules to ensure that scrolling gestures take priority
-/// over embedded UI elements such as buttons. This provides a more responsive and predictable interaction experience,
-/// especially in dense UI layouts like side panels and CarPlay-style interfaces where both scrolling and tapping coexist.
+/// A UIScrollView subclass that disables touch delays
+/// and prioritizes scroll gestures over embedded controls.
 final class CancelableScrollView: UIScrollView {
     
     override init(frame: CGRect) {

--- a/Sources/Views/XibViews/OptionsPanel.xib
+++ b/Sources/Views/XibViews/OptionsPanel.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -39,7 +39,7 @@
                     <color key="textColor" name="textColorPrimary"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HYb-RD-p6J">
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HYb-RD-p6J" customClass="CancelableScrollView" customModule="OsmAnd_Maps" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>


### PR DESCRIPTION
Introduce CancelableScrollView (UIScrollView subclass) to improve touch handling: disables delaysContentTouches and cancels touches for UIControls so scrolling takes precedence over embedded controls. Update OAOptionsPanelBlackViewController to reference CancelableScrollView and update OptionsPanel.xib to use the custom class.

Fix: #5408 