### PR TITLE
fix “minute” localization to use correct string

### DIFF
--- a/Sources/Controllers/TargetMenu/OARouteBaseViewController.mm
+++ b/Sources/Controllers/TargetMenu/OARouteBaseViewController.mm
@@ -217,7 +217,7 @@
         if (time.length > 0)
             [time appendAttributedString:space];
         NSAttributedString *val = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%d", minutes] attributes:numericAttributes];
-        NSAttributedString *units = [[NSAttributedString alloc] initWithString:OALocalizedString(@"m") attributes:alphabeticAttributes];
+        NSAttributedString *units = [[NSAttributedString alloc] initWithString:OALocalizedString(@"shared_string_minute_lowercase") attributes:alphabeticAttributes];
         [time appendAttributedString:val];
         [time appendAttributedString:space];
         [time appendAttributedString:units];


### PR DESCRIPTION
Previously the “m” string was used for minutes even though that’s the string for distance, so it only produces the correct string in some languages purely by coincidence. The correct string for the abbreviation of “minute(s)” is “shared_string_minute_lowercase”