### PR TITLE
Fix shield size

### DIFF
--- a/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
+++ b/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
@@ -64,8 +64,6 @@
 
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *exitRefTextContainerWidthConstraint;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *stackViewLeadingConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *shieldIconWidthConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *shieldIconHeightConstraint;
 
 @end
 
@@ -107,6 +105,7 @@
     
     NSString *_customId;
     BOOL _prevShowNextTurn;
+    NSLayoutConstraint *_shieldIconAspectRatioConstraint;
 }
 
 static int stackViewLeadingDefaultValue = 2;
@@ -205,15 +204,6 @@ static int stackViewLeadingToRefViewPadding = 16;
     BOOL showTurn = !_turnView.isHidden && _turnView.subviews.count > 0;
     BOOL showExit = !_exitRefTextContainer.isHidden && _exitRefText.text.length > 0;
     BOOL showAddress = !_addressText.isHidden && _addressText.text.length > 0;
-    if (showShield)
-    {
-        CGSize imageSize = _shieldIcon.image.size;
-        if (imageSize.height > 0)
-        {
-            CGFloat aspectRatio = imageSize.width / imageSize.height;
-            _shieldIconWidthConstraint.constant = _shieldIconHeightConstraint.constant * aspectRatio;
-        }
-    }
     CGRect exitRefFrame = _exitRefTextContainer.frame;
     
     self.stackViewLeadingConstraint.constant = stackViewLeadingDefaultValue;
@@ -234,7 +224,7 @@ static int stackViewLeadingToRefViewPadding = 16;
     
     CGFloat margin = _turnView.subviews.count > 0 ? 4 + _turnView.bounds.size.width + 2 : 2;
     margin += _exitRefTextContainer.hidden ? 0 : _exitRefTextContainer.frame.size.width + 2;
-    margin += showShield ? _shieldIconWidthConstraint.constant + 2 : 0;
+    margin += showShield ? _shieldIcon.frame.size.width + 2 : 0;
     margin += showExit ? exitRefFrame.size.width + 2 : 0;
     CGFloat maxTextWidth = w - margin * 2;
     CGSize size = [OAUtilities calculateTextBounds:showAddress ? _addressText.text : @"" width:maxTextWidth height:h font:_textFont];
@@ -590,6 +580,15 @@ static int stackViewLeadingToRefViewPadding = 16;
             if([self setRoadShield:_shieldIcon shields:shields])
             {
                 _shieldIcon.hidden = NO;
+                _shieldIconAspectRatioConstraint.active = NO;
+                CGSize imageSize = _shieldIcon.image.size;
+                if (imageSize.height > 0)
+                {
+                    CGFloat aspectRatio = imageSize.width / imageSize.height;
+                    _shieldIconAspectRatioConstraint = [_shieldIcon.widthAnchor constraintEqualToAnchor:_shieldIcon.heightAnchor
+                                                                                            multiplier:aspectRatio];
+                    _shieldIconAspectRatioConstraint.active = YES;
+                }
                 int idx = [streetName.text indexOf:@"»"];
                 if (idx > 0)
                     streetName.text = [streetName.text substringFromIndex:idx];

--- a/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
+++ b/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
@@ -106,6 +106,7 @@
     NSString *_customId;
     BOOL _prevShowNextTurn;
     NSLayoutConstraint *_shieldIconAspectRatioConstraint;
+    CGFloat _shieldIconAspectRatio;
 }
 
 static int stackViewLeadingDefaultValue = 2;
@@ -580,14 +581,18 @@ static int stackViewLeadingToRefViewPadding = 16;
             if([self setRoadShield:_shieldIcon shields:shields])
             {
                 _shieldIcon.hidden = NO;
-                _shieldIconAspectRatioConstraint.active = NO;
                 CGSize imageSize = _shieldIcon.image.size;
                 if (imageSize.height > 0)
                 {
                     CGFloat aspectRatio = imageSize.width / imageSize.height;
-                    _shieldIconAspectRatioConstraint = [_shieldIcon.widthAnchor constraintEqualToAnchor:_shieldIcon.heightAnchor
-                                                                                            multiplier:aspectRatio];
-                    _shieldIconAspectRatioConstraint.active = YES;
+                    if (aspectRatio != _shieldIconAspectRatio)
+                    {
+                        _shieldIconAspectRatioConstraint.active = NO;
+                        _shieldIconAspectRatioConstraint = [_shieldIcon.widthAnchor constraintEqualToAnchor:_shieldIcon.heightAnchor
+                                                                                                multiplier:aspectRatio];
+                        _shieldIconAspectRatioConstraint.active = YES;
+                        _shieldIconAspectRatio = aspectRatio;
+                    }
                 }
                 int idx = [streetName.text indexOf:@"»"];
                 if (idx > 0)

--- a/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
+++ b/Sources/Controllers/Map/Widgets/OATopTextView/OATopTextView.mm
@@ -64,6 +64,8 @@
 
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *exitRefTextContainerWidthConstraint;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *stackViewLeadingConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *shieldIconWidthConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *shieldIconHeightConstraint;
 
 @end
 
@@ -203,14 +205,14 @@ static int stackViewLeadingToRefViewPadding = 16;
     BOOL showTurn = !_turnView.isHidden && _turnView.subviews.count > 0;
     BOOL showExit = !_exitRefTextContainer.isHidden && _exitRefText.text.length > 0;
     BOOL showAddress = !_addressText.isHidden && _addressText.text.length > 0;
-    CGRect shieldFrame = _shieldIcon.frame;
     if (showShield)
     {
-        shieldFrame.size = _shieldIcon.image.size;
-        CGFloat height = h - 4;
-        CGFloat scaleFactor = height / shieldFrame.size.height;
-        shieldFrame.size = CGSizeMake(shieldFrame.size.width * scaleFactor, height);
-        _shieldIcon.frame = shieldFrame;
+        CGSize imageSize = _shieldIcon.image.size;
+        if (imageSize.height > 0)
+        {
+            CGFloat aspectRatio = imageSize.width / imageSize.height;
+            _shieldIconWidthConstraint.constant = _shieldIconHeightConstraint.constant * aspectRatio;
+        }
     }
     CGRect exitRefFrame = _exitRefTextContainer.frame;
     
@@ -232,7 +234,7 @@ static int stackViewLeadingToRefViewPadding = 16;
     
     CGFloat margin = _turnView.subviews.count > 0 ? 4 + _turnView.bounds.size.width + 2 : 2;
     margin += _exitRefTextContainer.hidden ? 0 : _exitRefTextContainer.frame.size.width + 2;
-    margin += showShield ? shieldFrame.size.width + 2 : 0;
+    margin += showShield ? _shieldIconWidthConstraint.constant + 2 : 0;
     margin += showExit ? exitRefFrame.size.width + 2 : 0;
     CGFloat maxTextWidth = w - margin * 2;
     CGSize size = [OAUtilities calculateTextBounds:showAddress ? _addressText.text : @"" width:maxTextWidth height:h font:_textFont];

--- a/Sources/Views/XibViews/OATopTextView.xib
+++ b/Sources/Views/XibViews/OATopTextView.xib
@@ -31,7 +31,6 @@
                                     <rect key="frame" x="26" y="10" width="30" height="30"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="7hC-kM-9B2"/>
-                                        <constraint firstAttribute="width" constant="30" id="B34-0F-X1d"/>
                                     </constraints>
                                 </imageView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8SS-I5-hTV">
@@ -215,8 +214,6 @@
                 <outlet property="exitRefTextContainer" destination="3ov-dr-SOd" id="yHV-0g-beC"/>
                 <outlet property="exitRefTextContainerWidthConstraint" destination="c2u-Jf-ukc" id="xpu-nB-UGX"/>
                 <outlet property="shieldIcon" destination="Z8c-N6-WrV" id="AtL-uY-5pa"/>
-                <outlet property="shieldIconHeightConstraint" destination="7hC-kM-9B2" id="tV2-aC-bYr"/>
-                <outlet property="shieldIconWidthConstraint" destination="B34-0F-X1d" id="sW1-xB-yZq"/>
                 <outlet property="stackViewLeadingConstraint" destination="wqD-d3-ul6" id="fYy-2t-Lqb"/>
                 <outlet property="turnView" destination="7DR-I9-K8G" id="0nc-tE-Svh"/>
                 <outlet property="waypointButtonMore" destination="6Px-uI-aHL" id="sPB-gq-CHR"/>

--- a/Sources/Views/XibViews/OATopTextView.xib
+++ b/Sources/Views/XibViews/OATopTextView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24128" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -215,6 +215,8 @@
                 <outlet property="exitRefTextContainer" destination="3ov-dr-SOd" id="yHV-0g-beC"/>
                 <outlet property="exitRefTextContainerWidthConstraint" destination="c2u-Jf-ukc" id="xpu-nB-UGX"/>
                 <outlet property="shieldIcon" destination="Z8c-N6-WrV" id="AtL-uY-5pa"/>
+                <outlet property="shieldIconHeightConstraint" destination="7hC-kM-9B2" id="tV2-aC-bYr"/>
+                <outlet property="shieldIconWidthConstraint" destination="B34-0F-X1d" id="sW1-xB-yZq"/>
                 <outlet property="stackViewLeadingConstraint" destination="wqD-d3-ul6" id="fYy-2t-Lqb"/>
                 <outlet property="turnView" destination="7DR-I9-K8G" id="0nc-tE-Svh"/>
                 <outlet property="waypointButtonMore" destination="6Px-uI-aHL" id="sPB-gq-CHR"/>
@@ -230,6 +232,6 @@
     </objects>
     <resources>
         <image name="ic_close.png" width="10" height="10"/>
-        <image name="three_dots" width="44" height="44"/>
+        <image name="three_dots" width="22" height="22"/>
     </resources>
 </document>


### PR DESCRIPTION
The shield UIImageView had fixed 30×30 Auto Layout constraints in XIB with scaleAspectFit. For shields with long text (e.g. "CM-410"), the image aspect ratio is wider than 1:1, so scaleAspectFit was scaling it down to fit the 30pt width — making the shield appear very small vertically.