### PR TITLE
Fix slow search history loading

### DIFF
--- a/Sources/Controllers/TargetMenu/Search/OAHistoryTableViewController.mm
+++ b/Sources/Controllers/TargetMenu/Search/OAHistoryTableViewController.mm
@@ -40,6 +40,8 @@
 {
     OAAppSettings *_settings;
     OATableDataModel *_data;
+    dispatch_queue_t _historyDataQueue;
+    NSUInteger _reloadGeneration;
     BOOL _decelerating;
     NSArray *_headerViews;
     BOOL _wasAnyDeleted;
@@ -52,6 +54,7 @@
     if (self)
     {
         self.view.frame = frame;
+        _historyDataQueue = dispatch_queue_create("com.osmand.history.tableDataQueue", DISPATCH_QUEUE_SERIAL);
     }
     return self;
 }
@@ -157,10 +160,7 @@
     }
     else
     {
-        [self generateData];
-        if (self.groupsAndItems.count > 0)
-            [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
-        [self updateDistanceAndDirection];
+        [self reloadHistoryDataAndScrollToTopAsync];
     }
 }
 
@@ -203,92 +203,98 @@
     }
     else
     {
-        self.groupsAndItems = [NSMutableArray array];
-        NSMutableArray *headerViews = [NSMutableArray array];
-        
+        [self reloadHistoryDataAsync];
+    }
+}
+
+- (NSArray<OAMultiselectableHeaderView *> *)createHeaderViewsForGroups:(NSArray<OASearchHistoryTableGroup *> *)groups
+{
+    NSMutableArray *headerViews = [NSMutableArray arrayWithCapacity:groups.count];
+    int i = 0;
+    for (OASearchHistoryTableGroup *group in groups)
+    {
+        OAMultiselectableHeaderView *headerView = [[OAMultiselectableHeaderView alloc] initWithFrame:CGRectMake(0.0, 1.0, 100.0, 44.0)];
+        if ([group.groupName isEqualToString:@"0"])
+            [headerView setTitleText:OALocalizedString(@"today")];
+        else if ([group.groupName isEqualToString:@"1"])
+            [headerView setTitleText:OALocalizedString(@"yesterday")];
+        else
+            [headerView setTitleText:group.groupName];
+
+        headerView.section = i++;
+        headerView.delegate = self;
+        [headerViews addObject:headerView];
+    }
+    return [NSArray arrayWithArray:headerViews];
+}
+
+- (void)reloadHistoryDataAsync
+{
+    [self reloadHistoryDataAsyncWithScrollToTop:NO];
+}
+
+- (void)reloadHistoryDataAndScrollToTopAsync
+{
+    [self reloadHistoryDataAsyncWithScrollToTop:YES];
+}
+
+- (void)reloadHistoryDataAsyncWithScrollToTop:(BOOL)scrollToTop
+{
+    NSUInteger generation = ++_reloadGeneration;
+    BOOL searchNearMapCenter = _searchNearMapCenter;
+    OsmAnd::PointI myLocation31 = _myLocation;
+    NSTimeInterval todayBeginTime = [self beginningOfToday];
+    NSTimeInterval yesterdayBeginTime = todayBeginTime - 60 * 60 * 24;
+
+    dispatch_async(_historyDataQueue, ^{
         OAHistoryHelper *helper = [OAHistoryHelper sharedInstance];
         NSArray *allItems = [helper getPointsHavingTypes:helper.searchTypes exceptNavigation:NO limit:0];
-        
-        NSTimeInterval todayBeginTime = [self beginningOfToday];
-        NSTimeInterval yesterdayBeginTime = todayBeginTime - 60 * 60 * 24;
-        
         NSDateFormatter *fmt = [[NSDateFormatter alloc] init];
         [fmt setDateFormat:@"LLLL - yyyy"];
-        
-        OsmAnd::LatLon latLon = OsmAnd::Utilities::convert31ToLatLon(_myLocation);
+
+        OsmAnd::LatLon latLon = OsmAnd::Utilities::convert31ToLatLon(myLocation31);
         CLLocationCoordinate2D myLocation = CLLocationCoordinate2DMake(latLon.latitude, latLon.longitude);
-        
+        NSMutableArray<OASearchHistoryTableGroup *> *groups = [NSMutableArray array];
+        NSMutableDictionary<NSString *, OASearchHistoryTableGroup *> *groupsByName = [NSMutableDictionary dictionary];
+
         for (OAHistoryItem *item in allItems)
         {
             NSString *groupName;
             NSTimeInterval time = [item.date timeIntervalSince1970];
             if (time < yesterdayBeginTime)
-            {
                 groupName = [fmt stringFromDate:item.date];
-            }
             else if (time < todayBeginTime)
-            {
                 groupName = @"1";
-            }
             else
-            {
                 groupName = @"0";
-            }
-            
-            OASearchHistoryTableGroup *grp;
-            for (OASearchHistoryTableGroup *g in self.groupsAndItems)
-                if ([g.groupName isEqualToString:groupName])
-                {
-                    grp = g;
-                    break;
-                }
-            
+
+            OASearchHistoryTableGroup *grp = groupsByName[groupName];
             if (!grp)
             {
                 grp = [[OASearchHistoryTableGroup alloc] init];
                 grp.groupName = groupName;
-                [self.groupsAndItems addObject:grp];
+                groupsByName[groupName] = grp;
+                [groups addObject:grp];
             }
-            
-            OASearchHistoryTableItem *tableItem;
-            if (_searchNearMapCenter)
-                tableItem = [[OASearchHistoryTableItem alloc] initWithItem:item mapCenterCoordinate:myLocation];
-            else
-                tableItem = [[OASearchHistoryTableItem alloc] initWithItem:item];
-            
+
+            OASearchHistoryTableItem *tableItem = searchNearMapCenter
+                    ? [[OASearchHistoryTableItem alloc] initWithItem:item mapCenterCoordinate:myLocation]
+                    : [[OASearchHistoryTableItem alloc] initWithItem:item];
             [grp.groupItems addObject:tableItem];
         }
-        
-        // Sort items
-        /*
-         NSArray *sortedArrayGroups = [self.groupsAndItems sortedArrayUsingComparator:^NSComparisonResult(SearchHistoryTableGroup* obj1, SearchHistoryTableGroup* obj2) {
-         return [obj1.groupName localizedCaseInsensitiveCompare:obj2.groupName];
-         }];
-         [self.groupsAndItems setArray:sortedArrayGroups];
-         */
-        
-        int i = 0;
-        for (OASearchHistoryTableGroup *group in self.groupsAndItems)
-        {
-            // add header
-            OAMultiselectableHeaderView *headerView = [[OAMultiselectableHeaderView alloc] initWithFrame:CGRectMake(0.0, 1.0, 100.0, 44.0)];
-            if ([group.groupName isEqualToString:@"0"])
-                [headerView setTitleText:OALocalizedString(@"today")];
-            else if ([group.groupName isEqualToString:@"1"])
-                [headerView setTitleText:OALocalizedString(@"yesterday")];
-            else
-                [headerView setTitleText:group.groupName];
-            
-            headerView.section = i++;
-            headerView.delegate = self;
-            [headerViews addObject:headerView];
-        }
-        
-        if (doReload)
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (generation != _reloadGeneration)
+                return;
+
+            self.groupsAndItems = [NSMutableArray arrayWithArray:groups];
+            _headerViews = [self createHeaderViewsForGroups:groups];
             [self.tableView reloadData];
-        
-        _headerViews = [NSArray arrayWithArray:headerViews];
-    }
+            if (scrollToTop && self.groupsAndItems.count > 0 && [self.tableView numberOfRowsInSection:0] > 0)
+                [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
+            [self updateDistanceAndDirection];
+        });
+    });
 }
 
 -(void)setSearchNearMapCenter:(BOOL)searchNearMapCenter

--- a/Sources/History/OAHistoryDB.h
+++ b/Sources/History/OAHistoryDB.h
@@ -16,6 +16,7 @@
 - (void)addPoint:(OAHistoryItem *)item;
 - (void)importBackupPoints:(NSArray<OAHistoryItem *> *)items;
 - (void)deletePoint:(OAHistoryItem *)item;
+- (void)deletePoints:(NSArray<OAHistoryItem *> *)items;
 
 - (OAHistoryItem *)getPointByName:(NSString *)name fromNavigation:(BOOL)fromNavigation;
 - (NSArray<OAHistoryItem *> *)getPoints:(NSString *)selectPostfix limit:(int)limit;

--- a/Sources/History/OAHistoryDB.mm
+++ b/Sources/History/OAHistoryDB.mm
@@ -60,6 +60,7 @@
         NSLog(@"SQLite error: %@", errorString);
     }
 }
+
 - (void)createDb
 {
     NSString *dir = [NSHomeDirectory() stringByAppendingString:@"/Library/History"];
@@ -86,7 +87,7 @@
                     OALog(@"Failed to create table: %@", [NSString stringWithCString:errMsg encoding:NSUTF8StringEncoding]);
                 }
                 if (errMsg != NULL) sqlite3_free(errMsg);
-                
+
                 sqlite3_close(historyDB);
             }
             else
@@ -149,7 +150,7 @@
     [self addPoints: @[item] updateLastTime: YES];
 }
 
-- (void)addPoints:(NSArray<OAHistoryItem *> *)items updateLastTime: (BOOL) updateLastTime
+- (void)addPoints:(NSArray<OAHistoryItem *> *)items updateLastTime:(BOOL)updateLastTime
 {
     dispatch_async(dbQueue, ^{
         sqlite3_stmt *statement;
@@ -158,16 +159,17 @@
         {
             bool updateMarkers = NO;
             bool updateHistory = NO;
-            for(OAHistoryItem * item: items) {
+            for (OAHistoryItem * item: items)
+            {
                 int64_t hId = 0;
                 NSString *querySQL = [NSString stringWithFormat:@"SELECT ROWID FROM %@ WHERE %@ = ? AND %@ = ? ORDER BY %@ DESC LIMIT 1", TABLE_NAME, POINT_COL_HASH, POINT_COL_FROM_NAVIGATION, POINT_COL_TIME];
                 const char *query_stmt = [querySQL UTF8String];
                 int64_t hHash = item.hHash > 0 ? item.hHash : [self getRowHash:item.latitude longitude:item.longitude name:item.name];
-                if (item.hType == OAHistoryTypeDirection) {
+                if (item.hType == OAHistoryTypeDirection)
                     updateMarkers = YES;
-                } else {
+                else
                     updateHistory = YES;
-                }
+                
                 if (sqlite3_prepare_v2(historyDB, query_stmt, -1, &statement, NULL) == SQLITE_OK)
                 {
                     sqlite3_bind_int64(statement, 1, hHash);
@@ -189,8 +191,8 @@
                 if (hId > 0)
                     sqlite3_bind_int64(statement, row++, hId);
                 
-                NSString *iconName = item.iconName ? item.iconName : @"";
-                NSString *typeName = item.typeName ? item.typeName : @"";
+                NSString *iconName = item.iconName ?: @"";
+                NSString *typeName = item.typeName ?: @"";
                 int fromNavigation = item.fromNavigation ? 1 : 0;
                 
                 sqlite3_bind_int64(statement, row++, hHash);
@@ -198,7 +200,7 @@
                 sqlite3_bind_double(statement, row++, item.latitude);
                 sqlite3_bind_double(statement, row++, item.longitude);
                 sqlite3_bind_text(statement, row++, [item.name UTF8String], -1, SQLITE_TRANSIENT);
-                sqlite3_bind_int(statement, row++, item.hType);
+                sqlite3_bind_int(statement, row++, (int)item.hType);
                 sqlite3_bind_text(statement, row++, [iconName UTF8String], -1, SQLITE_TRANSIENT);
                 sqlite3_bind_text(statement, row++, [typeName UTF8String], -1, SQLITE_TRANSIENT);
                 sqlite3_bind_int(statement, row, fromNavigation);
@@ -209,38 +211,59 @@
                 
             }
             sqlite3_close(historyDB);
-            if (updateLastTime && updateMarkers) {
+            if (updateLastTime && updateMarkers)
                 [self updateMarkersHistoryLastModifiedTime];
-            }
-            if (updateLastTime && updateHistory) {
+            
+            if (updateLastTime && updateHistory)
                 [self updateHistoryLastModifiedTime];
-            }
         }
     });
 }
 
 - (void)deletePoint:(OAHistoryItem *)item
 {
+    [self deletePoints:@[item]];
+}
+
+- (void)deletePoints:(NSArray<OAHistoryItem *> *)items
+{
+    if (items.count == 0)
+        return;
+
     dispatch_async(dbQueue, ^{
-        sqlite3_stmt    *statement;
-        
+        sqlite3_stmt *statement;
         const char *dbpath = [databasePath UTF8String];
-        
+
         if (sqlite3_open(dbpath, &historyDB) == SQLITE_OK)
         {
+            bool updateMarkers = NO;
+            bool updateHistory = NO;
             NSString *query = [NSString stringWithFormat:@"DELETE FROM %@ WHERE ROWID=?", TABLE_NAME];
-            
-            const char *update_stmt = [query UTF8String];
-            
-            sqlite3_prepare_v2(historyDB, update_stmt, -1, &statement, NULL);
-            sqlite3_bind_int64(statement, 1, item.hId);
-            sqlite3_step(statement);
-            sqlite3_finalize(statement);
-            
+            const char *delete_stmt = [query UTF8String];
+
+            sqlite3_exec(historyDB, "BEGIN TRANSACTION", NULL, NULL, NULL);
+            if (sqlite3_prepare_v2(historyDB, delete_stmt, -1, &statement, NULL) == SQLITE_OK)
+            {
+                for (OAHistoryItem *item in items)
+                {
+                    sqlite3_bind_int64(statement, 1, item.hId);
+                    [self checkError:sqlite3_step(statement)];
+                    sqlite3_reset(statement);
+                    sqlite3_clear_bindings(statement);
+
+                    if (item.hType == OAHistoryTypeDirection)
+                        updateMarkers = YES;
+                    else
+                        updateHistory = YES;
+                }
+                sqlite3_finalize(statement);
+            }
+            sqlite3_exec(historyDB, "COMMIT", NULL, NULL, NULL);
+
             sqlite3_close(historyDB);
-            if (item.hType == OAHistoryTypeDirection)
+            if (updateMarkers)
                 [self updateMarkersHistoryLastModifiedTime];
-            else
+            if (updateHistory)
                 [self updateHistoryLastModifiedTime];
         }
     });
@@ -335,6 +358,16 @@
             {
                 OAAppSettings *settings = [OAAppSettings sharedManager];
                 OAPOIHelper *poiHelper = [OAPOIHelper sharedInstance];
+                NSMutableSet<NSString *> *disabledPoiTypeNames = [NSMutableSet set];
+                if (!ignoreDisabledResult)
+                {
+                    for (NSString *disabledPoiType in [settings getDisabledTypes])
+                    {
+                        NSString *disabledPoiTypeName = [poiHelper getPhraseByName:disabledPoiType];
+                        if (disabledPoiTypeName.length > 0)
+                            [disabledPoiTypeNames addObject:disabledPoiTypeName];
+                    }
+                }
                 while (sqlite3_step(statement) == SQLITE_ROW)
                 {
                     OAHistoryItem *item = [[OAHistoryItem alloc] init];
@@ -362,14 +395,7 @@
                     BOOL skipDisabledResult = NO;
                     if (!ignoreDisabledResult)
                     {
-                        NSSet<NSString *> *disabledPoiTypes = [settings getDisabledTypes];
-                        for (NSString *disabledPoiType in disabledPoiTypes)
-                        {
-                            if ([[poiHelper getPhraseByName:disabledPoiType] isEqualToString:typeName])
-                                skipDisabledResult = YES;
-                        }
-                        if (!skipDisabledResult)
-                            skipDisabledResult = type == OAHistoryTypePOI && ![OAAmenitySearcher findPOIByName:name lat:lat lon:lon];
+                        skipDisabledResult = typeName.length > 0 && [disabledPoiTypeNames containsObject:typeName];
                     }
                     if (!skipDisabledResult)
                     {

--- a/Sources/History/OAHistoryHelper.m
+++ b/Sources/History/OAHistoryHelper.m
@@ -84,10 +84,7 @@
 
 - (void)removePoints:(NSArray *)items
 {
-    for (OAHistoryItem *item in items)
-    {
-        [_db deletePoint:item];
-    }
+    [_db deletePoints:items];
     [_historyPointsRemoveObservable notifyEventWithKey:items];
 }
 


### PR DESCRIPTION
Avoid blocking the main thread while preparing search history data, remove per-entry POI lookup during history reads, and batch-delete history entries in one database transaction.