### PR TITLE
Fix OSM Notes cancellation during renderer async fetch

### DIFF
--- a/Sources/Core/OAOsmNotesMapLayerProvider.h
+++ b/Sources/Core/OAOsmNotesMapLayerProvider.h
@@ -75,13 +75,19 @@ private:
     OsmAnd::AreaI _requestedBBox31;
     OsmAnd::AreaI _requestingBBox31;
     OsmAnd::ZoomLevel _requestingZoom;
+    uint64_t _requestingGeneration;
 
     bool queryOsmNotes(const OsmAnd::AreaI &bbox31,
-                       const OsmAnd::ZoomLevel &zoom);
+                       const OsmAnd::ZoomLevel &zoom,
+                       const uint64_t requestingGeneration,
+                       const std::shared_ptr<const OsmAnd::IQueryController>& queryController);
     bool parseResponse(const QByteArray &buffer,
                        const OsmAnd::AreaI &bbox31,
-                       const OsmAnd::ZoomLevel &zoom);
-    QList<std::shared_ptr<OsmAnd::MapSymbolsGroup>> buildMapSymbolsGroups(const OsmAnd::AreaI &bbox31);
+                       const OsmAnd::ZoomLevel &zoom,
+                       const uint64_t requestingGeneration);
+    QList<std::shared_ptr<OsmAnd::MapSymbolsGroup>> buildMapSymbolsGroups(
+        const OsmAnd::AreaI &bbox31,
+        const QList<std::shared_ptr<const OAOnlineOsmNote>>& notesCache);
 protected:
 public:
     OAOsmNotesMapLayerProvider(const float symbolsScaleFactor);
@@ -109,4 +115,3 @@ public:
     
     QList<std::shared_ptr<const OAOnlineOsmNote>> getNotesCache() const;
 };
-

--- a/Sources/Core/OAOsmNotesMapLayerProvider.mm
+++ b/Sources/Core/OAOsmNotesMapLayerProvider.mm
@@ -17,15 +17,17 @@
 #include <OsmAndCore/LatLon.h>
 #include <OsmAndCore/IWebClient.h>
 #include <OsmAndCore/Map/VectorLine.h>
-#include <OsmAndCore/QRunnableFunctor.h>
+#include <OsmAndCore/FunctorQueryController.h>
 #include "OAWebClient.h"
 
 OAOsmNotesMapLayerProvider::OAOsmNotesMapLayerProvider(const float symbolsScaleFactor_)
 : webClient(std::make_shared<OAWebClient>())
-, _dataReadyCallback(nullptr)
 , _cacheBBox31()
 , _cacheZoom(OsmAnd::ZoomLevel::InvalidZoomLevel)
 , _symbolsScaleFactor(symbolsScaleFactor_)
+, _dataReadyCallback(nullptr)
+, _requestingZoom(OsmAnd::ZoomLevel::InvalidZoomLevel)
+, _requestingGeneration(0)
 {
 }
 
@@ -72,8 +74,15 @@ bool OAOsmNotesMapLayerProvider::supportsNaturalObtainData() const
     return true;
 }
 
-bool OAOsmNotesMapLayerProvider::queryOsmNotes(const OsmAnd::AreaI &bbox31, const OsmAnd::ZoomLevel &zoom)
+bool OAOsmNotesMapLayerProvider::queryOsmNotes(
+    const OsmAnd::AreaI &bbox31,
+    const OsmAnd::ZoomLevel &zoom,
+    const uint64_t requestingGeneration,
+    const std::shared_ptr<const OsmAnd::IQueryController>& queryController)
 {
+    if (queryController && queryController->isAborted())
+        return false;
+
     double bottom = OsmAnd::Utilities::get31LatitudeY(bbox31.bottom());
     double top = OsmAnd::Utilities::get31LatitudeY(bbox31.top());
     double right = OsmAnd::Utilities::get31LongitudeX(bbox31.right());
@@ -81,18 +90,24 @@ bool OAOsmNotesMapLayerProvider::queryOsmNotes(const OsmAnd::AreaI &bbox31, cons
     QString url = "https://api.openstreetmap.org/api/0.6/notes?bbox=";
     url.append(QString::number(left)).append(",").append(QString::number(bottom)).append(",").append(QString::number(right)).append(",").append(QString::number(top));
     OsmAnd::IWebClient::DataRequest dataRequest;
+    dataRequest.queryController = queryController;
     const auto data = webClient->downloadData(url, dataRequest);
-    return data.size() > 0 ? parseResponse(data, bbox31, zoom) : false;
+    if (queryController && queryController->isAborted())
+        return false;
+    return data.size() > 0 ? parseResponse(data, bbox31, zoom, requestingGeneration) : false;
 }
 
 QList<std::shared_ptr<const OAOnlineOsmNote>> OAOsmNotesMapLayerProvider::getNotesCache() const
 {
+    QReadLocker scopedLocker(&_lock);
+
     return _notesCache;
 }
 
 bool OAOsmNotesMapLayerProvider::parseResponse(const QByteArray &buffer,
                                                const OsmAnd::AreaI &bbox31,
-                                               const OsmAnd::ZoomLevel &zoom)
+                                               const OsmAnd::ZoomLevel &zoom,
+                                               const uint64_t requestingGeneration)
 {
     QList<std::shared_ptr<const OAOnlineOsmNote>> notesCache;
 
@@ -176,7 +191,7 @@ bool OAOsmNotesMapLayerProvider::parseResponse(const QByteArray &buffer,
     
     QWriteLocker scopedLocker(&_lock);
     
-    if (_requestingBBox31 != bbox31 || _requestingZoom != zoom)
+    if (_requestingGeneration != requestingGeneration || _requestingBBox31 != bbox31 || _requestingZoom != zoom)
         return false;
 
     if (success)
@@ -195,10 +210,10 @@ bool OAOsmNotesMapLayerProvider::parseResponse(const QByteArray &buffer,
     return success;
 }
 
-QList<std::shared_ptr<OsmAnd::MapSymbolsGroup>> OAOsmNotesMapLayerProvider::buildMapSymbolsGroups(const OsmAnd::AreaI &bbox31)
+QList<std::shared_ptr<OsmAnd::MapSymbolsGroup>> OAOsmNotesMapLayerProvider::buildMapSymbolsGroups(
+    const OsmAnd::AreaI &bbox31,
+    const QList<std::shared_ptr<const OAOnlineOsmNote>>& notesCache)
 {
-    QReadLocker scopedLocker(&_lock);
-
     const auto iconOpen = [OANativeUtilities getScaledSkImage:[OANativeUtilities skImageFromPngResource:@"map_osm_note_unresolved"]
                                                   scaleFactor:_symbolsScaleFactor];
     const auto iconClosed = [OANativeUtilities getScaledSkImage:[OANativeUtilities skImageFromPngResource:@"map_osm_note_resolved"]
@@ -207,7 +222,7 @@ QList<std::shared_ptr<OsmAnd::MapSymbolsGroup>> OAOsmNotesMapLayerProvider::buil
 	if (!iconOpen || !iconClosed)
         return mapSymbolsGroups;
 
-    for (const auto note : _notesCache)
+    for (const auto note : notesCache)
     {
         const auto pos31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(note->getLatitude(), note->getLongitude()));
         if (bbox31.contains(pos31))
@@ -239,61 +254,106 @@ bool OAOsmNotesMapLayerProvider::obtainData(const IMapDataProvider::Request& req
         outData.reset();
         return true;
     }
+    if (req.queryController && req.queryController->isAborted())
+    {
+        outData.reset();
+        return false;
+    }
     
     const auto tileId = req.tileId;
     const auto zoom = req.zoom;
     const auto tileBBox31 = OsmAnd::Utilities::tileBoundingBox31(tileId, zoom);
     OsmAnd::AreaI queryBbox31;
+    QList<std::shared_ptr<const OAOnlineOsmNote>> notesCache;
+    uint64_t requestingGeneration = 0;
+    bool cacheAvailable = false;
 
-    {
-        QReadLocker scopedLocker(&_lock);
-        
-        if (_cacheBBox31.contains(tileBBox31) && _cacheZoom == zoom)
-        {
-            const auto mapSymbolsGroups = buildMapSymbolsGroups(tileBBox31);
-            outData.reset(new Data(tileId, zoom, mapSymbolsGroups));
-            return true;
-        }
-        else if (_requestingBBox31.contains(_requestedBBox31) && _requestingZoom == zoom)
-        {
-            return false;
-        }
-        queryBbox31 = OsmAnd::Utilities::roundBoundingBox31(
-                        _requestedBBox31.getEnlargedBy(_requestedBBox31.height() / 2, _requestedBBox31.width() / 2,
-                                                       _requestedBBox31.height() / 2, _requestedBBox31.width() / 2), zoom);
-    }
     {
         QWriteLocker scopedLocker(&_lock);
-        _requestingBBox31 = queryBbox31;
-        _requestingZoom = zoom;
-    }
-    
-    const auto selfWeak = std::weak_ptr<OAOsmNotesMapLayerProvider>(shared_from_this());
-    const auto requestClone = request.clone();
-    const OsmAnd::QRunnableFunctor::Callback task =
-    [selfWeak, requestClone, zoom, queryBbox31]
-    (const OsmAnd::QRunnableFunctor* const runnable)
-    {
-        const auto self = selfWeak.lock();
-        if (self)
-        {
-            if (self->queryOsmNotes(queryBbox31, zoom))
-            {
-                if (self->_dataReadyCallback)
-                    self->_dataReadyCallback();
-            }
-        }
-    };
 
-    const auto taskRunnable = new OsmAnd::QRunnableFunctor(task);
-    taskRunnable->setAutoDelete(true);
-    QThreadPool::globalInstance()->start(taskRunnable);
-    return false;
+        if (_cacheBBox31.contains(tileBBox31) && _cacheZoom == zoom)
+        {
+            notesCache = _notesCache;
+            cacheAvailable = true;
+        }
+        else if (_requestingZoom == zoom && _requestingBBox31.contains(_requestedBBox31))
+        {
+            outData.reset();
+            return false;
+        }
+        else
+        {
+            queryBbox31 = OsmAnd::Utilities::roundBoundingBox31(
+                            _requestedBBox31.getEnlargedBy(_requestedBBox31.height() / 2, _requestedBBox31.width() / 2,
+                                                           _requestedBBox31.height() / 2, _requestedBBox31.width() / 2), zoom);
+            _requestingBBox31 = queryBbox31;
+            _requestingZoom = zoom;
+            requestingGeneration = ++_requestingGeneration;
+        }
+    }
+
+    if (cacheAvailable)
+    {
+        const auto mapSymbolsGroups = buildMapSymbolsGroups(tileBBox31, notesCache);
+        if (req.queryController && req.queryController->isAborted())
+        {
+            outData.reset();
+            return false;
+        }
+        outData.reset(new Data(tileId, zoom, mapSymbolsGroups));
+        return true;
+    }
+
+    const auto rendererQueryController = req.queryController;
+    const auto requestQueryController = std::make_shared<OsmAnd::FunctorQueryController>(
+        [this, rendererQueryController, requestingGeneration]
+        (const OsmAnd::FunctorQueryController* const) -> bool
+        {
+            if (rendererQueryController && rendererQueryController->isAborted())
+                return true;
+
+            QReadLocker scopedLocker(&_lock);
+            return _requestingGeneration != requestingGeneration;
+        });
+
+    const bool requestSucceeded = queryOsmNotes(queryBbox31, zoom, requestingGeneration, requestQueryController);
+    const bool requestAborted = requestQueryController->isAborted();
+    bool currentRequest = false;
+    {
+        QWriteLocker scopedLocker(&_lock);
+        currentRequest = _requestingGeneration == requestingGeneration
+            && _requestingBBox31 == queryBbox31
+            && _requestingZoom == zoom;
+        if (currentRequest && requestSucceeded && !requestAborted)
+            notesCache = _notesCache;
+        if (currentRequest)
+        {
+            _requestingBBox31 = OsmAnd::AreaI();
+            _requestingZoom = OsmAnd::ZoomLevel::InvalidZoomLevel;
+        }
+    }
+
+    if (!currentRequest || !requestSucceeded || requestAborted)
+    {
+        outData.reset();
+        return false;
+    }
+
+    const auto mapSymbolsGroups = buildMapSymbolsGroups(tileBBox31, notesCache);
+    if (req.queryController && req.queryController->isAborted())
+    {
+        outData.reset();
+        return false;
+    }
+    outData.reset(new Data(tileId, zoom, mapSymbolsGroups));
+    if (_dataReadyCallback)
+        _dataReadyCallback();
+    return true;
 }
 
 bool OAOsmNotesMapLayerProvider::supportsNaturalObtainDataAsync() const
 {
-    return false;
+    return true;
 }
 
 void OAOsmNotesMapLayerProvider::obtainDataAsync(const IMapDataProvider::Request& request,
@@ -340,4 +400,3 @@ QString OAOsmNotesMapLayerProvider::NotesSymbolsGroup::toString() const
 {
     return QString();
 }
-


### PR DESCRIPTION
Route OSM Notes downloads through the renderer async resource path and pass
the renderer query controller into OAWebClient so shutdown cancellation reaches
the active URL task.

Use bbox-aware request coalescing with a generation token instead of a
provider-wide in-progress flag. New pans outside the current in-flight bbox
start a newer request, mark the old one stale, and prevent stale responses from
overwriting cache/state.