### PR TITLE
Fix iOS 5296 - set activity for planned tracks from active profile on…

### DIFF
--- a/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.h
+++ b/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.h
@@ -93,6 +93,7 @@ typedef NS_ENUM(NSInteger, EOAAddPointMode) {
 
 - (double) getRouteDistance;
 - (BOOL) isNewData;
+- (BOOL) hasRoutePoints;
 - (BOOL) isApproximationNeeded;
 - (BOOL) isAddNewSegmentAllowed;
 - (BOOL) hasRoute;

--- a/Sources/Controllers/RoutePlanning/OASaveGpxRouteAsyncTask.mm
+++ b/Sources/Controllers/RoutePlanning/OASaveGpxRouteAsyncTask.mm
@@ -206,11 +206,17 @@
     return gpx;
 }
 
+- (BOOL)shouldSyncRouteActivityWithEditedProfile
+{
+    return !_editingCtx.isNewData && _editingCtx.hasRoutePoints;
+}
+
 - (void)savePreselectedRouteActivity:(OASGpxFile *)gpxFile
 {
     OASRouteActivityHelper *activityHelper = [OASRouteActivityHelper shared];
     OASMetadata *metadata = gpxFile.metadata;
-    if ([metadata getRouteActivityActivities:[activityHelper getActivities]] != nil)
+    BOOL syncWithProfile = [self shouldSyncRouteActivityWithEditedProfile];
+    if (!syncWithProfile && [metadata getRouteActivityActivities:[activityHelper getActivities]] != nil)
         return;
 
     OAApplicationMode *appMode = _editingCtx.appMode;
@@ -218,7 +224,7 @@
         appMode = [OAAppSettings sharedManager].applicationMode.get;
 
     NSString *activityId = (NSString *)[[OAAppSettings sharedManager].currentTrackRouteActivity getProfileDefaultValue:appMode];
-    if (activityId.length > 0)
+    if (syncWithProfile || activityId.length > 0)
         [metadata setRouteActivityActivity:[activityHelper findRouteActivityId:activityId]];
 }
 

--- a/Sources/Controllers/RoutePlanning/OASaveGpxRouteAsyncTask.mm
+++ b/Sources/Controllers/RoutePlanning/OASaveGpxRouteAsyncTask.mm
@@ -85,6 +85,7 @@
         NSString *trackName = [fileName stringByDeletingPathExtension];
         
         OASGpxFile *gpx = [self generateGpxFile:trackName gpx:[[OASGpxFile alloc] initWithAuthor:[OAAppVersion getFullVersionWithAppName]]];
+        [self savePreselectedRouteActivity:gpx];
         OASKFile *file = [[OASKFile alloc] initWithFilePath:_outFile];
         OASKException *exception = [[OASGpxUtilities shared] writeGpxFileFile:file gpxFile:gpx];
         
@@ -105,6 +106,7 @@
             gpx.metadata = [[OASMetadata alloc] init];
             gpx.metadata.extensions = _gpxFile.metadata.extensions;
         }
+        [self savePreselectedRouteActivity:gpx];
 //        if (!gpx.showCurrentTrack) {
 //            res = GPXUtilities.writeGpxFile(outFile, gpx);
 //        }
@@ -202,6 +204,22 @@
         }
     }
     return gpx;
+}
+
+- (void)savePreselectedRouteActivity:(OASGpxFile *)gpxFile
+{
+    OASRouteActivityHelper *activityHelper = [OASRouteActivityHelper shared];
+    OASMetadata *metadata = gpxFile.metadata;
+    if ([metadata getRouteActivityActivities:[activityHelper getActivities]] != nil)
+        return;
+
+    OAApplicationMode *appMode = _editingCtx.appMode;
+    if (appMode == OAApplicationMode.DEFAULT)
+        appMode = [OAAppSettings sharedManager].applicationMode.get;
+
+    NSString *activityId = (NSString *)[[OAAppSettings sharedManager].currentTrackRouteActivity getProfileDefaultValue:appMode];
+    if (activityId.length > 0)
+        [metadata setRouteActivityActivity:[activityHelper findRouteActivityId:activityId]];
 }
 
 - (void) onPostExecute:(void(^)(OASGpxFile *, NSString *))onComplete

--- a/Sources/Helpers/OAAppSettings.m
+++ b/Sources/Helpers/OAAppSettings.m
@@ -6616,6 +6616,7 @@ static NSString *kOfflineKey = @"OFFLINE";
         [_currentTrackRouteActivity setModeDefaultValue:@"horse_riding" mode:OAApplicationMode.HORSE];
         [_currentTrackRouteActivity setModeDefaultValue:@"motor_scooter" mode:OAApplicationMode.MOPED];
         [_currentTrackRouteActivity setModeDefaultValue:@"truck_hgv" mode:OAApplicationMode.TRUCK];
+        [_currentTrackRouteActivity setModeDefaultValue:@"adventure_motorcycling" mode:OAApplicationMode.MOTORCYCLE];
         
         _customTrackColors = [[[OACommonStringList withKey:customTrackColorsKey defValue:@[]] makeGlobal] makeShared];
         _customTrackColorsLastUsed = [[[OACommonStringList withKey:customTrackColorsLastUsedKey defValue:@[]] makeGlobal] makeShared];


### PR DESCRIPTION
## What
Planned tracks now automatically get an activity type assigned on save,
matching the behavior already implemented for recorded tracks.

https://github.com/osmandapp/OsmAnd-iOS/issues/5296

Also adds a missing default activity for the Motorcycle profile.

## Changes
- `OASaveGpxRouteAsyncTask.mm` — added `savePreselectedRouteActivity:`
  that reads the active profile's default activity and writes it to the
  GPX metadata on save. If the track already has an activity set, it is
  not overwritten.
- `OAAppSettings.m` — added missing default activity for the Motorcycle
  profile (`adventure_motorcycling`).