### PR TITLE
Fix incorrect map centering after double-tap zoom gesture

### DIFF
--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -1056,10 +1056,11 @@ static char kMapSourceUpdateQueueKey;
 
 - (BOOL) isLastMultiGesture
 {
-    return (_movingByGesture && !_zoomingByGesture && !_rotatingByGesture && !_zoomingByTapGesture)
-        || (!_movingByGesture && _zoomingByGesture && !_rotatingByGesture && !_zoomingByTapGesture)
-        || (!_movingByGesture && !_zoomingByGesture && _rotatingByGesture && !_zoomingByTapGesture)
-        || (!_movingByGesture && !_zoomingByGesture && !_rotatingByGesture && _zoomingByTapGesture);
+    NSInteger activeGestures = (_movingByGesture ? 1 : 0)
+        + (_zoomingByGesture ? 1 : 0)
+        + (_rotatingByGesture ? 1 : 0)
+        + (_zoomingByTapGesture ? 1 : 0);
+    return activeGestures == 1;
 }
 
 - (void) storeTargetPosition:(UIGestureRecognizer *)recognizer scheduleRestore:(BOOL)scheduleRestore

--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -1056,9 +1056,10 @@ static char kMapSourceUpdateQueueKey;
 
 - (BOOL) isLastMultiGesture
 {
-    return (_movingByGesture && !_zoomingByGesture && !_rotatingByGesture)
-    	|| (!_movingByGesture && _zoomingByGesture && !_rotatingByGesture)
-    	|| (!_movingByGesture && !_zoomingByGesture && _rotatingByGesture);
+    return (_movingByGesture && !_zoomingByGesture && !_rotatingByGesture && !_zoomingByTapGesture)
+        || (!_movingByGesture && _zoomingByGesture && !_rotatingByGesture && !_zoomingByTapGesture)
+        || (!_movingByGesture && !_zoomingByGesture && _rotatingByGesture && !_zoomingByTapGesture)
+        || (!_movingByGesture && !_zoomingByGesture && !_rotatingByGesture && _zoomingByTapGesture);
 }
 
 - (void) storeTargetPosition:(UIGestureRecognizer *)recognizer scheduleRestore:(BOOL)scheduleRestore


### PR DESCRIPTION
isLastMultiGesture didn't account for _zoomingByTapGesture, so restorePreviousTarget never ran after the double-tap + drag gesture. This left fixedPixel pinned to the touch point, causing My Location to center the map there instead of the viewport center.