### PR TITLE
Fixed issues for Organized By feature

### DIFF
--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -668,6 +668,7 @@
 		460679FB27708A980076740B /* OARouteLineAppearanceHudViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 460679FA27708A980076740B /* OARouteLineAppearanceHudViewController.xib */; };
 		460767122A49F86400AF63F2 /* WikiAlgorithms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460767112A49F86400AF63F2 /* WikiAlgorithms.swift */; };
 		4609FAA22C5158F100B57F06 /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4609FAA12C5158F100B57F06 /* UIImageView+Extension.swift */; };
+		228EDAF170A7A81DF3A85783 /* UIImage+RouteActivityIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD9FA9C2F7AD66558B5B407 /* UIImage+RouteActivityIcon.swift */; };
 		460C1E702BFC9B490090D67B /* QuickActionIds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460C1E6F2BFC9B490090D67B /* QuickActionIds.swift */; };
 		460E9AC12B71111000411854 /* CloudTrashItemMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460E9AC02B71111000411854 /* CloudTrashItemMenuViewController.swift */; };
 		4611DF3A28569C5000885FD1 /* OASubscriptionBannerCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4611DF3928569C5000885FD1 /* OASubscriptionBannerCardView.xib */; };
@@ -4427,6 +4428,7 @@
 		460679FA27708A980076740B /* OARouteLineAppearanceHudViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OARouteLineAppearanceHudViewController.xib; sourceTree = "<group>"; };
 		460767112A49F86400AF63F2 /* WikiAlgorithms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiAlgorithms.swift; sourceTree = "<group>"; };
 		4609FAA12C5158F100B57F06 /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
+		8BD9FA9C2F7AD66558B5B407 /* UIImage+RouteActivityIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+RouteActivityIcon.swift"; sourceTree = "<group>"; };
 		460C1E6F2BFC9B490090D67B /* QuickActionIds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionIds.swift; sourceTree = "<group>"; };
 		460E9AC02B71111000411854 /* CloudTrashItemMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTrashItemMenuViewController.swift; sourceTree = "<group>"; };
 		4611DF3928569C5000885FD1 /* OASubscriptionBannerCardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OASubscriptionBannerCardView.xib; sourceTree = "<group>"; };
@@ -14608,6 +14610,7 @@
 				FA86F4142AE7C56E00DC3B2B /* UserDefaults+Extension.swift */,
 				FA069C6A2B9F65750007E4DE /* UILabel+Extension.swift */,
 				4609FAA12C5158F100B57F06 /* UIImageView+Extension.swift */,
+				8BD9FA9C2F7AD66558B5B407 /* UIImage+RouteActivityIcon.swift */,
 				32BC95722CC021CE00FEEAB8 /* UIFont+Extension.swift */,
 				CEAF081A2FD9226C0048A74A /* Array+Extension.swift */,
 			);
@@ -17975,6 +17978,7 @@
 				DA5A844626C563A900F274C7 /* OABaseScrollableHudViewController.mm in Sources */,
 				DA5A841826C563A800F274C7 /* OAGPXEditWptListViewController.mm in Sources */,
 				4609FAA22C5158F100B57F06 /* UIImageView+Extension.swift in Sources */,
+				228EDAF170A7A81DF3A85783 /* UIImage+RouteActivityIcon.swift in Sources */,
 				274167472E4DD3660051DD4B /* BaseWidgetView+Extension.swift in Sources */,
 				DA5A852E26C563A900F274C7 /* OrderedDictionary.m in Sources */,
 				DA5A833A26C563A800F274C7 /* OAHomeWorkCell.mm in Sources */,

--- a/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Resources/Localizations/en.lproj/Localizable.strings
@@ -643,6 +643,7 @@
 "no_tracks_on_map" = "No tracks on map";
 "select_tracks_to_display" =  "Select tracks to display them on the map.";
 "show_all_tracks" = "Show all tracks";
+"show_all_tracks_on_the_map" = "Show all tracks on the map";
 "recently_visible" = "Recently visible %@";
 "sort_subfolders_tracks" = "Sort subfolders";
 "shared_string_subfolders_in" = "Subfolders in";

--- a/Sources/Controllers/MyPlaces/TracksFilterDetailsViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksFilterDetailsViewController.swift
@@ -565,7 +565,7 @@ final class TracksFilterDetailsViewController: OABaseNavbarViewController {
         case .activity:
             let activity = RouteActivityHelper.shared.findRouteActivity(id: itemName)
             row.title = activity?.label ?? localizedString("shared_string_none")
-            row.icon = activity.map { UIImage.activityIcon($0.iconName, fallback: .icCustomInfoOutlined) } ?? .icCustomActivityOutlined
+            row.icon = activity.map { UIImage.routeActivityIcon($0.iconName, fallback: .icCustomInfoOutlined) } ?? .icCustomActivityOutlined
             row.iconTintColor = selectedItems.contains(itemName) ? .iconColorActive : .iconColorDefault
             if let groupLabel = activity?.group.label {
                 row.setObj(groupLabel, forKey: Self.descriptionKey)

--- a/Sources/Controllers/MyPlaces/TracksFilterDetailsViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksFilterDetailsViewController.swift
@@ -565,7 +565,7 @@ final class TracksFilterDetailsViewController: OABaseNavbarViewController {
         case .activity:
             let activity = RouteActivityHelper.shared.findRouteActivity(id: itemName)
             row.title = activity?.label ?? localizedString("shared_string_none")
-            row.icon = activity != nil ? (activity.flatMap { UIImage.mapSvgImageNamed("mx_\($0.iconName)") } ?? .icCustomInfoOutlined) : .icCustomActivityOutlined
+            row.icon = activity.map { UIImage.activityIcon($0.iconName, fallback: .icCustomInfoOutlined) } ?? .icCustomActivityOutlined
             row.iconTintColor = selectedItems.contains(itemName) ? .iconColorActive : .iconColorDefault
             if let groupLabel = activity?.group.label {
                 row.setObj(groupLabel, forKey: Self.descriptionKey)

--- a/Sources/Controllers/MyPlaces/TracksViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksViewController.swift
@@ -547,7 +547,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
         row.title = organizedGroupTitle(organizedGroup)
         row.descr = formattedTracksCount(organizedGroup.getTrackItems().count)
         if organizedGroup.getType() == .activity {
-            row.icon = UIImage.activityIcon(organizedGroup.getIconName(), fallback: .templateImageNamed("ic_custom_activity"))
+            row.icon = UIImage.routeActivityIcon(organizedGroup.getIconName(), fallback: .templateImageNamed("ic_custom_activity"))
         } else {
             row.iconName = organizedGroup.getType().iconName
         }

--- a/Sources/Controllers/MyPlaces/TracksViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksViewController.swift
@@ -59,7 +59,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
     private let isVisibleKey = "isVisibleKey"
     private let isFullWidthSeparatorKey = "isFullWidthSeparatorKey"
     private let trackSortDescrKey = "trackSortDescrKey"
-    
+
     private var tableData = OATableDataModel()
     private var asyncLoader: TrackFolderLoaderTask?
     
@@ -171,8 +171,11 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
     private func onLoadFinished(folder: TrackFolder) {
         rootFolder = folder
         currentFolder = getTrackFolderByPath(currentFolderPath) ?? rootFolder
-        organizedGroup = nil
+        if let groupId = organizedGroup?.getId() {
+            organizedGroup = smartFolder?.getSubgroupById(subgroupId: groupId) as? OrganizedTracksGroup
+        }
         onRefreshEnd()
+        updateNavigationBarTitle()
         updateSearchResultsWithFilteredTracks()
         updateData()
     }
@@ -544,7 +547,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
         row.title = organizedGroupTitle(organizedGroup)
         row.descr = formattedTracksCount(organizedGroup.getTrackItems().count)
         if organizedGroup.getType() == .activity {
-            row.icon = UIImage.mapSvgImageNamed("mx_\(organizedGroup.getIconName())") ?? .templateImageNamed("ic_custom_activity")
+            row.icon = UIImage.activityIcon(organizedGroup.getIconName(), fallback: .templateImageNamed("ic_custom_activity"))
         } else {
             row.iconName = organizedGroup.getType().iconName
         }
@@ -666,7 +669,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
             title = localizedString("tracks_on_map")
         } else if isSmartFolder {
             if let organizedGroup {
-                title = organizedGroup.getName()
+                title = organizedGroupTitle(organizedGroup)
             } else {
                 title = isEditFilterActive ? localizedString("edit_filter") : smartFolder.getDirName(includingSubdirs: false)
             }
@@ -898,14 +901,14 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
         let folderAnalysis: TrackFolderAnalysis
         if isSmartFolder {
             if let organizedGroup {
-                folderAnalysis = organizedGroup.getFolderAnalysis()
+                folderAnalysis = TrackFolderAnalysis(folder: organizedGroup)
             } else {
                 guard let smartFolder = smartFolder else { return "" }
-                folderAnalysis = smartFolder.getFolderAnalysis()
+                folderAnalysis = TrackFolderAnalysis(folder: smartFolder)
             }
         } else {
-            guard let analysis = getTrackFolderByPath(currentFolderPath)?.getFolderAnalysis() else { return "" }
-            folderAnalysis = analysis
+            guard let folder = getTrackFolderByPath(currentFolderPath) else { return "" }
+            folderAnalysis = TrackFolderAnalysis(folder: folder)
         }
         
         let totalDistance = folderAnalysis.totalDistance
@@ -1077,8 +1080,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
         updateNavigationBarTitle()
         setupNavbar()
         updateSortButtonAndMenu()
-        generateData()
-        tableView.reloadData()
+        updateData()
     }
 
     private func leaveOrganizedGroup() {
@@ -1086,8 +1088,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
         updateNavigationBarTitle()
         setupNavbar()
         updateSortButtonAndMenu()
-        generateData()
-        tableView.reloadData()
+        updateData()
     }
 
     private func onNavbarRefreshSmartFolderButtonClicked() {
@@ -2289,8 +2290,8 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
                 if let color = item.obj(forKey: colorKey) as? UIColor {
                     cell.leftIconView.tintColor = color
                 }
-                
-                let tracksFoldersKeys = [tracksFolderKey, tracksSmartFolderKey, trackKey]
+
+                let tracksFoldersKeys = [tracksFolderKey, tracksSmartFolderKey, trackKey, organizedGroupKey]
                 if tracksFoldersKeys.contains(where: { $0 == item.key }) {
                     cell.setCustomLeftSeparatorInset(true)
                     cell.separatorInset = UIEdgeInsets(top: 0, left: 60, bottom: 0, right: 16)
@@ -2509,7 +2510,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
             guard let group = item.obj(forKey: organizedGroupKey) as? OrganizedTracksGroup else { return nil }
             let menuProvider: UIContextMenuActionProvider = { [weak self] _ in
                 guard let self else { return nil }
-                let showOnMapAction = UIAction(title: localizedString("show_all_tracks"), image: .icCustomMapPinOutlined.resizedMenuImage()) { [weak self] _ in
+                let showOnMapAction = UIAction(title: localizedString("show_all_tracks_on_the_map"), image: .icCustomMapPinOutlined.resizedMenuImage()) { [weak self] _ in
                     guard let self else { return }
                     let tracksToShow = group.getTrackItems().compactMap { $0.gpxFilePath }.filter { !self.settings.mapSettingVisibleGpx.contains($0) }
                     if !tracksToShow.isEmpty {

--- a/Sources/Controllers/MyPlaces/TracksViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksViewController.swift
@@ -901,14 +901,14 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
         let folderAnalysis: TrackFolderAnalysis
         if isSmartFolder {
             if let organizedGroup {
-                folderAnalysis = TrackFolderAnalysis(folder: organizedGroup)
+                folderAnalysis = organizedGroup.getFolderAnalysis()
             } else {
                 guard let smartFolder = smartFolder else { return "" }
-                folderAnalysis = TrackFolderAnalysis(folder: smartFolder)
+                folderAnalysis = smartFolder.getFolderAnalysis()
             }
         } else {
-            guard let folder = getTrackFolderByPath(currentFolderPath) else { return "" }
-            folderAnalysis = TrackFolderAnalysis(folder: folder)
+            guard let analysis = getTrackFolderByPath(currentFolderPath)?.getFolderAnalysis() else { return "" }
+            folderAnalysis = analysis
         }
         
         let totalDistance = folderAnalysis.totalDistance

--- a/Sources/Controllers/TargetMenu/GPX/SelectRouteActivityViewController.swift
+++ b/Sources/Controllers/TargetMenu/GPX/SelectRouteActivityViewController.swift
@@ -111,7 +111,7 @@ final class SelectRouteActivityViewController: OABaseNavbarViewController {
                 row.cellType = OASimpleTableViewCell.reuseIdentifier
                 row.key = activity.id
                 row.title = activity.label
-                row.icon = UIImage.mapSvgImageNamed("mx_\(activity.iconName)") ?? .icCustomInfoOutlined
+                row.icon = UIImage.activityIcon(activity.iconName, fallback: .icCustomInfoOutlined)
                 row.iconTintColor = (activity.id == selectedActivity?.id) ? .iconColorActive : .iconColorDefault
                 row.setObj(activity.id == selectedActivity?.id, forKey: "isSelected")
                 row.setObj(activity, forKey: "routeActivity")
@@ -125,7 +125,7 @@ final class SelectRouteActivityViewController: OABaseNavbarViewController {
                     row.cellType = OASimpleTableViewCell.reuseIdentifier
                     row.key = activity.id
                     row.title = activity.label
-                    row.icon = UIImage.mapSvgImageNamed("mx_\(activity.iconName)") ?? .icCustomInfoOutlined
+                    row.icon = UIImage.activityIcon(activity.iconName, fallback: .icCustomInfoOutlined)
                     row.iconTintColor = (activity.id == selectedActivity?.id) ? .iconColorActive : .iconColorDefault
                     row.setObj(activity, forKey: "routeActivity")
                     if isCheckmarkAllowed {

--- a/Sources/Controllers/TargetMenu/GPX/SelectRouteActivityViewController.swift
+++ b/Sources/Controllers/TargetMenu/GPX/SelectRouteActivityViewController.swift
@@ -111,7 +111,7 @@ final class SelectRouteActivityViewController: OABaseNavbarViewController {
                 row.cellType = OASimpleTableViewCell.reuseIdentifier
                 row.key = activity.id
                 row.title = activity.label
-                row.icon = UIImage.activityIcon(activity.iconName, fallback: .icCustomInfoOutlined)
+                row.icon = UIImage.routeActivityIcon(activity.iconName, fallback: .icCustomInfoOutlined)
                 row.iconTintColor = (activity.id == selectedActivity?.id) ? .iconColorActive : .iconColorDefault
                 row.setObj(activity.id == selectedActivity?.id, forKey: "isSelected")
                 row.setObj(activity, forKey: "routeActivity")
@@ -125,7 +125,7 @@ final class SelectRouteActivityViewController: OABaseNavbarViewController {
                     row.cellType = OASimpleTableViewCell.reuseIdentifier
                     row.key = activity.id
                     row.title = activity.label
-                    row.icon = UIImage.activityIcon(activity.iconName, fallback: .icCustomInfoOutlined)
+                    row.icon = UIImage.routeActivityIcon(activity.iconName, fallback: .icCustomInfoOutlined)
                     row.iconTintColor = (activity.id == selectedActivity?.id) ? .iconColorActive : .iconColorDefault
                     row.setObj(activity, forKey: "routeActivity")
                     if isCheckmarkAllowed {

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHeaderView.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHeaderView.mm
@@ -266,7 +266,7 @@
     [self setGpxActivity:activity.label];
     if (!self.gpxActivityContainerView.hidden)
     {
-        self.gpxActivityIconView.image = [UIImage mapSvgImageNamed:[NSString stringWithFormat:@"mx_%@", activity.iconName]] ?: [UIImage templateImageNamed:@"ic_custom_info_outlined"];
+        self.gpxActivityIconView.image = [UIImage activityIcon:activity.iconName fallback:[UIImage templateImageNamed:@"ic_custom_info_outlined"]];
         self.gpxActivityIconView.tintColor = [UIColor colorNamed:ACColorNameIconColorSecondary];
         self.gpxActivityTextView.textColor = [UIColor colorNamed:ACColorNameTextColorSecondary];
     }

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHeaderView.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHeaderView.mm
@@ -266,7 +266,7 @@
     [self setGpxActivity:activity.label];
     if (!self.gpxActivityContainerView.hidden)
     {
-        self.gpxActivityIconView.image = [UIImage activityIcon:activity.iconName fallback:[UIImage templateImageNamed:@"ic_custom_info_outlined"]];
+        self.gpxActivityIconView.image = [UIImage routeActivityIcon:activity.iconName fallback:[UIImage templateImageNamed:@"ic_custom_info_outlined"]];
         self.gpxActivityIconView.tintColor = [UIColor colorNamed:ACColorNameIconColorSecondary];
         self.gpxActivityTextView.textColor = [UIColor colorNamed:ACColorNameTextColorSecondary];
     }

--- a/Sources/Helpers/Extensions/Extensions.swift
+++ b/Sources/Helpers/Extensions/Extensions.swift
@@ -11,8 +11,6 @@ import UIKit
 
 extension UIImage {
 
-    private static let activityIconPadding: CGFloat = 3
-
     func rotate(radians: CGFloat) -> UIImage {
         let rotatedSize = CGRect(origin: .zero, size: size)
             .applying(CGAffineTransform(rotationAngle: CGFloat(radians)))
@@ -71,21 +69,6 @@ extension UIImage {
     
     @objc func resizedTemplateImage(with size: CGFloat) -> UIImage? {
         OAUtilities.resize(self, newSize: CGSize(width: size, height: size))?.withRenderingMode(.alwaysTemplate)
-    }
-
-    func withPadding(_ padding: CGFloat) -> UIImage {
-        guard padding > 0 else { return self }
-        let paddedSize = CGSize(width: size.width + padding * 2, height: size.height + padding * 2)
-        let renderer = UIGraphicsImageRenderer(size: paddedSize)
-        let padded = renderer.image { _ in
-            draw(in: CGRect(x: padding, y: padding, width: size.width, height: size.height))
-        }
-        return padded.withRenderingMode(renderingMode)
-    }
-
-    @objc static func activityIcon(_ iconName: String?, fallback: UIImage?) -> UIImage? {
-        guard let iconName, let mapIcon = mapSvgImageNamed("mx_\(iconName)") else { return fallback }
-        return mapIcon.withPadding(activityIconPadding)
     }
 }
 

--- a/Sources/Helpers/Extensions/Extensions.swift
+++ b/Sources/Helpers/Extensions/Extensions.swift
@@ -11,6 +11,8 @@ import UIKit
 
 extension UIImage {
 
+    private static let activityIconPadding: CGFloat = 3
+
     func rotate(radians: CGFloat) -> UIImage {
         let rotatedSize = CGRect(origin: .zero, size: size)
             .applying(CGAffineTransform(rotationAngle: CGFloat(radians)))
@@ -69,6 +71,21 @@ extension UIImage {
     
     @objc func resizedTemplateImage(with size: CGFloat) -> UIImage? {
         OAUtilities.resize(self, newSize: CGSize(width: size, height: size))?.withRenderingMode(.alwaysTemplate)
+    }
+
+    func withPadding(_ padding: CGFloat) -> UIImage {
+        guard padding > 0 else { return self }
+        let paddedSize = CGSize(width: size.width + padding * 2, height: size.height + padding * 2)
+        let renderer = UIGraphicsImageRenderer(size: paddedSize)
+        let padded = renderer.image { _ in
+            draw(in: CGRect(x: padding, y: padding, width: size.width, height: size.height))
+        }
+        return padded.withRenderingMode(renderingMode)
+    }
+
+    @objc static func activityIcon(_ iconName: String?, fallback: UIImage?) -> UIImage? {
+        guard let iconName, let mapIcon = mapSvgImageNamed("mx_\(iconName)") else { return fallback }
+        return mapIcon.withPadding(activityIconPadding)
     }
 }
 

--- a/Sources/SwiftExtensions/UIImage+RouteActivityIcon.swift
+++ b/Sources/SwiftExtensions/UIImage+RouteActivityIcon.swift
@@ -1,0 +1,26 @@
+//
+//  UIImage+RouteActivityIcon.swift
+//  OsmAnd Maps
+//
+
+import UIKit
+
+extension UIImage {
+
+    private static let routeActivityIconPadding: CGFloat = 3
+
+    @objc static func routeActivityIcon(_ iconName: String?, fallback: UIImage?) -> UIImage? {
+        guard let iconName, let mapIcon = mapSvgImageNamed("mx_\(iconName)") else { return fallback }
+        return mapIcon.withPadding(routeActivityIconPadding)
+    }
+
+    private func withPadding(_ padding: CGFloat) -> UIImage {
+        guard padding > 0 else { return self }
+        let paddedSize = CGSize(width: size.width + padding * 2, height: size.height + padding * 2)
+        let renderer = UIGraphicsImageRenderer(size: paddedSize)
+        let padded = renderer.image { _ in
+            draw(in: CGRect(x: padding, y: padding, width: size.width, height: size.height))
+        }
+        return padded.withRenderingMode(renderingMode)
+    }
+}

--- a/Sources/SwiftExtensions/UIImage+RouteActivityIcon.swift
+++ b/Sources/SwiftExtensions/UIImage+RouteActivityIcon.swift
@@ -5,13 +5,15 @@
 
 import UIKit
 
-extension UIImage {
+private enum RouteActivityIconStyle {
+    static let padding: CGFloat = 3
+}
 
-    private static let routeActivityIconPadding: CGFloat = 3
+extension UIImage {
 
     @objc static func routeActivityIcon(_ iconName: String?, fallback: UIImage?) -> UIImage? {
         guard let iconName, let mapIcon = mapSvgImageNamed("mx_\(iconName)") else { return fallback }
-        return mapIcon.withPadding(routeActivityIconPadding)
+        return mapIcon.withPadding(RouteActivityIconStyle.padding)
     }
 
     private func withPadding(_ padding: CGFloat) -> UIImage {


### PR DESCRIPTION
## Fixes: Organize by / smart folder screen

- **Activity icon size** — map (`mx_`) activity icons rendered edge-to-edge (no padding), looking larger than standard `ic_custom_*`. Added shared `UIImage.activityIcon(_:fallback:)` (pads glyph to 24pt in 30pt frame) and used it in all 4 call sites.
- **Navbar title `%@ %@`** — group screen used raw `getName()` (range template). Now uses `organizedGroupTitle(_:)`, same as row titles.
- **Row separator** — organized-group rows now use the 16pt right inset (were going edge-to-edge).
- **Refresh inside a group** — `onLoadFinished` unconditionally reset `organizedGroup = nil`, bouncing to the group list. Now re-resolves the group by id via `getSubgroupById` (as Android does), with title refresh.
- **Wrong footer stats in a group** — `getFolderAnalysis()` returns a cached (stale) analysis; footer also wasn't recomputed on enter. Now builds a fresh `TrackFolderAnalysis` (like Android) and `enter`/`leaveOrganizedGroup` call `updateData()`.