### PR TITLE
Fixes stuttering/jerky behavior during GPS navigation (issue #5355)

### DIFF
--- a/Sources/Controllers/Map/Layers/OAMyPositionLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAMyPositionLayer.mm
@@ -248,56 +248,40 @@ typedef enum {
             [OARootViewController.instance.mapPanel.mapViewController.mapLayers.myPositionLayer setMyLocationCircleRadius:(horizontalAccuracy)];
         });
 
-        BOOL hasOngoingPositionAnim = animationDuration <= 0
-            && _mapView.mapMarkersAnimator->getCurrentAnimation(marker, OsmAnd::Animator::AnimatedValue::Target) != nullptr;
+        BOOL isAnimatedMove = animationDuration > 0;
+        BOOL targetAnimRunning = _mapView.mapMarkersAnimator->getCurrentAnimation(marker, OsmAnd::Animator::AnimatedValue::Target) != nullptr;
+        BOOL keepRunningTargetAnim = !isAnimatedMove && targetAnimRunning;
+        BOOL shouldAnimateAzimuth = isAnimatedMove || keepRunningTargetAnim;
 
-        if (!hasOngoingPositionAnim)
-            _mapView.mapMarkersAnimator->cancelAnimations(marker);
-        else
-            _mapView.mapMarkersAnimator->cancelCurrentAnimation(marker, OsmAnd::Animator::AnimatedValue::Azimuth);
+        double bearingDir = OsmAnd::Utilities::normalizedAngleDegrees(bearing);
+        double headingDir = OsmAnd::Utilities::normalizedAngleDegrees(heading);
 
-        if (animationDuration > 0)
+        if (isAnimatedMove)
         {
+            _mapView.mapMarkersAnimator->cancelCurrentAnimation(marker, OsmAnd::Animator::AnimatedValue::Target);
             _mapView.mapMarkersAnimator->animatePositionTo(marker, target31, animationDuration,  OsmAnd::Animator::TimingFunction::Linear);
-            if (marker->model3D != nullptr)
-            {
-                _mapView.mapMarkersAnimator->animateModel3DDirectionTo(marker, OsmAnd::Utilities::normalizedAngleDegrees(bearing), kRotateAnimationTime, OsmAnd::Animator::TimingFunction::Linear);
-                [_mapView setMyLocationSectorDirection:(OsmAnd::Utilities::normalizedAngleDegrees(heading))];
-            }
-            else
-            {
-                if (iconKey)
-                    _mapView.mapMarkersAnimator->animateDirectionTo(marker, iconKey, OsmAnd::Utilities::normalizedAngleDegrees(bearing), kRotateAnimationTime,  OsmAnd::Animator::TimingFunction::Linear);
-            }
         }
-        else if (!hasOngoingPositionAnim)
+        else if (!keepRunningTargetAnim)
         {
             marker->setPosition(target31);
             [_mapView setMyLocationCirclePosition:(target31)];
-
-            if (marker->model3D != nullptr)
-            {
-                marker->setModel3DDirection(OsmAnd::Utilities::normalizedAngleDegrees(bearing));
-                [_mapView setMyLocationSectorDirection:(OsmAnd::Utilities::normalizedAngleDegrees(heading))];
-            }
-            else
-            {
-                if (iconKey)
-                    marker->setOnMapSurfaceIconDirection(iconKey, OsmAnd::Utilities::normalizedAngleDegrees(bearing));
-            }
         }
-        else
+
+        _mapView.mapMarkersAnimator->cancelCurrentAnimation(marker, OsmAnd::Animator::AnimatedValue::Azimuth);
+        if (marker->model3D != nullptr)
         {
-            if (marker->model3D != nullptr)
-            {
-                _mapView.mapMarkersAnimator->animateModel3DDirectionTo(marker, OsmAnd::Utilities::normalizedAngleDegrees(bearing), kRotateAnimationTime, OsmAnd::Animator::TimingFunction::Linear);
-                [_mapView setMyLocationSectorDirection:(OsmAnd::Utilities::normalizedAngleDegrees(heading))];
-            }
+            if (shouldAnimateAzimuth)
+                _mapView.mapMarkersAnimator->animateModel3DDirectionTo(marker, bearingDir, kRotateAnimationTime, OsmAnd::Animator::TimingFunction::Linear);
             else
-            {
-                if (iconKey)
-                    _mapView.mapMarkersAnimator->animateDirectionTo(marker, iconKey, OsmAnd::Utilities::normalizedAngleDegrees(bearing), kRotateAnimationTime,  OsmAnd::Animator::TimingFunction::Linear);
-            }
+                marker->setModel3DDirection(bearingDir);
+            [_mapView setMyLocationSectorDirection:(headingDir)];
+        }
+        else if (iconKey)
+        {
+            if (shouldAnimateAzimuth)
+                _mapView.mapMarkersAnimator->animateDirectionTo(marker, iconKey, bearingDir, kRotateAnimationTime,  OsmAnd::Animator::TimingFunction::Linear);
+            else
+                marker->setOnMapSurfaceIconDirection(iconKey, bearingDir);
         }
 
         if (visible && marker->isHidden())

--- a/Sources/Controllers/Map/Layers/OAMyPositionLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAMyPositionLayer.mm
@@ -248,7 +248,14 @@ typedef enum {
             [OARootViewController.instance.mapPanel.mapViewController.mapLayers.myPositionLayer setMyLocationCircleRadius:(horizontalAccuracy)];
         });
 
-        _mapView.mapMarkersAnimator->cancelAnimations(marker);
+        BOOL hasOngoingPositionAnim = animationDuration <= 0
+            && _mapView.mapMarkersAnimator->getCurrentAnimation(marker, OsmAnd::Animator::AnimatedValue::Target) != nullptr;
+
+        if (!hasOngoingPositionAnim)
+            _mapView.mapMarkersAnimator->cancelAnimations(marker);
+        else
+            _mapView.mapMarkersAnimator->cancelCurrentAnimation(marker, OsmAnd::Animator::AnimatedValue::Azimuth);
+
         if (animationDuration > 0)
         {
             _mapView.mapMarkersAnimator->animatePositionTo(marker, target31, animationDuration,  OsmAnd::Animator::TimingFunction::Linear);
@@ -263,7 +270,7 @@ typedef enum {
                     _mapView.mapMarkersAnimator->animateDirectionTo(marker, iconKey, OsmAnd::Utilities::normalizedAngleDegrees(bearing), kRotateAnimationTime,  OsmAnd::Animator::TimingFunction::Linear);
             }
         }
-        else
+        else if (!hasOngoingPositionAnim)
         {
             marker->setPosition(target31);
             [_mapView setMyLocationCirclePosition:(target31)];
@@ -277,6 +284,19 @@ typedef enum {
             {
                 if (iconKey)
                     marker->setOnMapSurfaceIconDirection(iconKey, OsmAnd::Utilities::normalizedAngleDegrees(bearing));
+            }
+        }
+        else
+        {
+            if (marker->model3D != nullptr)
+            {
+                _mapView.mapMarkersAnimator->animateModel3DDirectionTo(marker, OsmAnd::Utilities::normalizedAngleDegrees(bearing), kRotateAnimationTime, OsmAnd::Animator::TimingFunction::Linear);
+                [_mapView setMyLocationSectorDirection:(OsmAnd::Utilities::normalizedAngleDegrees(heading))];
+            }
+            else
+            {
+                if (iconKey)
+                    _mapView.mapMarkersAnimator->animateDirectionTo(marker, iconKey, OsmAnd::Utilities::normalizedAngleDegrees(bearing), kRotateAnimationTime,  OsmAnd::Animator::TimingFunction::Linear);
             }
         }
 

--- a/Sources/Controllers/Map/OAMapViewTrackingUtilities.mm
+++ b/Sources/Controllers/Map/OAMapViewTrackingUtilities.mm
@@ -411,7 +411,7 @@ static double const TILT_ANIMATION_TIME = 0.4;
     NSTimeInterval movingTime;
     if (animateMyLocation)
     {
-        movingTime = timeDiff;
+        movingTime = MAX(timeDiff, NAV_ANIMATION_TIME);
     }
     else
     {

--- a/Sources/Services/OALocationSimulation.mm
+++ b/Sources/Services/OALocationSimulation.mm
@@ -256,14 +256,21 @@ static const float LOCATION_TIMEOUT = 1.5;
 - (NSArray *)useSimulationConstantSpeed:(float)speed current:(OASimulatedLocation *)current directions:(NSMutableArray<OASimulatedLocation *> *)directions meters:(float)meters intervalTime:(float)intervalTime coeff:(float)coeff
 {
     NSMutableArray *result = [NSMutableArray array];
-    if ([current distanceFromLocation:directions[0]] > meters)
+    float remaining = meters;
+    while (directions.count > 0 && remaining > 0)
     {
-        current = [[OASimulatedLocation alloc] initWithSimulatedLocation:[self middleLocation:current end:directions[0] meters:meters]];
-    }
-    else
-    {
-        current = [[OASimulatedLocation alloc] initWithSimulatedLocation:directions[0]];
-        [directions removeObjectAtIndex:0];
+        float distToNext = [current distanceFromLocation:directions[0]];
+        if (distToNext > remaining)
+        {
+            current = [[OASimulatedLocation alloc] initWithSimulatedLocation:[self middleLocation:current end:directions[0] meters:remaining]];
+            remaining = 0;
+        }
+        else
+        {
+            current = [[OASimulatedLocation alloc] initWithSimulatedLocation:directions[0]];
+            [directions removeObjectAtIndex:0];
+            remaining -= distToNext;
+        }
     }
     meters = speed * intervalTime * coeff;
     


### PR DESCRIPTION
OAMyPositionLayer: Previously every location update unconditionally cancelled all marker animations. When a compass heading update arrived mid-position-animation, it interrupted the smooth arrow movement, causing a visible jerk. Now, if a heading-only update (animationDuration <= 0) arrives while a position animation is already running, only the azimuth animation is cancelled and restarted — the position animation continues uninterrupted.

OAMapViewTrackingUtilities: Added NAV_ANIMATION_TIME (1s) as a minimum for movingTime in navigation mode. Previously movingTime = timeDiff could be 0 on the first GPS update (no previous location) or shorter than 1s on fast GPS intervals, causing the camera to snap rather than animate smoothly.