### PR TITLE
Pt prioritize platform instead of stop for routes 5 #22830

### DIFF
--- a/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
+++ b/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
@@ -207,14 +207,14 @@ static NSInteger const MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS = 20;
             NSString *connectedPlatformId = [stop getConnectedPlatformId];
             auto dist = OsmAnd::Utilities::distance(stop.longitude, stop.latitude, lon, lat);
             
-            if (([stopName containsString:amenityName] || [amenityName containsString:stopName])
+            if ((([stopName containsString:amenityName] || [amenityName containsString:stopName])
                 && dist < MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS
                 && (!nearestStop
-                    || [OAUtilities isCoordEqual:[nearestStop getLocation].coordinate destLat:[stop getLocation].coordinate]
+                    || [OAUtilities isCoordEqual:[nearestStop getLocation].coordinate destLat:[stop getLocation].coordinate]))
                     || [OAUtilities isCoordEqual:[stop getLocation].coordinate destLat:CLLocationCoordinate2DMake(lat, lon)]
                     || (connectedPlatformId
                         && ([connectedPlatformId isEqualToString:[@(amenity.obfId) stringValue]]
-                            || (nearestStop && [connectedPlatformId isEqualToString:[@(nearestStop.obfId) stringValue]]))))
+                            || (nearestStop && [connectedPlatformId isEqualToString:[@(nearestStop.obfId) stringValue]])))
                 )
             {
                 [stopAggregated addLocalTransportStop:stop];

--- a/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
+++ b/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
@@ -204,13 +204,17 @@ static NSInteger const MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS = 20;
         {
             [stop setTransportStopAggregated:stopAggregated];
             NSString *stopName = [[stop name] lowercaseString];
+            NSString *connectedPlatformId = [stop getConnectedPlatformId];
             auto dist = OsmAnd::Utilities::distance(stop.longitude, stop.latitude, lon, lat);
             
             if (([stopName containsString:amenityName] || [amenityName containsString:stopName])
                 && dist < MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS
                 && (!nearestStop
                     || [OAUtilities isCoordEqual:[nearestStop getLocation].coordinate destLat:[stop getLocation].coordinate]
-                    || [OAUtilities isCoordEqual:[stop getLocation].coordinate destLat:CLLocationCoordinate2DMake(lat, lon)])
+                    || [OAUtilities isCoordEqual:[stop getLocation].coordinate destLat:CLLocationCoordinate2DMake(lat, lon)]
+                    || (connectedPlatformId
+                        && ([connectedPlatformId isEqualToString:[@(amenity.obfId) stringValue]]
+                            || (nearestStop && [connectedPlatformId isEqualToString:[@(nearestStop.obfId) stringValue]]))))
                 )
             {
                 [stopAggregated addLocalTransportStop:stop];

--- a/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
+++ b/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
@@ -214,7 +214,7 @@ static NSInteger const MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS = 20;
                     || [OAUtilities isCoordEqual:[stop getLocation].coordinate destLat:CLLocationCoordinate2DMake(lat, lon)]
                     || (connectedPlatformId
                         && ([connectedPlatformId isEqualToString:[@(amenity.obfId) stringValue]]
-                            || (nearestStop && [connectedPlatformId isEqualToString:[@(nearestStop.obfId) stringValue]])))
+                            || (nearestStop && [connectedPlatformId isEqualToString:[@(nearestStop.stopId) stringValue]])))
                 )
             {
                 [stopAggregated addLocalTransportStop:stop];

--- a/Sources/Transport/OATransportStop.h
+++ b/Sources/Transport/OATransportStop.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)findAmenityDataIfNeeded;
 - (NSString *)getStopObjectName:(NSString *)lang transliterate:(BOOL)transliterate;
+- (NSString *)getConnectedPlatformId;
 
 @end
 

--- a/Sources/Transport/OATransportStop.mm
+++ b/Sources/Transport/OATransportStop.mm
@@ -15,6 +15,7 @@
 
 #include <OsmAndCore.h>
 #include <OsmAndCore/Utilities.h>
+#include <OsmAndCore/QKeyValueIterator.h>
 #include <OsmAndCore/Data/TransportStop.h>
 #include <OsmAndCore/Data/TransportRoute.h>
 #include <OsmAndCore/Data/TransportStopExit.h>
@@ -37,6 +38,7 @@ static NSString *CONNECTED_PLATFORM_ID = @"osmand:connected_platform_id";
 
 - (instancetype)initWithStop:(std::shared_ptr<const OsmAnd::TransportStop>)stop
 {
+    self = [super init];
     if (self)
     {
         _stop = stop;
@@ -48,6 +50,10 @@ static NSString *CONNECTED_PLATFORM_ID = @"osmand:connected_platform_id";
             self.latitude = stop->location.latitude;
             self.longitude = stop->location.longitude;
             self.stopId = stop->id.id;
+            for (const auto& entry : OsmAnd::rangeOf(OsmAnd::constOf(stop->localizedNames)))
+            {
+                self.localizedNames[entry.key().toNSString()] = entry.value().toNSString();
+            }
             
             NSMutableArray<CLLocation *> *extiLocations = [NSMutableArray new];
             const auto stopExits = stop->exits;

--- a/Sources/Transport/OATransportStop.mm
+++ b/Sources/Transport/OATransportStop.mm
@@ -19,6 +19,8 @@
 #include <OsmAndCore/Data/TransportRoute.h>
 #include <OsmAndCore/Data/TransportStopExit.h>
 
+static NSString *CONNECTED_PLATFORM_ID = @"osmand:connected_platform_id";
+
 
 @interface OATransportStop()
 
@@ -112,6 +114,11 @@
     const auto qLang = QString::fromNSString(lang);
     const auto qName = _stop->getName(qLang, transliterate);
     return qName.toNSString();
+}
+
+- (NSString *)getConnectedPlatformId
+{
+    return self.localizedNames[CONNECTED_PLATFORM_ID];
 }
 
 - (BOOL)isEqual:(OATransportStop *)object


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/22830)

[synced this android request](https://github.com/osmandapp/OsmAnd/pull/25316)

[related core request](https://github.com/osmandapp/OsmAnd-core/pull/1073)




### Transport Stop (Points)

---

40.53729 -3.89062
https://www.openstreetmap.org/node/7317152907 
(there are 6 routes but OsmAnd only displays 1) 

before / after:

<img width="1325" height="801" alt="Screenshot 2026-06-30 at 00 00 42" src="https://github.com/user-attachments/assets/55b5921b-20a9-43b0-8bd0-709f509cf1bd" />


---

40.51562 -3.89957
https://www.openstreetmap.org/node/2050786713 
(there are 7 routes but OsmAnd only displays 1)

<img width="1330" height="809" alt="Screenshot 2026-06-30 at 00 01 27" src="https://github.com/user-attachments/assets/8f418dd8-611a-46cf-97bd-3378745a681c" />


---

40.43444 -3.71925
https://www.openstreetmap.org/node/1439708980 
(there are 10 routes but OsmAnd displays 1 route from the nearest platform) 

<img width="1328" height="809" alt="Screenshot 2026-06-30 at 00 02 45" src="https://github.com/user-attachments/assets/b92ffa39-39ad-4ebd-b279-0ef6ad00f19d" />


---


### Transport Platforms (Polygons)

40.73781 -4.06424
https://www.openstreetmap.org/way/190124171 
(there are 3 routes but OsmAnd displays 0)

<img width="1331" height="808" alt="Screenshot 2026-06-30 at 00 03 53" src="https://github.com/user-attachments/assets/80e124f9-7264-40a8-9ba5-f1c1cf5caa48" />


---

40.70687 -4.06702
https://www.openstreetmap.org/way/1227180184 
(there is 1 route but OsmAnd displays 0, however the other platform of this train station is correct)

<img width="1332" height="809" alt="Screenshot 2026-06-30 at 00 05 08" src="https://github.com/user-attachments/assets/8693284b-7a05-4120-a273-c8284f5d6fcd" />


---

40.47337 -3.68258
https://www.openstreetmap.org/way/202094336 
(user: there are 3 routes but OsmAnd displays 0)
(nnngrach: I think there should be 5 routes)

<img width="1329" height="808" alt="Screenshot 2026-06-30 at 00 06 38" src="https://github.com/user-attachments/assets/a32e43aa-4425-442b-b506-a9db2897ee78" />





---

obf files for testing:

[Madrid_crop_old.obf.zip](https://github.com/user-attachments/files/29340282/Madrid_crop_old.obf.zip)

[Madrid_crop_new.obf.zip](https://github.com/user-attachments/files/29340298/Madrid_crop_new.obf.zip)

