### PR TITLE
Pt-prioritize-platform-instead-of-stop-for-routes-7

### DIFF
--- a/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
+++ b/Sources/Controllers/TargetMenu/OATransportStopsBaseController.mm
@@ -206,12 +206,12 @@ static NSInteger const MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS = 20;
             NSString *stopName = [[stop name] lowercaseString];
             auto dist = OsmAnd::Utilities::distance(stop.longitude, stop.latitude, lon, lat);
             
-            if (([stopName containsString:amenityName] || [amenityName containsString:stopName])
+            if ((([stopName containsString:amenityName] || [amenityName containsString:stopName])
                 && dist < MAX_DISTANCE_BETWEEN_AMENITY_AND_LOCAL_STOPS
                 && (!nearestStop
-                    || [OAUtilities isCoordEqual:[nearestStop getLocation].coordinate destLat:[stop getLocation].coordinate]
-                    || [OAUtilities isCoordEqual:[stop getLocation].coordinate destLat:CLLocationCoordinate2DMake(lat, lon)])
-                )
+                    || [OAUtilities isCoordEqual:[nearestStop getLocation].coordinate destLat:[stop getLocation].coordinate]))
+                || [OAUtilities isCoordEqual:[stop getLocation].coordinate destLat:CLLocationCoordinate2DMake(lat, lon)]
+                || [stop isConnectedToStop:amenity.obfId])
             {
                 [stopAggregated addLocalTransportStop:stop];
                 if (!nearestStop)

--- a/Sources/Transport/OATransportStop.h
+++ b/Sources/Transport/OATransportStop.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)findAmenityDataIfNeeded;
 - (NSString *)getStopObjectName:(NSString *)lang transliterate:(BOOL)transliterate;
+- (BOOL)isConnectedToStop:(uint64_t)stopId;
 
 @end
 

--- a/Sources/Transport/OATransportStop.mm
+++ b/Sources/Transport/OATransportStop.mm
@@ -15,9 +15,12 @@
 
 #include <OsmAndCore.h>
 #include <OsmAndCore/Utilities.h>
+#include <OsmAndCore/QKeyValueIterator.h>
 #include <OsmAndCore/Data/TransportStop.h>
 #include <OsmAndCore/Data/TransportRoute.h>
 #include <OsmAndCore/Data/TransportStopExit.h>
+
+static NSString *CONNECTED_STOP_IDS = @"osmand:connected_stop_ids";
 
 
 @interface OATransportStop()
@@ -35,6 +38,7 @@
 
 - (instancetype)initWithStop:(std::shared_ptr<const OsmAnd::TransportStop>)stop
 {
+    self = [super init];
     if (self)
     {
         _stop = stop;
@@ -46,6 +50,10 @@
             self.latitude = stop->location.latitude;
             self.longitude = stop->location.longitude;
             self.stopId = stop->id.id;
+            for (const auto& entry : OsmAnd::rangeOf(OsmAnd::constOf(stop->localizedNames)))
+            {
+                self.localizedNames[entry.key().toNSString()] = entry.value().toNSString();
+            }
             
             NSMutableArray<CLLocation *> *extiLocations = [NSMutableArray new];
             const auto stopExits = stop->exits;
@@ -112,6 +120,21 @@
     const auto qLang = QString::fromNSString(lang);
     const auto qName = _stop->getName(qLang, transliterate);
     return qName.toNSString();
+}
+
+- (BOOL)isConnectedToStop:(uint64_t)stopId
+{
+    NSString *connectedStopIds = self.localizedNames[CONNECTED_STOP_IDS];
+    if (connectedStopIds)
+    {
+        NSString *idString = [@(stopId) stringValue];
+        for (NSString *connectedStopId in [connectedStopIds componentsSeparatedByString:@","])
+        {
+            if ([idString isEqualToString:connectedStopId])
+                return YES;
+        }
+    }
+    return NO;
 }
 
 - (BOOL)isEqual:(OATransportStop *)object


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/22830)

[synced this android request](https://github.com/osmandapp/OsmAnd/pull/25436)

[related core request](https://github.com/osmandapp/OsmAnd-core/pull/1079)


### Transport Stop (Points)

---

40.53729 -3.89062
https://www.openstreetmap.org/node/7317152907 
(there are 6 routes but OsmAnd only displays 1) 

<img width="1325" height="801" alt="614772617-55b5921b-20a9-43b0-8bd0-709f509cf1bd" src="https://github.com/user-attachments/assets/6de9fbd4-7419-44a6-8fb8-867f43a34397" />


---

40.51562 -3.89957
https://www.openstreetmap.org/node/2050786713 
(there are 7 routes but OsmAnd only displays 1)

<img width="1330" height="809" alt="614772693-8f418dd8-611a-46cf-97bd-3378745a681c" src="https://github.com/user-attachments/assets/76634920-61ba-4f9c-8cf4-f0be5f0f20e1" />


---

40.43444 -3.71925
https://www.openstreetmap.org/node/1439708980 
(there are 10 routes but OsmAnd displays 1 route from the nearest platform) 

<img width="1328" height="809" alt="614772767-b92ffa39-39ad-4ebd-b279-0ef6ad00f19d" src="https://github.com/user-attachments/assets/684a3346-7ddd-4ccc-b33d-d27c35740daf" />


---


### Transport Platforms (Polygons)

40.73781 -4.06424
https://www.openstreetmap.org/way/190124171 
(there are 3 routes but OsmAnd displays 0)

<img width="1331" height="808" alt="614772836-80e124f9-7264-40a8-9ba5-f1c1cf5caa48" src="https://github.com/user-attachments/assets/c2ecfec5-ae90-427c-acba-d3dd1162e987" />


---

40.70687 -4.06702
https://www.openstreetmap.org/way/1227180184 
(there is 1 route but OsmAnd displays 0, however the other platform of this train station is correct)

<img width="1332" height="809" alt="614772938-8693284b-7a05-4120-a273-c8284f5d6fcd" src="https://github.com/user-attachments/assets/3e409b24-04f4-4d26-a8ad-794b6b7ccde7" />


---

40.47337 -3.68258
https://www.openstreetmap.org/way/202094336 
(user: there are 3 routes but OsmAnd displays 0)

<img width="1329" height="808" alt="614772982-a32e43aa-4425-442b-b506-a9db2897ee78" src="https://github.com/user-attachments/assets/4dd9f2fa-03ca-4d42-8e2d-1b42ea86b46c" />

---

### Navigation test

Start, end points:
40.4736526,-3.6823814    
40.40457 -3.68737

<img width="1323" height="800" alt="Screenshot 2026-07-14 at 13 23 43" src="https://github.com/user-attachments/assets/47d8eaea-9fd9-474a-a99d-361fb5353525" />

<img width="1331" height="798" alt="Screenshot 2026-07-14 at 13 24 06" src="https://github.com/user-attachments/assets/7ee9ec9d-1314-48cc-8f14-10b592fc356a" />


---

### obf files for testing:

[Madrid_crop_old.obf.zip](https://github.com/user-attachments/files/29340282/Madrid_crop_old.obf.zip)

[Madrid_crop_new2.obf.zip](https://github.com/user-attachments/files/29998206/Madrid_crop_new2.obf.zip)


