### PR TITLE
add-voice-alarm-for-enforcement_traffic_signal

### DIFF
--- a/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Resources/Localizations/en.lproj/Localizable.strings
@@ -714,6 +714,7 @@
 "traffic_warning_stop" = "Stop sign";
 "traffic_warning_calming" = "Traffic calming";
 "traffic_warning_speed_camera" = "Speed camera";
+"traffic_warning_enforcement_traffic_signals" = "Red light camera";
 "traffic_warning" = "Traffic warning";
 "traffic_warning_railways" = "Railroad crossing";
 "traffic_warning_pedestrian" = "Pedestrian crosswalk";

--- a/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Resources/Localizations/en.lproj/Localizable.strings
@@ -714,7 +714,7 @@
 "traffic_warning_stop" = "Stop sign";
 "traffic_warning_calming" = "Traffic calming";
 "traffic_warning_speed_camera" = "Speed camera";
-"traffic_warning_enforcement_traffic_signals" = "Red light camera";
+"traffic_warning_red_light_camera" = "Red light camera";
 "traffic_warning" = "Traffic warning";
 "traffic_warning_railways" = "Railroad crossing";
 "traffic_warning_pedestrian" = "Pedestrian crosswalk";

--- a/Sources/Controllers/Map/Widgets/OAAlarmWidget.mm
+++ b/Sources/Controllers/Map/Widgets/OAAlarmWidget.mm
@@ -172,7 +172,7 @@
                 }
                 text = @(alarm.intValue).stringValue;
             }
-            else if ([alarm isTrafficCamera])
+            else if (alarm.type == AIT_SPEED_CAMERA || alarm.type == AIT_RED_LIGHT_CAMERA)
             {
                 locImgId = @"warnings_speed_camera";
             }
@@ -236,7 +236,7 @@
             visible = (text && text.length > 0) || (locImgId.length > 0);
             if (visible)
             {
-                if ([alarm isTrafficCamera])
+                if (alarm.type == AIT_SPEED_CAMERA || alarm.type == AIT_RED_LIGHT_CAMERA)
                     visible = cams;
                 else if (alarm.type == AIT_PEDESTRIAN)
                     visible = peds;

--- a/Sources/Controllers/Map/Widgets/OAAlarmWidget.mm
+++ b/Sources/Controllers/Map/Widgets/OAAlarmWidget.mm
@@ -172,7 +172,7 @@
                 }
                 text = @(alarm.intValue).stringValue;
             }
-            else if ([alarm isSpeedCameraType])
+            else if ([alarm isTrafficCamera])
             {
                 locImgId = @"warnings_speed_camera";
             }
@@ -236,7 +236,7 @@
             visible = (text && text.length > 0) || (locImgId.length > 0);
             if (visible)
             {
-                if ([alarm isSpeedCameraType])
+                if ([alarm isTrafficCamera])
                     visible = cams;
                 else if (alarm.type == AIT_PEDESTRIAN)
                     visible = peds;

--- a/Sources/Controllers/Map/Widgets/OAAlarmWidget.mm
+++ b/Sources/Controllers/Map/Widgets/OAAlarmWidget.mm
@@ -172,7 +172,7 @@
                 }
                 text = @(alarm.intValue).stringValue;
             }
-            else if (alarm.type == AIT_SPEED_CAMERA)
+            else if ([alarm isSpeedCameraType])
             {
                 locImgId = @"warnings_speed_camera";
             }
@@ -236,7 +236,7 @@
             visible = (text && text.length > 0) || (locImgId.length > 0);
             if (visible)
             {
-                if (alarm.type == AIT_SPEED_CAMERA)
+                if ([alarm isSpeedCameraType])
                     visible = cams;
                 else if (alarm.type == AIT_PEDESTRIAN)
                     visible = peds;

--- a/Sources/Router/OAAlarmInfo.h
+++ b/Sources/Router/OAAlarmInfo.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, EOAAlarmInfoType)
     AIT_TUNNEL,
     AIT_HAZARD,
     AIT_MAXIMUM,
-    AIT_ENFORCEMENT_TRAFFIC_SIGNALS,
+    AIT_RED_LIGHT_CAMERA,
 };
 
 @interface OAAlarmInfo : NSObject<OALocationPoint>
@@ -50,6 +50,6 @@ typedef NS_ENUM(NSInteger, EOAAlarmInfoType)
 
 - (int) updateDistanceAndGetPriority:(float)time distance:(float)distance;
 
-- (BOOL) isSpeedCameraType;
+- (BOOL) isTrafficCamera;
 
 @end

--- a/Sources/Router/OAAlarmInfo.h
+++ b/Sources/Router/OAAlarmInfo.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, EOAAlarmInfoType)
     AIT_TUNNEL,
     AIT_HAZARD,
     AIT_MAXIMUM,
+    AIT_ENFORCEMENT_TRAFFIC_SIGNALS,
 };
 
 @interface OAAlarmInfo : NSObject<OALocationPoint>
@@ -48,5 +49,7 @@ typedef NS_ENUM(NSInteger, EOAAlarmInfoType)
 + (NSString* ) getVisualName:(EOAAlarmInfoType)type;
 
 - (int) updateDistanceAndGetPriority:(float)time distance:(float)distance;
+
+- (BOOL) isSpeedCameraType;
 
 @end

--- a/Sources/Router/OAAlarmInfo.mm
+++ b/Sources/Router/OAAlarmInfo.mm
@@ -57,6 +57,13 @@
             alarmInfo = [[OAAlarmInfo alloc] initWithType:AIT_STOP locationIndex:locInd];
         }
     }
+    else if ("enforcement" == ruleType.getTag())
+    {
+        if ("traffic_signals" == ruleType.getValue())
+        {
+            alarmInfo = [[OAAlarmInfo alloc] initWithType:AIT_ENFORCEMENT_TRAFFIC_SIGNALS locationIndex:locInd];
+        }
+    }
     else if ("barrier" == ruleType.getTag())
     {
         if ("toll_booth" == ruleType.getValue())
@@ -105,7 +112,7 @@
     if (time < 6 || distance < 75 || self.type == AIT_SPEED_LIMIT)
         return [self.class getPriority:self.type];
 
-    if (self.type == AIT_SPEED_CAMERA && (time < 15 || distance < 150))
+    if ([self isSpeedCameraType] && (time < 15 || distance < 150))
         return [self.class getPriority:self.type];
 
     // 2nd level
@@ -140,6 +147,8 @@
             return 10;
         case AIT_TUNNEL:
             return 11;
+        case AIT_ENFORCEMENT_TRAFFIC_SIGNALS:
+            return 12;
 
         default:
             return 0;
@@ -171,6 +180,8 @@
             return @"TUNNEL";
         case AIT_MAXIMUM:
             return @"MAXIMUM";
+        case AIT_ENFORCEMENT_TRAFFIC_SIGNALS:
+            return @"ENFORCEMENT_TRAFFIC_SIGNALS";
 
         default:
             return @"";
@@ -202,10 +213,17 @@
             return OALocalizedString(@"tunnel_warning");
         case AIT_MAXIMUM:
             return OALocalizedString(@"traffic_warning");
+        case AIT_ENFORCEMENT_TRAFFIC_SIGNALS:
+            return OALocalizedString(@"traffic_warning_enforcement_traffic_signals");
             
         default:
             return @"";
     }
+}
+
+- (BOOL) isSpeedCameraType
+{
+    return self.type == AIT_SPEED_CAMERA || self.type == AIT_ENFORCEMENT_TRAFFIC_SIGNALS;
 }
 
 - (NSUInteger) hash

--- a/Sources/Router/OAAlarmInfo.mm
+++ b/Sources/Router/OAAlarmInfo.mm
@@ -112,7 +112,7 @@
     if (time < 6 || distance < 75 || self.type == AIT_SPEED_LIMIT)
         return [self.class getPriority:self.type];
 
-    if ([self isTrafficCamera] && (time < 15 || distance < 150))
+    if ((self.type == AIT_SPEED_CAMERA || self.type == AIT_RED_LIGHT_CAMERA) && (time < 15 || distance < 150))
         return [self.class getPriority:self.type];
 
     // 2nd level

--- a/Sources/Router/OAAlarmInfo.mm
+++ b/Sources/Router/OAAlarmInfo.mm
@@ -61,7 +61,7 @@
     {
         if ("traffic_signals" == ruleType.getValue())
         {
-            alarmInfo = [[OAAlarmInfo alloc] initWithType:AIT_ENFORCEMENT_TRAFFIC_SIGNALS locationIndex:locInd];
+            alarmInfo = [[OAAlarmInfo alloc] initWithType:AIT_RED_LIGHT_CAMERA locationIndex:locInd];
         }
     }
     else if ("barrier" == ruleType.getTag())
@@ -112,7 +112,7 @@
     if (time < 6 || distance < 75 || self.type == AIT_SPEED_LIMIT)
         return [self.class getPriority:self.type];
 
-    if ([self isSpeedCameraType] && (time < 15 || distance < 150))
+    if ([self isTrafficCamera] && (time < 15 || distance < 150))
         return [self.class getPriority:self.type];
 
     // 2nd level
@@ -147,7 +147,7 @@
             return 10;
         case AIT_TUNNEL:
             return 11;
-        case AIT_ENFORCEMENT_TRAFFIC_SIGNALS:
+        case AIT_RED_LIGHT_CAMERA:
             return 12;
 
         default:
@@ -180,8 +180,8 @@
             return @"TUNNEL";
         case AIT_MAXIMUM:
             return @"MAXIMUM";
-        case AIT_ENFORCEMENT_TRAFFIC_SIGNALS:
-            return @"ENFORCEMENT_TRAFFIC_SIGNALS";
+        case AIT_RED_LIGHT_CAMERA:
+            return @"RED_LIGHT_CAMERA";
 
         default:
             return @"";
@@ -213,17 +213,17 @@
             return OALocalizedString(@"tunnel_warning");
         case AIT_MAXIMUM:
             return OALocalizedString(@"traffic_warning");
-        case AIT_ENFORCEMENT_TRAFFIC_SIGNALS:
-            return OALocalizedString(@"traffic_warning_enforcement_traffic_signals");
+        case AIT_RED_LIGHT_CAMERA:
+            return OALocalizedString(@"traffic_warning_red_light_camera");
             
         default:
             return @"";
     }
 }
 
-- (BOOL) isSpeedCameraType
+- (BOOL) isTrafficCamera
 {
-    return self.type == AIT_SPEED_CAMERA || self.type == AIT_ENFORCEMENT_TRAFFIC_SIGNALS;
+    return self.type == AIT_SPEED_CAMERA || self.type == AIT_RED_LIGHT_CAMERA;
 }
 
 - (NSUInteger) hash

--- a/Sources/Router/OALocationPointWrapper.mm
+++ b/Sources/Router/OALocationPointWrapper.mm
@@ -100,7 +100,7 @@
         OAAlarmInfo *alarm = (OAAlarmInfo *) _point;
         EOAAlarmInfoType type = alarm.type;
         //assign alarm list icons manually for now
-        if (type == AIT_SPEED_CAMERA)
+        if ([alarm isSpeedCameraType])
         {
             return [OAUtilities getMxIcon:@"highway_speed_camera"];
         }

--- a/Sources/Router/OALocationPointWrapper.mm
+++ b/Sources/Router/OALocationPointWrapper.mm
@@ -100,7 +100,7 @@
         OAAlarmInfo *alarm = (OAAlarmInfo *) _point;
         EOAAlarmInfoType type = alarm.type;
         //assign alarm list icons manually for now
-        if ([alarm isSpeedCameraType])
+        if ([alarm isTrafficCamera])
         {
             return [OAUtilities getMxIcon:@"highway_speed_camera"];
         }

--- a/Sources/Router/OALocationPointWrapper.mm
+++ b/Sources/Router/OALocationPointWrapper.mm
@@ -100,7 +100,7 @@
         OAAlarmInfo *alarm = (OAAlarmInfo *) _point;
         EOAAlarmInfoType type = alarm.type;
         //assign alarm list icons manually for now
-        if ([alarm isTrafficCamera])
+        if (type == AIT_SPEED_CAMERA || type == AIT_RED_LIGHT_CAMERA)
         {
             return [OAUtilities getMxIcon:@"highway_speed_camera"];
         }

--- a/Sources/Router/OAVoiceRouter.mm
+++ b/Sources/Router/OAVoiceRouter.mm
@@ -835,8 +835,8 @@ std::string preferredLanguage;
         BOOL speakTrafficWarnings = [_settings.speakTrafficWarnings get];
         BOOL speakTunnels = type == AIT_TUNNEL && [_settings.speakTunnels get];
         BOOL speakPedestrian = type == AIT_PEDESTRIAN && [_settings.speakPedestrian get];
-        BOOL speakSpeedCamera = type == AIT_SPEED_CAMERA && [_settings.speakCameras get];
-        BOOL speakPrefType = type == AIT_TUNNEL || type == AIT_PEDESTRIAN || type == AIT_SPEED_CAMERA;
+        BOOL speakSpeedCamera = [info isSpeedCameraType] && [_settings.speakCameras get];
+        BOOL speakPrefType = type == AIT_TUNNEL || type == AIT_PEDESTRIAN || [info isSpeedCameraType];
 
         if (speakSpeedCamera || speakPedestrian || speakTunnels || (speakTrafficWarnings && !speakPrefType))
         {

--- a/Sources/Router/OAVoiceRouter.mm
+++ b/Sources/Router/OAVoiceRouter.mm
@@ -835,8 +835,8 @@ std::string preferredLanguage;
         BOOL speakTrafficWarnings = [_settings.speakTrafficWarnings get];
         BOOL speakTunnels = type == AIT_TUNNEL && [_settings.speakTunnels get];
         BOOL speakPedestrian = type == AIT_PEDESTRIAN && [_settings.speakPedestrian get];
-        BOOL speakSpeedCamera = [info isTrafficCamera] && [_settings.speakCameras get];
-        BOOL speakPrefType = type == AIT_TUNNEL || type == AIT_PEDESTRIAN || [info isTrafficCamera];
+        BOOL speakSpeedCamera = (type == AIT_SPEED_CAMERA || type == AIT_RED_LIGHT_CAMERA) && [_settings.speakCameras get];
+        BOOL speakPrefType = type == AIT_TUNNEL || type == AIT_PEDESTRIAN || type == AIT_SPEED_CAMERA || type == AIT_RED_LIGHT_CAMERA;
 
         if (speakSpeedCamera || speakPedestrian || speakTunnels || (speakTrafficWarnings && !speakPrefType))
         {

--- a/Sources/Router/OAVoiceRouter.mm
+++ b/Sources/Router/OAVoiceRouter.mm
@@ -835,8 +835,8 @@ std::string preferredLanguage;
         BOOL speakTrafficWarnings = [_settings.speakTrafficWarnings get];
         BOOL speakTunnels = type == AIT_TUNNEL && [_settings.speakTunnels get];
         BOOL speakPedestrian = type == AIT_PEDESTRIAN && [_settings.speakPedestrian get];
-        BOOL speakSpeedCamera = [info isSpeedCameraType] && [_settings.speakCameras get];
-        BOOL speakPrefType = type == AIT_TUNNEL || type == AIT_PEDESTRIAN || [info isSpeedCameraType];
+        BOOL speakSpeedCamera = [info isTrafficCamera] && [_settings.speakCameras get];
+        BOOL speakPrefType = type == AIT_TUNNEL || type == AIT_PEDESTRIAN || [info isTrafficCamera];
 
         if (speakSpeedCamera || speakPedestrian || speakTunnels || (speakTrafficWarnings && !speakPrefType))
         {

--- a/Sources/Router/OAWaypointHelper.mm
+++ b/Sources/Router/OAWaypointHelper.mm
@@ -573,7 +573,7 @@
 
                 float time = speed > 0 ? distanceByRoute / speed : INT_MAX;
                 int priority = [inf updateDistanceAndGetPriority:time distance:distanceByRoute];
-                if (priority < mostPriority && (showCameras ||  ![inf isTrafficCamera]))
+                if (priority < mostPriority && (showCameras || (inf.type != AIT_SPEED_CAMERA && inf.type != AIT_RED_LIGHT_CAMERA)))
                 {
                     mostImportant = inf;
                     mostPriority = priority;
@@ -680,7 +680,7 @@
     OAAlarmInfo *prevSpeedCam = nil;
     for (OAAlarmInfo *i in route.alarmInfo)
     {
-        if ([i isTrafficCamera])
+        if (i.type == AIT_SPEED_CAMERA || i.type == AIT_RED_LIGHT_CAMERA)
         {
             if ([settings.showCameras get:mode] || [settings.speakCameras get:mode])
             {
@@ -925,7 +925,7 @@
                 OAAlarmInfo *info = [OAAlarmInfo createAlarmInfo:typeRule locInd:0 coordinate:loc.coordinate];
                 if (info)
                 {
-                    if (![info isTrafficCamera ] || showCameras)
+                    if ((info.type != AIT_SPEED_CAMERA && info.type != AIT_RED_LIGHT_CAMERA) || showCameras)
                     {
                         return info;
                     }

--- a/Sources/Router/OAWaypointHelper.mm
+++ b/Sources/Router/OAWaypointHelper.mm
@@ -573,7 +573,7 @@
 
                 float time = speed > 0 ? distanceByRoute / speed : INT_MAX;
                 int priority = [inf updateDistanceAndGetPriority:time distance:distanceByRoute];
-                if (priority < mostPriority && (showCameras || inf.type != AIT_SPEED_CAMERA))
+                if (priority < mostPriority && (showCameras ||  ![inf isSpeedCameraType]))
                 {
                     mostImportant = inf;
                     mostPriority = priority;
@@ -680,7 +680,7 @@
     OAAlarmInfo *prevSpeedCam = nil;
     for (OAAlarmInfo *i in route.alarmInfo)
     {
-        if (i.type == AIT_SPEED_CAMERA)
+        if ([i isSpeedCameraType])
         {
             if ([settings.showCameras get:mode] || [settings.speakCameras get:mode])
             {
@@ -925,7 +925,7 @@
                 OAAlarmInfo *info = [OAAlarmInfo createAlarmInfo:typeRule locInd:0 coordinate:loc.coordinate];
                 if (info)
                 {
-                    if (info.type != AIT_SPEED_CAMERA || showCameras)
+                    if (![info isSpeedCameraType ] || showCameras)
                     {
                         return info;
                     }

--- a/Sources/Router/OAWaypointHelper.mm
+++ b/Sources/Router/OAWaypointHelper.mm
@@ -573,7 +573,7 @@
 
                 float time = speed > 0 ? distanceByRoute / speed : INT_MAX;
                 int priority = [inf updateDistanceAndGetPriority:time distance:distanceByRoute];
-                if (priority < mostPriority && (showCameras ||  ![inf isSpeedCameraType]))
+                if (priority < mostPriority && (showCameras ||  ![inf isTrafficCamera]))
                 {
                     mostImportant = inf;
                     mostPriority = priority;
@@ -680,7 +680,7 @@
     OAAlarmInfo *prevSpeedCam = nil;
     for (OAAlarmInfo *i in route.alarmInfo)
     {
-        if ([i isSpeedCameraType])
+        if ([i isTrafficCamera])
         {
             if ([settings.showCameras get:mode] || [settings.speakCameras get:mode])
             {
@@ -925,7 +925,7 @@
                 OAAlarmInfo *info = [OAAlarmInfo createAlarmInfo:typeRule locInd:0 coordinate:loc.coordinate];
                 if (info)
                 {
-                    if (![info isSpeedCameraType ] || showCameras)
+                    if (![info isTrafficCamera ] || showCameras)
                     {
                         return info;
                     }


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/4291#issuecomment-3739100339)

[related resources request](https://github.com/osmandapp/OsmAnd-resources/pull/1399)
[related android request](https://github.com/osmandapp/OsmAnd/pull/25385)

Add new navigation alert for "[enforcement=traffic_signals](https://wiki.openstreetmap.org/wiki/Relation:enforcement)" ([red-light camera](https://en.wikipedia.org/wiki/Red_light_camera)).

---

video after:


https://github.com/user-attachments/assets/e2f83597-1c94-4f1c-8962-86a9a63be41c



---

test points:

52.44055 7.07736
52.44103 7.06800

https://www.openstreetmap.org/relation/6932249#map=19/52.440751/7.072881

