### PR TITLE
Fix Referer header for SQLite tile sources

### DIFF
--- a/OsmAnd MapsTests/Networking/OAWebClientTests.mm
+++ b/OsmAnd MapsTests/Networking/OAWebClientTests.mm
@@ -1,0 +1,53 @@
+//
+//  OAWebClientTests.mm
+//  OsmAnd MapsTests
+//
+//  Copyright © 2026 OsmAnd. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "OAWebClient.h"
+
+@interface OAWebClientTests : XCTestCase
+@end
+
+@implementation OAWebClientTests
+
+- (void)testRequestHeadersIncludeUserAgentAndReferer
+{
+    OAWebClientDataRequest dataRequest;
+    dataRequest.headers[QStringLiteral("Referer")] = QStringLiteral("https://nakarte.me/");
+
+    const auto headers = OAWebClient::getRequestHeaders(
+        QStringLiteral("Custom User Agent"),
+        dataRequest);
+
+    XCTAssertTrue(headers.value(QStringLiteral("User-Agent")) == QStringLiteral("Custom User Agent"));
+    XCTAssertTrue(headers.value(QStringLiteral("Referer")) == QStringLiteral("https://nakarte.me/"));
+}
+
+- (void)testRequestHeadersOmitEmptyReferer
+{
+    OAWebClientDataRequest dataRequest;
+
+    const auto headers = OAWebClient::getRequestHeaders(
+        QStringLiteral("Custom User Agent"),
+        dataRequest);
+
+    XCTAssertTrue(headers.value(QStringLiteral("User-Agent")) == QStringLiteral("Custom User Agent"));
+    XCTAssertFalse(headers.contains(QStringLiteral("Referer")));
+}
+
+- (void)testRequestHeadersSupportGenericDataRequest
+{
+    OsmAnd::IWebClient::DataRequest dataRequest;
+
+    const auto headers = OAWebClient::getRequestHeaders(
+        QStringLiteral("Custom User Agent"),
+        dataRequest);
+
+    XCTAssertTrue(headers.value(QStringLiteral("User-Agent")) == QStringLiteral("Custom User Agent"));
+    XCTAssertFalse(headers.contains(QStringLiteral("Referer")));
+}
+
+@end

--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -1701,6 +1701,7 @@
 		D1A0B0032F50000100A0B001 /* OpeningHoursParserTestSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0002F50000100A0B001 /* OpeningHoursParserTestSupport.mm */; };
 		D1A0B0112F50001100A0B001 /* URLExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0102F50001100A0B001 /* URLExtractionTests.swift */; };
 		D1A0B0122F50001100A0B001 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3216E9522BA097BD0087D0EF /* StringExtensions.swift */; };
+		F0A1B00230D5000100A1B002 /* OAWebClientTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B00130D5000100A1B001 /* OAWebClientTests.mm */; };
 		D71B9A8C2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71B9A8B2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift */; };
 		D71B9A8E2FC96D2D00FBB0F3 /* OrganizeByTypeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71B9A8D2FC96D2D00FBB0F3 /* OrganizeByTypeExtension.swift */; };
 		D71B9A902FC99D5D00FBB0F3 /* OrganizeByTypeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71B9A8F2FC99D5D00FBB0F3 /* OrganizeByTypeCell.swift */; };
@@ -5709,6 +5710,7 @@
 		D1A0AFFF2F50000100A0B001 /* OpeningHoursParserTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpeningHoursParserTestSupport.h; sourceTree = "<group>"; };
 		D1A0B0002F50000100A0B001 /* OpeningHoursParserTestSupport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OpeningHoursParserTestSupport.mm; sourceTree = "<group>"; };
 		D1A0B0102F50001100A0B001 /* URLExtractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtractionTests.swift; sourceTree = "<group>"; };
+		F0A1B00130D5000100A1B001 /* OAWebClientTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OAWebClientTests.mm; sourceTree = "<group>"; };
 		D71B9A8B2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeTracksByViewController.swift; sourceTree = "<group>"; };
 		D71B9A8D2FC96D2D00FBB0F3 /* OrganizeByTypeExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeByTypeExtension.swift; sourceTree = "<group>"; };
 		D71B9A8F2FC99D5D00FBB0F3 /* OrganizeByTypeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeByTypeCell.swift; sourceTree = "<group>"; };
@@ -14336,6 +14338,7 @@
 				FA7EA4082FD2ACF700509B01 /* Extensions */,
 				FAB624402E0953870048965E /* OsmAnd MapsTests-Bridging-Header.h */,
 				FAB6243D2E0953580048965E /* Managers */,
+				F0A1B00330D5000100A1B003 /* Networking */,
 				DA80DAA8251E0C0C008E6267 /* Router */,
 				8A1CF862250D145C003D3829 /* test-resources */,
 				DA72AB932508F44900851313 /* Search */,
@@ -14909,6 +14912,14 @@
 				D1A0B0102F50001100A0B001 /* URLExtractionTests.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		F0A1B00330D5000100A1B003 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				F0A1B00130D5000100A1B001 /* OAWebClientTests.mm */,
+			);
+			path = Networking;
 			sourceTree = "<group>";
 		};
 		FA82B9172E74197A00A250F1 /* ImageLoading */ = {
@@ -19014,6 +19025,7 @@
 				D1A0B0012F50000100A0B001 /* OpeningHoursParserTest.swift in Sources */,
 				D1A0B0032F50000100A0B001 /* OpeningHoursParserTestSupport.mm in Sources */,
 				D1A0B0112F50001100A0B001 /* URLExtractionTests.swift in Sources */,
+				F0A1B00230D5000100A1B002 /* OAWebClientTests.mm in Sources */,
 				FAB6243F2E0953830048965E /* SelectionManagerTests.swift in Sources */,
 				DA80DAAA251E0C37008E6267 /* OARouteResultPreparationTest.mm in Sources */,
 				FAB624412E0954F90048965E /* SelectionManager.swift in Sources */,

--- a/Sources/Core/OASQLiteTileSourceMapLayerProvider.h
+++ b/Sources/Core/OASQLiteTileSourceMapLayerProvider.h
@@ -29,6 +29,7 @@ private:
     
     std::shared_ptr<OsmAnd::TileSqliteDatabase> _ts;
     QString _fileName;
+    QString _referer;
     QString _userAgent;
     int _tileSize;
     QList<QString> _randomsArray;

--- a/Sources/Core/OASQLiteTileSourceMapLayerProvider.mm
+++ b/Sources/Core/OASQLiteTileSourceMapLayerProvider.mm
@@ -45,7 +45,10 @@ OASQLiteTileSourceMapLayerProvider::OASQLiteTileSourceMapLayerProvider(const QSt
             if (ok)
                 _tileSize = (int) tileSize;
             
-            ok = true;
+            auto referer = meta.getReferer(&ok);
+            if (ok)
+                _referer = referer;
+
             auto userAgent = meta.getUserAgent(&ok);
             if (ok)
                 _userAgent = userAgent;
@@ -148,8 +151,10 @@ QByteArray OASQLiteTileSourceMapLayerProvider::downloadTile(
     const auto& tileUrl = getUrlToLoad(tileId, zoom);
     if (!tileUrl.isEmpty())
     {
-        OsmAnd::IWebClient::DataRequest dataRequest;
+        OAWebClientDataRequest dataRequest;
         dataRequest.queryController = queryController;
+        if (!_referer.isEmpty())
+            dataRequest.headers[QStringLiteral("Referer")] = _referer;
         const auto& downloadResult = _webClient->downloadData(tileUrl, dataRequest, _userAgent);
         
         // If there was error, check what the error was

--- a/Sources/Core/OAWebClient.h
+++ b/Sources/Core/OAWebClient.h
@@ -13,7 +13,13 @@
 #include <objc/objc.h>
 
 #include <OsmAndCore/IWebClient.h>
+#include <QHash>
 
+class OAWebClientDataRequest : public OsmAnd::IWebClient::DataRequest
+{
+public:
+    QHash<QString, QString> headers;
+};
 
 class OARequestResult : public OsmAnd::IWebClient::IRequestResult
 {
@@ -63,6 +69,10 @@ public:
         const QString& fileName,
         const long long lastTime,
         IWebClient::DataRequest& dataRequest) const;
+
+    static QHash<QString, QString> getRequestHeaders(
+        const QString& userAgent,
+        const IWebClient::DataRequest& dataRequest);
 };
 
 

--- a/Sources/Core/OAWebClient.mm
+++ b/Sources/Core/OAWebClient.mm
@@ -63,7 +63,9 @@ QByteArray OAWebClient::downloadData(
     if (url != nullptr && !url.isEmpty())
     {
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[url.toNSString() stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet]] cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:kTimeout];
-        [request addValue:(userAgent.isNull() || userAgent.isEmpty()) ? OAAppVersion.getVersionForUrl : userAgent.toNSString() forHTTPHeaderField:@"User-Agent"];
+        const auto headers = getRequestHeaders(userAgent, dataRequest);
+        for (auto it = headers.constBegin(); it != headers.constEnd(); ++it)
+            [request addValue:it.value().toNSString() forHTTPHeaderField:it.key().toNSString()];
 
         unsigned int responseCode = 0;
         NSURLResponse __block *response = nil;
@@ -115,6 +117,22 @@ QByteArray OAWebClient::downloadData(
         dataRequest.requestResult.reset(new OAHttpRequestResult(true, responseCode));
     }
     return res;
+}
+
+QHash<QString, QString> OAWebClient::getRequestHeaders(
+    const QString& userAgent,
+    const IWebClient::DataRequest& dataRequest)
+{
+    const auto webClientDataRequest = dynamic_cast<const OAWebClientDataRequest*>(&dataRequest);
+    QHash<QString, QString> headers = webClientDataRequest
+        ? webClientDataRequest->headers
+        : QHash<QString, QString>();
+
+    headers[QStringLiteral("User-Agent")] = (userAgent.isNull() || userAgent.isEmpty())
+        ? QString::fromNSString(OAAppVersion.getVersionForUrl)
+        : userAgent;
+
+    return headers;
 }
 
 QString OAWebClient::downloadString(

--- a/Sources/Helpers/OAMapTileDownloader.mm
+++ b/Sources/Helpers/OAMapTileDownloader.mm
@@ -273,6 +273,8 @@
                                                        timeoutInterval:60.0];
     [request setHTTPMethod:@"GET"];
     [request addValue:tileSource.userAgent.length > 0 ? tileSource.userAgent : kDefaultUserAgent forHTTPHeaderField:@"User-Agent"];
+    if (tileSource.referer.length > 0)
+        [request addValue:tileSource.referer forHTTPHeaderField:@"Referer"];
     NSURLSessionDownloadTask *task = [_urlSession downloadTaskWithRequest:request completionHandler:^(NSURL * _Nullable location, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         NSData *data = [NSData dataWithContentsOfFile:location.path];
         if (data)


### PR DESCRIPTION
## Summary
- read the `referer` value from SQLite tile source metadata
- add the configured value as the HTTP `Referer` header for online tile requests
- preserve existing custom and default `User-Agent` behavior
- apply the header in both map rendering and bulk tile download paths
- add focused tests for custom request headers

## Problem
OsmAnd iOS reads and applies `info.useragent` from online SQLite tile sources, but `info.referer` was parsed without being added to tile download requests. Tile servers that require a matching Referer therefore reject requests from iOS.

