### PR TITLE
fix invalid related poitype detection. codesync.

### DIFF
--- a/Sources/Controllers/Map/Helpers/OAClickableWayHelper.h
+++ b/Sources/Controllers/Map/Helpers/OAClickableWayHelper.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (OAClickableWayMenuProvider *)getContextMenuProvider;
 
 - (BOOL)isClickableWayTags:(NSString *)name tags:(NSDictionary<NSString *, NSString *> *)tags;
+- (BOOL)isClickableWayAmenity:(OAPOI *)amenity;
 
 - (ClickableWay *)loadClickableWay:(OAPOI *)amenity;
 

--- a/Sources/Controllers/Map/Helpers/OAClickableWayHelper.mm
+++ b/Sources/Controllers/Map/Helpers/OAClickableWayHelper.mm
@@ -272,4 +272,9 @@
     return NO;
 }
 
+- (BOOL)isClickableWayAmenity:(OAPOI *)amenity
+{
+    return [self isClickableWayTags:amenity.name tags:[amenity getOsmTags]];
+}
+
 @end

--- a/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
+++ b/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
@@ -680,7 +680,10 @@ static inline BOOL OARowsContainKey(NSArray<OAAmenityInfoRow *> *rows, NSString 
 
 - (OAAmenityInfoRow *)buildRouteRow:(NSMutableArray<OAAmenityInfoRow *> *)rows amenities:(NSArray<OAPOI *> *)amenities key:(NSString *)key title:(NSString *)title
 {
-    NSString *type = [NSString stringWithFormat:@"\"%@\"", [self getTypeStr]];
+    OAPOI *amenity = [self getTargetPoiIfExisted];
+    NSString *type = amenity ? [OAPOIViewController getTypeStrFor:amenity] : [self getTypeStr];
+    
+    type = [NSString stringWithFormat:@"\"%@\"", type];
     NSString *count = [NSString stringWithFormat:@"(%lu)", amenities.count];
     NSString *text = [NSString stringWithFormat:OALocalizedString(@"ltr_or_rtl_triple_combine_via_space"), title, type, count];
     

--- a/Sources/Controllers/TargetMenu/POI/AmenityExtensionsHelper.swift
+++ b/Sources/Controllers/TargetMenu/POI/AmenityExtensionsHelper.swift
@@ -7,6 +7,9 @@
 
 @objcMembers
 final class AmenityExtensionsHelper: NSObject {
+    static let MIN_UPHILL_DOWNHILL_FIXED_TO_SHOW: Float = 10.0
+    static let MIN_UPHILL_DOWNHILL_PERCENT_TO_SHOW: Float = 0.0 // customizable (default 0)
+    
     private static let wikidata = "wikidata"
     private static let wikipedia = "wikipedia"
     private static let wikimediaCommons = "wikimedia_commons"
@@ -30,5 +33,43 @@ final class AmenityExtensionsHelper: NSObject {
             let key = tag == image ? osmImageKey : tag
             result[key] = value.removingPercentEncoding ?? value
         }
+    }
+    
+    static func getAmenityMetricsFormatted(_ amenity: OAPOI) -> String? {
+        let distMeters = getAmenityDistanceMeters(amenity)
+        let upMeters = KAlgorithms.shared.parseFloatSilently(input: amenity.getAdditionalInfo(TravelGpx.DIFF_ELEVATION_UP), def: 0)
+        let downMeters = KAlgorithms.shared.parseFloatSilently(input: amenity.getAdditionalInfo(TravelGpx.DIFF_ELEVATION_DOWN), def: 0)
+        
+        guard let dist = OAOsmAndFormatter.getFormattedDistance(distMeters, with: OsmAndFormatterParams.noTrailingZeros),
+              let uphill = OAOsmAndFormatter.getFormattedDistance(upMeters, with: OsmAndFormatterParams.noTrailingZeros),
+              let downhill = OAOsmAndFormatter.getFormattedDistance(downMeters, with: OsmAndFormatterParams.noTrailingZeros) else {
+            return nil
+        }
+        
+        var metrics = [String]()
+        if distMeters > 0 {
+            metrics.append(TrkSegment.SegmentSlopeType.flat.symbol + dist)
+            if upMeters >= MIN_UPHILL_DOWNHILL_FIXED_TO_SHOW &&
+                upMeters / distMeters * 100 > MIN_UPHILL_DOWNHILL_PERCENT_TO_SHOW {
+                metrics.append(TrkSegment.SegmentSlopeType.uphill.symbol + uphill)
+            }
+            if downMeters >= MIN_UPHILL_DOWNHILL_FIXED_TO_SHOW &&
+                downMeters / distMeters * 100 > MIN_UPHILL_DOWNHILL_PERCENT_TO_SHOW {
+                metrics.append(TrkSegment.SegmentSlopeType.downhill.symbol + downhill)
+            }
+        }
+        
+        return metrics.isEmpty ? nil : metrics.joined(separator: " ")
+    }
+    
+    private static func getAmenityDistanceMeters(_ amenity: OAPOI) -> Float {
+        let distanceTag = amenity.getAdditionalInfo(TravelGpx.DISTANCE) ?? ""
+        var km = KAlgorithms.shared.parseFloatSilently(input: distanceTag, def: 0)
+        if km > 0 && !distanceTag.contains(".") {
+            // Before 1 Apr 2025 distance format was MMMMM (meters, no fractional part).
+            // Since 1 Apr 2025 format has been fixed to KM.D (km, 1 fractional digit).
+            km /= 1000
+        }
+        return km * 1000
     }
 }

--- a/Sources/Controllers/TargetMenu/POI/AmenityExtensionsHelper.swift
+++ b/Sources/Controllers/TargetMenu/POI/AmenityExtensionsHelper.swift
@@ -7,8 +7,8 @@
 
 @objcMembers
 final class AmenityExtensionsHelper: NSObject {
-    static let MIN_UPHILL_DOWNHILL_FIXED_TO_SHOW: Float = 10.0
-    static let MIN_UPHILL_DOWNHILL_PERCENT_TO_SHOW: Float = 0.0 // customizable (default 0)
+    static let minUphillDownhillFixedToShow: Float = 10.0
+    static let minUphillDownhillPercentToShow: Float = 0.0 // customizable (default 0)
     
     private static let wikidata = "wikidata"
     private static let wikipedia = "wikipedia"
@@ -35,8 +35,8 @@ final class AmenityExtensionsHelper: NSObject {
         }
     }
     
-    static func getAmenityMetricsFormatted(_ amenity: OAPOI) -> String? {
-        let distMeters = getAmenityDistanceMeters(amenity)
+    static func formattedAmenityMetrics(_ amenity: OAPOI) -> String? {
+        let distMeters = amenityDistanceMeters(amenity)
         let upMeters = KAlgorithms.shared.parseFloatSilently(input: amenity.getAdditionalInfo(TravelGpx.DIFF_ELEVATION_UP), def: 0)
         let downMeters = KAlgorithms.shared.parseFloatSilently(input: amenity.getAdditionalInfo(TravelGpx.DIFF_ELEVATION_DOWN), def: 0)
         
@@ -49,12 +49,12 @@ final class AmenityExtensionsHelper: NSObject {
         var metrics = [String]()
         if distMeters > 0 {
             metrics.append(TrkSegment.SegmentSlopeType.flat.symbol + dist)
-            if upMeters >= MIN_UPHILL_DOWNHILL_FIXED_TO_SHOW &&
-                upMeters / distMeters * 100 > MIN_UPHILL_DOWNHILL_PERCENT_TO_SHOW {
+            if upMeters >= minUphillDownhillFixedToShow &&
+                upMeters / distMeters * 100 > minUphillDownhillPercentToShow {
                 metrics.append(TrkSegment.SegmentSlopeType.uphill.symbol + uphill)
             }
-            if downMeters >= MIN_UPHILL_DOWNHILL_FIXED_TO_SHOW &&
-                downMeters / distMeters * 100 > MIN_UPHILL_DOWNHILL_PERCENT_TO_SHOW {
+            if downMeters >= minUphillDownhillFixedToShow &&
+                downMeters / distMeters * 100 > minUphillDownhillPercentToShow {
                 metrics.append(TrkSegment.SegmentSlopeType.downhill.symbol + downhill)
             }
         }
@@ -62,7 +62,7 @@ final class AmenityExtensionsHelper: NSObject {
         return metrics.isEmpty ? nil : metrics.joined(separator: " ")
     }
     
-    private static func getAmenityDistanceMeters(_ amenity: OAPOI) -> Float {
+    private static func amenityDistanceMeters(_ amenity: OAPOI) -> Float {
         let distanceTag = amenity.getAdditionalInfo(TravelGpx.DISTANCE) ?? ""
         var km = KAlgorithms.shared.parseFloatSilently(input: distanceTag, def: 0)
         if km > 0 && !distanceTag.contains(".") {

--- a/Sources/Controllers/TargetMenu/POI/OAPOIViewController.h
+++ b/Sources/Controllers/TargetMenu/POI/OAPOIViewController.h
@@ -19,6 +19,7 @@ static NSString * OTHER_MAP_CATEGORY = @"Other";
 - (void)setObject:(id)object;
 - (void) setup:(OAPOI *)poi;
 - (NSString *) getOsmUrl;
++ (NSString *) getTypeStrFor:(OAPOI *)amenity;
 
 - (BOOL)buildShortWikiDescription:(NSDictionary<NSString *, id> *)filteredInfo allowOnlineWiki:(BOOL)allowOnlineWiki rows:(NSMutableArray<OAAmenityInfoRow *> *)rows;
 

--- a/Sources/Controllers/TargetMenu/POI/OAPOIViewController.mm
+++ b/Sources/Controllers/TargetMenu/POI/OAPOIViewController.mm
@@ -142,7 +142,7 @@ static const NSArray<NSString *> *kPrefixTags = @[@"start_date"];
 + (NSString *)getTypeWithDistanceStr:(OAPOI *)amenity
 {
     NSString *type = [self getTypeStr:amenity];
-    NSString *metrics = [AmenityExtensionsHelper getAmenityMetricsFormatted:amenity];
+    NSString *metrics = [AmenityExtensionsHelper formattedAmenityMetrics:amenity];
     NSString *activityType = [amenity getRouteActivityType];
     if (!NSStringIsEmpty(activityType))
         type = activityType;

--- a/Sources/Controllers/TargetMenu/POI/OAPOIViewController.mm
+++ b/Sources/Controllers/TargetMenu/POI/OAPOIViewController.mm
@@ -125,6 +125,51 @@ static const NSArray<NSString *> *kPrefixTags = @[@"start_date"];
     [self applyTopToolbarTargetTitle];
 }
 
++ (NSString *) getTypeStrFor:(OAPOI *)amenity
+{
+    OAClickableWayHelper *clickableWayHelper = [[OAClickableWayHelper alloc] init];
+    if ([amenity isRouteTrack] || [clickableWayHelper isClickableWayAmenity:amenity])
+    {
+        return [self getTypeWithDistanceStr:amenity];
+    }
+    else if (amenity.type && amenity.type.isWiki)
+    {
+        return [self getCommonWikiTypeStr:amenity];
+    }
+    return [self getTypeStr:amenity];
+}
+
++ (NSString *)getTypeWithDistanceStr:(OAPOI *)amenity
+{
+    NSString *type = [self getTypeStr:amenity];
+    NSString *metrics = [AmenityExtensionsHelper getAmenityMetricsFormatted:amenity];
+    NSString *activityType = [amenity getRouteActivityType];
+    if (!NSStringIsEmpty(activityType))
+        type = activityType;
+    
+    if (metrics)
+        return [NSString stringWithFormat:OALocalizedString(@"ltr_or_rtl_combine_via_comma"), type, metrics];
+    else
+        return type;
+}
+
++ (NSString *)getCommonWikiTypeStr:(OAPOI *)amenity
+{
+    OAPOIHelper *poiTypes = [OAPOIHelper sharedInstance];
+    for (NSString *additionalInfoKey : [amenity getAdditionalInfoKeys])
+    {
+        OAPOIType *poiType = [poiTypes getPoiTypeByKey:additionalInfoKey];
+        if (poiType)
+            return poiType.nameLocalized;
+    }
+    return [self getTypeStr:amenity];
+}
+
++ (NSString *) getTypeStr:(OAPOI *)amenity
+{
+    return [amenity getMainSubtypeStr];
+}
+
 - (NSString *) getTypeStr
 {
     return [self.poi getMainSubtypeStr];


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4499#issuecomment-4874472872)

test point: 50.44832 30.49468

before - Related(Wikipedia):

<img width="1136" height="912" alt="Screenshot 2026-07-07 at 19 38 11" src="https://github.com/user-attachments/assets/e9b42d96-3aa9-4d81-b596-32008ea2a489" />

---

after - Related(University): 

<img width="1136" height="912" alt="Screenshot 2026-07-07 at 22 08 57" src="https://github.com/user-attachments/assets/fbaf4d01-0b0f-4b43-a293-f88ea0427a22" />

---

android:

<img width="422" height="937" alt="Screenshot 2026-07-07 at 20 05 56" src="https://github.com/user-attachments/assets/7d78867d-e0d7-462a-87e6-fb5c537e5edc" />

---

synced this functions:

<img width="1530" height="590" alt="Screenshot 2026-07-07 at 22 15 01" src="https://github.com/user-attachments/assets/93ff00f6-f67c-4e41-95fb-2ccf0c6c113d" />

---

<img width="1560" height="905" alt="Screenshot 2026-07-07 at 22 16 12" src="https://github.com/user-attachments/assets/8186d155-18a7-4866-acd9-205066b3d3bc" />

---

<img width="1680" height="844" alt="Screenshot 2026-07-07 at 22 17 09" src="https://github.com/user-attachments/assets/f05f604d-4595-439a-933c-6ad3d15b56af" />


