### PR TITLE
Improve POI context menu open speed & smoothness 

### DIFF
--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -138,6 +138,7 @@ static const CGFloat kDistanceBetweenFingers = 50.0;
 static const NSInteger kDetailedMapZoom = 9;
 static const NSTimeInterval kRenderSyncSlowBlockThreshold = 0.05;
 static const NSTimeInterval kSingleTapContextMenuDelay = 0.15;
+static const NSTimeInterval kSingleTapContextMenuDoubleTapGuard = 0.4;
 static char kMapSourceUpdateQueueKey;
 
 @interface OATouchLocation : NSObject
@@ -233,6 +234,7 @@ static char kMapSourceUpdateQueueKey;
     UIPanGestureRecognizer* _grMouseWheelScroll;
 
     dispatch_block_t _pendingContextMenuBlock;
+    NSTimeInterval _singleTapContextMenuShownTime;
 
     BOOL _startRotating;
     BOOL _startZooming;
@@ -1564,6 +1566,7 @@ static char kMapSourceUpdateQueueKey;
         return;
 
     [self cancelPendingContextMenu];
+    [self dismissSingleTapContextMenuIfRecognizedAsDoubleTap];
 
     if (_mapView.zoomLevel >= _mapView.maxZoom)
         return;
@@ -1768,6 +1771,7 @@ static char kMapSourceUpdateQueueKey;
         if (!strongSelf)
             return;
         strongSelf->_pendingContextMenuBlock = nil;
+        strongSelf->_singleTapContextMenuShownTime = CACurrentMediaTime();
         [strongSelf showContextMenuAtPoint:touchPoint lat:lat lon:lon longPress:NO forceHide:forceHide];
     });
     _pendingContextMenuBlock = block;
@@ -1781,6 +1785,19 @@ static char kMapSourceUpdateQueueKey;
         dispatch_block_cancel(_pendingContextMenuBlock);
         _pendingContextMenuBlock = nil;
     }
+}
+
+- (void)dismissSingleTapContextMenuIfRecognizedAsDoubleTap
+{
+    if (_singleTapContextMenuShownTime <= 0)
+        return;
+
+    NSTimeInterval elapsed = CACurrentMediaTime() - _singleTapContextMenuShownTime;
+    _singleTapContextMenuShownTime = 0;
+    if (elapsed > kSingleTapContextMenuDoubleTapGuard)
+        return;
+
+    [[OARootViewController instance].mapPanel hideContextMenu];
 }
 
 - (id<OAMapRendererViewProtocol>) mapRendererView

--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -137,6 +137,7 @@ static const float ZONE_2_ZOOM_THRESHOLD = 1.5f;
 static const CGFloat kDistanceBetweenFingers = 50.0;
 static const NSInteger kDetailedMapZoom = 9;
 static const NSTimeInterval kRenderSyncSlowBlockThreshold = 0.05;
+static const NSTimeInterval kSingleTapContextMenuDelay = 0.15;
 static char kMapSourceUpdateQueueKey;
 
 @interface OATouchLocation : NSObject
@@ -230,6 +231,8 @@ static char kMapSourceUpdateQueueKey;
     UITapGestureRecognizer* _grSymbolContextMenu;
     UILongPressGestureRecognizer* _grPointContextMenu;
     UIPanGestureRecognizer* _grMouseWheelScroll;
+
+    dispatch_block_t _pendingContextMenuBlock;
 
     BOOL _startRotating;
     BOOL _startZooming;
@@ -456,10 +459,6 @@ static char kMapSourceUpdateQueueKey;
     _grPointContextMenu = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                         action:@selector(pointContextMenuGestureDetected:)];
     _grPointContextMenu.delegate = self;
-
-    // prevents single tap to fire together with double tap
-    [_grSymbolContextMenu requireGestureRecognizerToFail:_grZoomIn];
-    [_grSymbolContextMenu requireGestureRecognizerToFail:_grZoomDoubleTap];
 
     [self createGeoTiffCollection];
 
@@ -927,6 +926,8 @@ static char kMapSourceUpdateQueueKey;
 
 - (BOOL) gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
+    if (gestureRecognizer == _grSymbolContextMenu && touch.tapCount >= 2)
+        [self cancelPendingContextMenu];
     if (gestureRecognizer == _grZoomOut && [[OAAppSettings sharedManager].showDistanceRuler get])
         return NO;
     if (gestureRecognizer == _grZoomDoubleTap)
@@ -1562,6 +1563,8 @@ static char kMapSourceUpdateQueueKey;
     if (recognizer.state != UIGestureRecognizerStateEnded)
         return;
 
+    [self cancelPendingContextMenu];
+
     if (_mapView.zoomLevel >= _mapView.maxZoom)
         return;
 
@@ -1735,16 +1738,49 @@ static char kMapSourceUpdateQueueKey;
     accepted |= !longPress && recognizer.state == UIGestureRecognizerStateEnded;
     if (accepted)
     {
-        OAMapPanelViewController *mapPanel = [OARootViewController instance].mapPanel;
-        OAFloatingButtonsHudViewController *quickAction = mapPanel.hudViewController.floatingButtonsController;
-        [quickAction hideActionsSheetAnimated:nil];
-        [_mapLayers.contextMenuLayer showContextMenu:touchPoint showUnknownLocation:longPress forceHide:[recognizer isKindOfClass:UITapGestureRecognizer.class] && recognizer.numberOfTouches == 1];
-        
-        // Handle route planning touch events
-        [_mapLayers.routePlanningLayer onMapPointSelected:CLLocationCoordinate2DMake(lat, lon) longPress:longPress];
+        BOOL forceHide = [recognizer isKindOfClass:UITapGestureRecognizer.class] && recognizer.numberOfTouches == 1;
+        if (recognizer == _grSymbolContextMenu)
+        {
+            [self scheduleSingleTapContextMenu:touchPoint lat:lat lon:lon forceHide:forceHide];
+            return YES;
+        }
+        [self showContextMenuAtPoint:touchPoint lat:lat lon:lon longPress:longPress forceHide:forceHide];
         return YES;
     }
     return NO;
+}
+
+- (void)showContextMenuAtPoint:(CGPoint)touchPoint lat:(double)lat lon:(double)lon longPress:(BOOL)longPress forceHide:(BOOL)forceHide
+{
+    OAMapPanelViewController *mapPanel = [OARootViewController instance].mapPanel;
+    OAFloatingButtonsHudViewController *quickAction = mapPanel.hudViewController.floatingButtonsController;
+    [quickAction hideActionsSheetAnimated:nil];
+    [_mapLayers.contextMenuLayer showContextMenu:touchPoint showUnknownLocation:longPress forceHide:forceHide];
+    [_mapLayers.routePlanningLayer onMapPointSelected:CLLocationCoordinate2DMake(lat, lon) longPress:longPress];
+}
+
+- (void)scheduleSingleTapContextMenu:(CGPoint)touchPoint lat:(double)lat lon:(double)lon forceHide:(BOOL)forceHide
+{
+    [self cancelPendingContextMenu];
+    __weak __typeof(self) weakSelf = self;
+    dispatch_block_t block = dispatch_block_create((dispatch_block_flags_t)0, ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+        strongSelf->_pendingContextMenuBlock = nil;
+        [strongSelf showContextMenuAtPoint:touchPoint lat:lat lon:lon longPress:NO forceHide:forceHide];
+    });
+    _pendingContextMenuBlock = block;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kSingleTapContextMenuDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), block);
+}
+
+- (void)cancelPendingContextMenu
+{
+    if (_pendingContextMenuBlock)
+    {
+        dispatch_block_cancel(_pendingContextMenuBlock);
+        _pendingContextMenuBlock = nil;
+    }
 }
 
 - (id<OAMapRendererViewProtocol>) mapRendererView

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -1505,15 +1505,21 @@ typedef enum
 
     [self setSelectedObject:targetPoint];
 
-    [self showTargetPointMenu:saveState showFullMenu:NO onComplete:^{
-        
-        [_mapViewController contextMenuDidShow:selectedObject.object];
-        if (targetPoint.centerMap)
-            [self goToTargetPointWithZoom:preferredZoom];
-        
-        if (_targetMenuView.needsManualContextMode)
-            [self enterContextMenuMode];
-    }];
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+        [strongSelf showTargetPointMenu:saveState showFullMenu:NO onComplete:^{
+
+            [strongSelf.mapViewController contextMenuDidShow:selectedObject.object];
+            if (targetPoint.centerMap)
+                [strongSelf goToTargetPointWithZoom:preferredZoom];
+
+            if (strongSelf.targetMenuView.needsManualContextMode)
+                [strongSelf enterContextMenuMode];
+        }];
+    });
 }
 
 - (void)setSelectedObject:(OATargetPoint *)targetPoint
@@ -2469,6 +2475,8 @@ typedef enum
     _mapStateSaved = saveMapState;
     
     OATargetMenuViewController *controller = [OATargetMenuViewController createMenuController:_targetMenuView.targetPoint selectedObject:_targetMenuView.selectedObject activeTargetType:_activeTargetType activeViewControllerState:_activeViewControllerState headerOnly:NO];
+    if (!showFullMenu)
+        [controller setDetailRowsDeferred:YES];
     BOOL prepared = NO;
     switch (_targetMenuView.targetPoint.type)
     {
@@ -2585,7 +2593,8 @@ typedef enum
     }
     
     [self.view addSubview:self.targetMenuView];
-    
+    [self.targetMenuView layoutIfNeeded];
+
     if (onComplete)
         onComplete();
     

--- a/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
+++ b/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
@@ -135,6 +135,10 @@ static const NSInteger kOrderCoordinatesRow = 20000;
 
     BOOL _otherCardsReady;
     BOOL _isFetchingNearestPoi;
+    BOOL _rowUpdatesDeferred;
+    BOOL _pendingRowUpdate;
+    BOOL _detailRowsDeferred;
+    BOOL _pendingDetailRowsBuild;
 }
 
 - (instancetype)init
@@ -162,8 +166,41 @@ static const NSInteger kOrderCoordinatesRow = 20000;
     [self updateInfoRows];
 }
 
+- (void)setRowUpdatesDeferred:(BOOL)deferred
+{
+    if (_rowUpdatesDeferred == deferred)
+        return;
+
+    _rowUpdatesDeferred = deferred;
+    if (!deferred && _pendingRowUpdate)
+    {
+        _pendingRowUpdate = NO;
+        [self updateInfoRows];
+    }
+}
+
+- (void)setDetailRowsDeferred:(BOOL)deferred
+{
+    _detailRowsDeferred = deferred;
+}
+
+- (void)buildDeferredDetailRows
+{
+    if (!_pendingDetailRowsBuild)
+        return;
+
+    _pendingDetailRowsBuild = NO;
+    _detailRowsDeferred = NO;
+    [self rebuildRows];
+}
+
 - (void) updateInfoRows
 {
+    if (_rowUpdatesDeferred)
+    {
+        _pendingRowUpdate = YES;
+        return;
+    }
     [self sortInfoRows];
     _calculatedWidth = 0;
     [self.tableView reloadData];
@@ -266,7 +303,14 @@ static const NSInteger kOrderCoordinatesRow = 20000;
 
     if (_showTitleIfTruncated)
         [self buildTitleRow:rows];
-    
+
+    if (_detailRowsDeferred)
+    {
+        _pendingDetailRowsBuild = YES;
+        [self updateInfoRows];
+        return;
+    }
+
     [self buildWithinRow:rows];
     [self buildNearestRows:rows];
     

--- a/Sources/Controllers/TargetMenu/OATargetMenuViewController.h
+++ b/Sources/Controllers/TargetMenu/OATargetMenuViewController.h
@@ -132,6 +132,10 @@ typedef void (^ContentHeightChangeListenerBlock)(CGFloat newHeight);
 
 - (UIColor *)getAdditionalInfoColor;
 - (NSAttributedString *)getAdditionalInfoStr;
+
+- (void)setRowUpdatesDeferred:(BOOL)deferred;
+- (void)setDetailRowsDeferred:(BOOL)deferred;
+- (void)buildDeferredDetailRows;
 - (UIImage *)getAdditionalInfoImage;
 
 - (BOOL)supportFullMenu;

--- a/Sources/Controllers/TargetMenu/OATargetMenuViewController.mm
+++ b/Sources/Controllers/TargetMenu/OATargetMenuViewController.mm
@@ -562,6 +562,18 @@
     return nil;
 }
 
+- (void)setRowUpdatesDeferred:(BOOL)deferred
+{
+}
+
+- (void)setDetailRowsDeferred:(BOOL)deferred
+{
+}
+
+- (void)buildDeferredDetailRows
+{
+}
+
 - (UIImage *)getAdditionalInfoImage
 {
     return nil;

--- a/Sources/Views/OATargetPointView.mm
+++ b/Sources/Views/OATargetPointView.mm
@@ -886,16 +886,23 @@ static const NSInteger _buttonsCount = 4;
             frame.origin.y = 0;
         }
         
-        [UIView animateWithDuration:0.3 animations:^{
-            
+        [self.customController setRowUpdatesDeferred:YES];
+        [UIView animateWithDuration:0.15 animations:^{
+
             self.frame = frame;
-            
+
         } completion:^(BOOL finished) {
             if (onComplete)
                 onComplete();
-            
+
             if (!_showFullScreen && self.customController && [self.customController supportMapInteraction])
                 [self.menuViewDelegate targetViewEnableMapInteraction];
+
+            OATargetMenuViewController *controller = self.customController;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [controller setRowUpdatesDeferred:NO];
+                [controller buildDeferredDetailRows];
+            });
         }];
     }
     else
@@ -913,6 +920,8 @@ static const NSInteger _buttonsCount = 4;
 
         if (!_showFullScreen && self.customController && [self.customController supportMapInteraction])
             [self.menuViewDelegate targetViewEnableMapInteraction];
+
+        [self.customController buildDeferredDetailRows];
     }
 
     [self startLocationUpdate];

--- a/Sources/Views/OATargetPointView.mm
+++ b/Sources/Views/OATargetPointView.mm
@@ -887,7 +887,7 @@ static const NSInteger _buttonsCount = 4;
         }
         
         [self.customController setRowUpdatesDeferred:YES];
-        [UIView animateWithDuration:0.15 animations:^{
+        [UIView animateWithDuration:0.2 animations:^{
 
             self.frame = frame;
 


### PR DESCRIPTION
Reduces the perceived latency and jank when opening the POI context menu on tap, bringing it closer to the Android timing.
Changes

- Single-tap delay instead of requireGestureRecognizerToFail. Removed the requireGestureRecognizerToFail: links between the single-tap context-menu recognizer and the zoom recognizers (they imposed the system's ~400 ms double-tap arbitration on every tap). Replaced with a tunable kSingleTapContextMenuDelay (0.15 s): the menu is scheduled after the tap and cancelled if a second tap begins (touch.tapCount >= 2) or a double-tap zoom fires. Net effect: single tap opens faster while double-tap-to-zoom still works.

- Two-phase menu build. On a collapsed open (showFullMenu == NO) only the header rows are built before the slide; the detail rows are built right after the slide completes (setDetailRowsDeferred: / buildDeferredDetailRows). This keeps the table render off the animation's critical path.

- Deferred row reloads during the slide (setRowUpdatesDeferred:) so async row updates don't reload the table mid-animation.

- Marker and selection polygon drawn first. Menu presentation now yields one runloop cycle before building the menu controller, so the context pin marker and the selected-object polygon/contour highlight render immediately, before the heavier controller/menu build runs.

- Slide animation 0.3 s → 0.15 s.