### PR TITLE
Privacy-preserving iOS crash diagnostics

### DIFF
--- a/OsmAnd MapsTests/Services/CrashDiagnosticsTests.swift
+++ b/OsmAnd MapsTests/Services/CrashDiagnosticsTests.swift
@@ -1,0 +1,325 @@
+//
+//  CrashDiagnosticsTests.swift
+//  OsmAnd MapsTests
+//
+
+import XCTest
+
+final class CrashDiagnosticsTests: XCTestCase {
+    func testKSCrashNormalizationDropsSensitiveRawFields() throws {
+        let rawReport: [String: Any] = [
+            "report": [
+                "timestamp": "2026-07-24T12:00:12Z",
+                "process_name": "OsmAnd Maps",
+            ],
+            "system": [
+                "CFBundleShortVersionString": "5.2.0",
+                "CFBundleVersion": "5200",
+                "machine": "iPhone16,2",
+                "system_version": "18.5",
+                "device_app_hash": "persistent-installation-secret",
+                "process_path": "/private/var/containers/OsmAnd Maps",
+            ],
+            "crash": [
+                "error": [
+                    "type": "signal",
+                    "reason": "Search query: private cafe",
+                    "signal": ["signal": 6, "name": "SIGABRT"],
+                ],
+                "threads": [
+                    [
+                        "index": 0,
+                        "crashed": true,
+                        "registers": ["basic": ["x0": 123]],
+                        "stack": ["contents": "private stack memory"],
+                        "backtrace": [
+                            "contents": [
+                                [
+                                    "instruction_addr": 4_096,
+                                    "object_addr": 2_048,
+                                    "object_name": "/private/var/containers/Bundle/Application/OsmAnd",
+                                    "symbol_name": "OAAppDelegate.applicationDidBecomeActive()",
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            "binary_images": [
+                [
+                    "name": "/private/var/containers/Bundle/Application/OsmAnd",
+                    "uuid": "00112233445566778899AABBCCDDEEFF",
+                    "image_addr": 2_048,
+                    "image_size": 8_192,
+                ],
+            ],
+            "console_log": "favorite Home; latitude 51.5; https://private.example",
+            "user": [
+                "notification_contents": "private message",
+                "custom_plugin_name": "Home automation",
+                "map_region_id": "london",
+                "route": "Home to Work",
+                "file_path": "/private/var/mobile/Documents/private.gpx",
+                "account_email": "person@example.com",
+            ],
+        ]
+        let session = CrashSessionState(
+            context: CrashContextSnapshot(),
+            breadcrumbs: [
+                CrashBreadcrumb(
+                    elapsedMilliseconds: 1_000,
+                    event: "app_became_active",
+                    numericMetadata: ["latitude": 51_500_000, "item_count": 2]
+                ),
+            ]
+        )
+
+        let report = try XCTUnwrap(
+            CrashDiagnosticsSanitizer.normalizeKSCrashReport(rawReport, session: session)
+        )
+        let data = try CrashDiagnosticsSanitizer.prettyPrintedData(for: report)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(json.contains("\"binary_name\" : \"OsmAnd\""))
+        XCTAssertTrue(json.contains("\"item_count\" : 2"))
+        for prohibited in [
+            "private cafe",
+            "private stack memory",
+            "persistent-installation-secret",
+            "notification_contents",
+            "custom_plugin_name",
+            "map_region_id",
+            "Home to Work",
+            "person@example.com",
+            "latitude",
+            "https://",
+            "/private/",
+            "console_log",
+            "registers",
+        ] {
+            XCTAssertFalse(json.localizedCaseInsensitiveContains(prohibited), prohibited)
+        }
+    }
+
+    func testNonFatalOnlyAllowsEnumeratedNumericMetadata() throws {
+        let event = CrashNonFatalEvent(
+            component: .networking,
+            code: 42,
+            severity: .warning,
+            numericMetadata: [
+                "status_code": 503,
+                "latitude": 51_500_000,
+                "search_query_hash": 123,
+            ]
+        )
+        let report = CrashDiagnosticsSanitizer.makeNonFatalEnvelope(
+            event,
+            session: CrashSessionState(context: CrashContextSnapshot(), breadcrumbs: [])
+        )
+
+        XCTAssertEqual(report.diagnostic.numericMetadata, ["status_code": 503])
+    }
+
+    func testApprovalHashesExactlyTheReviewedEnvelope() throws {
+        let baseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: baseDirectory) }
+        let store = CrashDiagnosticsStore(baseDirectory: baseDirectory)
+        let report = sampleEnvelope()
+
+        XCTAssertTrue(try store.save(report))
+        let reviewedData = try store.prettyPrintedReportData(reportID: report.reportID)
+        XCTAssertFalse(reviewedData.isEmpty)
+        let request = try store.approve(reportID: report.reportID)
+        let verified = try store.verifiedUploadRequest(reportID: report.reportID)
+        let canonicalData = try CrashDiagnosticsSanitizer.canonicalData(for: report)
+
+        XCTAssertEqual(request, verified)
+        XCTAssertEqual(
+            request.consent.reviewedPayloadSHA256,
+            CrashDiagnosticsSanitizer.sha256Hex(canonicalData)
+        )
+        XCTAssertEqual(request.consent.mode, "per_report")
+    }
+
+    func testMetricKitFixtureUsesTheSamePrivacyAllowlistAndDeduplicatesFatalReport() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/metrickit_call_stack.json")
+        let fixtureData = try Data(contentsOf: fixtureURL)
+        let metricKitReport = CrashDiagnosticsSanitizer.makeMetricKitEnvelope(
+            kind: .crash,
+            occurredAt: try XCTUnwrap(
+                ISO8601DateFormatter().date(from: "2026-07-24T12:00:00Z")
+            ),
+            appVersion: "5.2.0",
+            appBuild: "5200",
+            deviceModel: "iPhone16,2",
+            osVersion: "18.5",
+            signal: 6,
+            callStackTreeData: fixtureData
+        )
+        let serialized = try CrashDiagnosticsSanitizer.prettyPrintedData(for: metricKitReport)
+        let json = try XCTUnwrap(String(data: serialized, encoding: .utf8))
+
+        XCTAssertTrue(json.contains("\"binary_name\" : \"OsmAnd\""))
+        XCTAssertFalse(json.contains("private.example"))
+        XCTAssertFalse(json.contains("private cafe"))
+        XCTAssertFalse(json.contains("/private/"))
+
+        let baseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: baseDirectory) }
+        let store = CrashDiagnosticsStore(baseDirectory: baseDirectory)
+        XCTAssertTrue(try store.save(sampleEnvelope()))
+        XCTAssertFalse(try store.save(metricKitReport))
+    }
+
+    func testFatalReportsTakeRetentionPriorityOverNonFatalReports() throws {
+        let baseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: baseDirectory) }
+        let store = CrashDiagnosticsStore(baseDirectory: baseDirectory)
+        let fatalA = sampleEnvelope()
+        let fatalB = copy(
+            fatalA,
+            reportID: UUID().uuidString.lowercased(),
+            occurredAt: "2026-07-24T12:10:00Z"
+        )
+        let nonFatalA = nonFatalEnvelope(errorCode: 7)
+        let nonFatalB = nonFatalEnvelope(errorCode: 8)
+        let now = Date()
+
+        XCTAssertTrue(try store.save(fatalA, now: now))
+        XCTAssertTrue(try store.save(fatalB, now: now.addingTimeInterval(1)))
+        XCTAssertTrue(try store.save(nonFatalA, now: now.addingTimeInterval(2)))
+        XCTAssertTrue(try store.save(nonFatalB, now: now.addingTimeInterval(3)))
+
+        let summaries = store.summaries()
+        XCTAssertEqual(summaries.count, CrashDiagnosticsStore.maximumReportCount)
+        XCTAssertEqual(summaries.filter { $0.source == .kscrash }.count, 2)
+    }
+
+    func testReportsExpireAfterSevenDays() throws {
+        let baseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: baseDirectory) }
+        let store = CrashDiagnosticsStore(baseDirectory: baseDirectory)
+        let expired = Date().addingTimeInterval(-CrashDiagnosticsStore.maximumAge - 1)
+
+        XCTAssertTrue(try store.save(sampleEnvelope(), now: expired))
+        XCTAssertTrue(store.summaries().isEmpty)
+    }
+
+    func testApprovedReportRetriesOnlyAfterBackoffWithoutChangingPayload() throws {
+        let baseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: baseDirectory) }
+        let store = CrashDiagnosticsStore(baseDirectory: baseDirectory)
+        let report = sampleEnvelope()
+        let now = Date()
+        XCTAssertTrue(try store.save(report, now: now))
+        let approved = try store.approve(reportID: report.reportID, now: now)
+
+        let retryAt = try XCTUnwrap(
+            store.markUploadFailure(reportID: report.reportID, now: now)
+        )
+        XCTAssertTrue(store.approvedReportsDue(now: now).isEmpty)
+        XCTAssertEqual(
+            store.approvedReportsDue(now: retryAt.addingTimeInterval(1)),
+            [report.reportID]
+        )
+        XCTAssertEqual(try store.verifiedUploadRequest(reportID: report.reportID), approved)
+    }
+
+    private func sampleEnvelope() -> CrashReportEnvelope {
+        CrashReportEnvelope(
+            schemaVersion: 1,
+            reportID: UUID().uuidString.lowercased(),
+            source: .kscrash,
+            occurredAt: "2026-07-24T12:00:00Z",
+            app: CrashAppInfo(version: "5.2.0", build: "5200"),
+            device: CrashDeviceInfo(model: "iPhone16.2", osVersion: "18.5"),
+            diagnostic: CrashDiagnostic(
+                kind: .signal,
+                exceptionName: nil,
+                exceptionType: nil,
+                exceptionCode: nil,
+                signal: 6,
+                signalName: "SIGABRT",
+                terminationReason: nil,
+                crashedThread: 0,
+                hangDurationMilliseconds: nil,
+                cpuTimeMilliseconds: nil,
+                sampledTimeMilliseconds: nil,
+                diskWritesBytes: nil,
+                component: nil,
+                errorCode: nil,
+                severity: nil,
+                numericMetadata: nil,
+                threads: [
+                    CrashThread(
+                        index: 0,
+                        crashed: true,
+                        frames: [
+                            CrashStackFrame(
+                                instructionAddress: 4_096,
+                                binaryAddress: 2_048,
+                                binaryOffset: 2_048,
+                                binaryName: "OsmAnd",
+                                binaryUUID: "00112233445566778899AABBCCDDEEFF",
+                                symbolAddress: nil,
+                                symbolName: nil
+                            ),
+                        ]
+                    ),
+                ],
+                binaryImages: [
+                    CrashBinaryImage(
+                        name: "OsmAnd",
+                        uuid: "00112233445566778899AABBCCDDEEFF",
+                        imageAddress: 2_048
+                    ),
+                ]
+            ),
+            context: CrashContextSnapshot(),
+            breadcrumbs: []
+        )
+    }
+
+    private func nonFatalEnvelope(errorCode: Int) -> CrashReportEnvelope {
+        let event = CrashNonFatalEvent(
+            component: .resources,
+            code: errorCode,
+            severity: .warning,
+            numericMetadata: [:]
+        )
+        let report = CrashDiagnosticsSanitizer.makeNonFatalEnvelope(
+            event,
+            session: CrashSessionState(context: CrashContextSnapshot(), breadcrumbs: [])
+        )
+        return copy(
+            report,
+            reportID: UUID().uuidString.lowercased(),
+            occurredAt: report.occurredAt
+        )
+    }
+
+    private func copy(
+        _ report: CrashReportEnvelope,
+        reportID: String,
+        occurredAt: String
+    ) -> CrashReportEnvelope {
+        CrashReportEnvelope(
+            schemaVersion: report.schemaVersion,
+            reportID: reportID,
+            source: report.source,
+            occurredAt: occurredAt,
+            app: report.app,
+            device: report.device,
+            diagnostic: report.diagnostic,
+            context: report.context,
+            breadcrumbs: report.breadcrumbs
+        )
+    }
+}

--- a/OsmAnd MapsTests/Services/Fixtures/metrickit_call_stack.json
+++ b/OsmAnd MapsTests/Services/Fixtures/metrickit_call_stack.json
@@ -1,0 +1,28 @@
+{
+  "callStackPerThread": true,
+  "callStacks": [
+    {
+      "threadAttributed": true,
+      "callStackRootFrames": [
+        {
+          "address": 4096,
+          "binaryName": "OsmAnd",
+          "binaryUUID": "00112233-4455-6677-8899-AABBCCDDEEFF",
+          "offsetIntoBinaryTextSegment": 2048,
+          "sampleCount": 1,
+          "sourceURL": "https://private.example/tiles",
+          "subFrames": [
+            {
+              "address": 8192,
+              "binaryName": "/private/var/containers/Bundle/Application/OsmAnd",
+              "binaryUUID": "00112233-4455-6677-8899-AABBCCDDEEFF",
+              "offsetIntoBinaryTextSegment": 6144,
+              "sampleCount": 1,
+              "searchQuery": "private cafe"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -1300,6 +1300,19 @@
 		84F4641E1B664D3B00C1D96F /* ic_popup_no_internet@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 84F464171B664D3B00C1D96F /* ic_popup_no_internet@2x.png */; };
 		84F464211B664D3B00C1D96F /* ic_popup_no_internet@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 84F464181B664D3B00C1D96F /* ic_popup_no_internet@3x.png */; };
 		894E639B06194FAE9135FAD3 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 675D59365E264CE6A5F93C66 /* Kingfisher */; };
+		CD1000000000000000000001 /* CrashDiagnosticsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000001 /* CrashDiagnosticsModels.swift */; };
+		CD1000000000000000000002 /* CrashDiagnosticsSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000002 /* CrashDiagnosticsSanitizer.swift */; };
+		CD1000000000000000000003 /* CrashDiagnosticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000003 /* CrashDiagnosticsStore.swift */; };
+		CD1000000000000000000004 /* CrashDiagnosticsUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000004 /* CrashDiagnosticsUploader.swift */; };
+		CD1000000000000000000005 /* CrashDiagnosticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000005 /* CrashDiagnosticsService.swift */; };
+		CD1000000000000000000006 /* CrashDiagnosticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000006 /* CrashDiagnosticsViewController.swift */; };
+		CD1000000000000000000007 /* CrashDiagnosticsBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000007 /* CrashDiagnosticsBannerPresenter.swift */; };
+		CD1000000000000000000008 /* OACrashDiagnosticsKSCrashBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000009 /* OACrashDiagnosticsKSCrashBridge.mm */; };
+		CD1000000000000000000009 /* Recording in Frameworks */ = {isa = PBXBuildFile; productRef = CD5000000000000000000001 /* Recording */; };
+		CD6000000000000000000001 /* CrashDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6000000000000000000005 /* CrashDiagnosticsTests.swift */; };
+		CD6000000000000000000002 /* CrashDiagnosticsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000001 /* CrashDiagnosticsModels.swift */; };
+		CD6000000000000000000003 /* CrashDiagnosticsSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000002 /* CrashDiagnosticsSanitizer.swift */; };
+		CD6000000000000000000004 /* CrashDiagnosticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2000000000000000000003 /* CrashDiagnosticsStore.swift */; };
 		8A2DF237287EFD9E003642B7 /* OAMapCreatorDbHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DF236287EFD9E003642B7 /* OAMapCreatorDbHelper.mm */; };
 		8A31787527E1D8A800CA8AA4 /* OAMapRendererEnvironment.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A31787427E1D8A800CA8AA4 /* OAMapRendererEnvironment.mm */; };
 		8A3BE84F27DBB2AC00C5DFE2 /* OAWeatherContourLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A3BE84E27DBB2AC00C5DFE2 /* OAWeatherContourLayer.mm */; };
@@ -8453,6 +8466,17 @@
 		FAF6C89A2AD013F400A3ED94 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		FAF6C89D2AD014C800A3ED94 /* ThemeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		FAF6C89E2AD014C800A3ED94 /* Theme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		CD2000000000000000000001 /* CrashDiagnosticsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsModels.swift; sourceTree = "<group>"; };
+		CD2000000000000000000002 /* CrashDiagnosticsSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsSanitizer.swift; sourceTree = "<group>"; };
+		CD2000000000000000000003 /* CrashDiagnosticsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsStore.swift; sourceTree = "<group>"; };
+		CD2000000000000000000004 /* CrashDiagnosticsUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsUploader.swift; sourceTree = "<group>"; };
+		CD2000000000000000000005 /* CrashDiagnosticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsService.swift; sourceTree = "<group>"; };
+		CD2000000000000000000006 /* CrashDiagnosticsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsViewController.swift; sourceTree = "<group>"; };
+		CD2000000000000000000007 /* CrashDiagnosticsBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsBannerPresenter.swift; sourceTree = "<group>"; };
+		CD2000000000000000000008 /* OACrashDiagnosticsKSCrashBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OACrashDiagnosticsKSCrashBridge.h; sourceTree = "<group>"; };
+		CD2000000000000000000009 /* OACrashDiagnosticsKSCrashBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OACrashDiagnosticsKSCrashBridge.mm; sourceTree = "<group>"; };
+		CD6000000000000000000005 /* CrashDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDiagnosticsTests.swift; sourceTree = "<group>"; };
+		CD6000000000000000000007 /* metrickit_call_stack.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = metrickit_call_stack.json; sourceTree = "<group>"; };
 		FAF7920E2A780F2500CE5F79 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -8502,6 +8526,7 @@
 				BBA3AF80197FC4BB0039D991 /* libbz2.dylib in Frameworks */,
 				BBA3AF81197FC4BB0039D991 /* libiconv.dylib in Frameworks */,
 				894E639B06194FAE9135FAD3 /* Kingfisher in Frameworks */,
+				CD1000000000000000000009 /* Recording in Frameworks */,
 				FA7000012F90000000000009 /* AFNetworking in Frameworks */,
 				FA7000012F9000000000000A /* BRCybertron in Frameworks */,
 			);
@@ -14373,6 +14398,7 @@
 		DA5A80E526C563A600F274C7 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				CD3000000000000000000001 /* CrashDiagnostics */,
 				FAF6C89C2AD014C800A3ED94 /* ThemeManager */,
 				DA5A80E726C563A600F274C7 /* OALocationServices.h */,
 				DA5A80E826C563A600F274C7 /* OALocationServices.mm */,
@@ -14476,6 +14502,7 @@
 		DA72AB8A2508F40F00851313 /* OsmAnd MapsTests */ = {
 			isa = PBXGroup;
 			children = (
+				CD6000000000000000000006 /* Services */,
 				FA7EA4082FD2ACF700509B01 /* Extensions */,
 				FAB624402E0953870048965E /* OsmAnd MapsTests-Bridging-Header.h */,
 				FAB6243D2E0953580048965E /* Managers */,
@@ -14486,6 +14513,23 @@
 				7600F13F2F8010AC00DC552B /* Util */,
 			);
 			path = "OsmAnd MapsTests";
+			sourceTree = "<group>";
+		};
+		CD6000000000000000000006 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				CD6000000000000000000008 /* Fixtures */,
+				CD6000000000000000000005 /* CrashDiagnosticsTests.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		CD6000000000000000000008 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				CD6000000000000000000007 /* metrickit_call_stack.json */,
+			);
+			path = Fixtures;
 			sourceTree = "<group>";
 		};
 		DA72AB932508F44900851313 /* Search */ = {
@@ -15415,6 +15459,22 @@
 			path = ThemeManager;
 			sourceTree = "<group>";
 		};
+		CD3000000000000000000001 /* CrashDiagnostics */ = {
+			isa = PBXGroup;
+			children = (
+				CD2000000000000000000001 /* CrashDiagnosticsModels.swift */,
+				CD2000000000000000000002 /* CrashDiagnosticsSanitizer.swift */,
+				CD2000000000000000000003 /* CrashDiagnosticsStore.swift */,
+				CD2000000000000000000004 /* CrashDiagnosticsUploader.swift */,
+				CD2000000000000000000005 /* CrashDiagnosticsService.swift */,
+				CD2000000000000000000006 /* CrashDiagnosticsViewController.swift */,
+				CD2000000000000000000007 /* CrashDiagnosticsBannerPresenter.swift */,
+				CD2000000000000000000008 /* OACrashDiagnosticsKSCrashBridge.h */,
+				CD2000000000000000000009 /* OACrashDiagnosticsKSCrashBridge.mm */,
+			);
+			path = CrashDiagnostics;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -15440,6 +15500,7 @@
 			name = "OsmAnd Maps";
 			packageProductDependencies = (
 				675D59365E264CE6A5F93C66 /* Kingfisher */,
+				CD5000000000000000000001 /* Recording */,
 				FA7000012F9000000000002B /* AFNetworking */,
 				FA7000012F9000000000002D /* BRCybertron */,
 			);
@@ -15586,6 +15647,7 @@
 			mainGroup = BB098CE81793F7FD00423944;
 			packageReferences = (
 				11D9394822FF40EFAB7D4478 /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				CD4000000000000000000001 /* XCRemoteSwiftPackageReference "KSCrash" */,
 				ADEBBA52BE4C4EA4B376A7E6 /* XCLocalSwiftPackageReference "Scripts/SwiftLint" */,
 				FA7000012F9000000000002A /* XCLocalSwiftPackageReference "Packages/AFNetworking" */,
 				FA7000012F9000000000002C /* XCLocalSwiftPackageReference "Packages/BRCybertron" */,
@@ -17576,6 +17638,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD1000000000000000000001 /* CrashDiagnosticsModels.swift in Sources */,
+				CD1000000000000000000002 /* CrashDiagnosticsSanitizer.swift in Sources */,
+				CD1000000000000000000003 /* CrashDiagnosticsStore.swift in Sources */,
+				CD1000000000000000000004 /* CrashDiagnosticsUploader.swift in Sources */,
+				CD1000000000000000000005 /* CrashDiagnosticsService.swift in Sources */,
+				CD1000000000000000000006 /* CrashDiagnosticsViewController.swift in Sources */,
+				CD1000000000000000000007 /* CrashDiagnosticsBannerPresenter.swift in Sources */,
+				CD1000000000000000000008 /* OACrashDiagnosticsKSCrashBridge.mm in Sources */,
 				321C838E2F33BBD70028FCCC /* CapacityRowBehaviour.swift in Sources */,
 				C50E32822CA3FBDF00EEC41F /* TracksFiltersViewController.swift in Sources */,
 				46E9AD9228DC894600CC55F9 /* OASimpleTableViewCell.m in Sources */,
@@ -19225,6 +19295,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD6000000000000000000001 /* CrashDiagnosticsTests.swift in Sources */,
+				CD6000000000000000000002 /* CrashDiagnosticsModels.swift in Sources */,
+				CD6000000000000000000003 /* CrashDiagnosticsSanitizer.swift in Sources */,
+				CD6000000000000000000004 /* CrashDiagnosticsStore.swift in Sources */,
 				D1A0B0012F50000100A0B001 /* OpeningHoursParserTest.swift in Sources */,
 				D1A0B0032F50000100A0B001 /* OpeningHoursParserTestSupport.mm in Sources */,
 				D1A0B0112F50001100A0B001 /* URLExtractionTests.swift in Sources */,
@@ -19703,6 +19777,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Dev OsmAnd Profile";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Sources/OsmAnd Maps-Bridging-Header.h";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -19973,6 +20048,14 @@
 				version = 8.10.0;
 			};
 		};
+		CD4000000000000000000001 /* XCRemoteSwiftPackageReference "KSCrash" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kstenerud/KSCrash.git";
+			requirement = {
+				kind = exactVersion;
+				version = 2.5.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -19980,6 +20063,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 11D9394822FF40EFAB7D4478 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		CD5000000000000000000001 /* Recording */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CD4000000000000000000001 /* XCRemoteSwiftPackageReference "KSCrash" */;
+			productName = Recording;
 		};
 		FA7000012F9000000000002B /* AFNetworking */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/OsmAnd.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OsmAnd.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,14 @@
 {
-  "originHash" : "254be8b517bdba70c7fb5cb54b0ef277b5f9c40ead1cda7095b381bb9a961e51",
   "pins" : [
+    {
+      "identity" : "kscrash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kstenerud/KSCrash.git",
+      "state" : {
+        "revision" : "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
+        "version" : "2.5.1"
+      }
+    },
     {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",

--- a/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Resources/Localizations/en.lproj/Localizable.strings
@@ -4970,3 +4970,34 @@
 "selected_waypoints_exit_descr" = "Your waypoint selections will not be saved if you close now";
 "auto_select_nearest_points" = "Auto-select nearest points";
 "auto_select_nearest_footer" = "Automatically find and select the waypoints closest to this track.";
+
+// Crash diagnostics
+"crash_diagnostics" = "Crash diagnostics";
+"crash_diagnostics_description" = "Review privacy-filtered reports stored on this device.";
+"crash_diagnostics_pending_count" = "%ld pending reports";
+"crash_diagnostics_pending_reports" = "Pending reports";
+"crash_diagnostics_privacy_title" = "Private by design";
+"crash_diagnostics_privacy_description" = "Reports stay on this device until you review a report and choose Send once. Coordinates, routes, searches, favorites, names, URLs, file paths, logs, account data, and persistent identifiers are excluded.";
+"crash_diagnostics_no_reports" = "No pending reports";
+"crash_diagnostics_crash" = "Crash report";
+"crash_diagnostics_hang" = "App hang report";
+"crash_diagnostics_cpu" = "CPU exception report";
+"crash_diagnostics_disk" = "Disk-write exception report";
+"crash_diagnostics_non_fatal" = "Recoverable error report";
+"crash_diagnostics_not_sent" = "Not sent";
+"crash_diagnostics_approved" = "Approved; waiting to retry";
+"crash_diagnostics_rejected" = "Receiver rejected this report";
+"crash_diagnostics_review" = "Review crash report";
+"crash_diagnostics_payload" = "Sanitized crash report JSON";
+"crash_diagnostics_send_once" = "Send once";
+"crash_diagnostics_later" = "Later";
+"crash_diagnostics_report_unavailable" = "This report is no longer available.";
+"crash_diagnostics_delete_title" = "Delete this report?";
+"crash_diagnostics_delete_description" = "The report will be permanently removed from this device.";
+"crash_diagnostics_banner" = "Crash report available — review before sending";
+"crash_diagnostics_test" = "Test crash";
+"crash_diagnostics_test_warning" = "The app will terminate";
+"crash_diagnostics_test_confirmation" = "This intentionally terminates the app. Relaunch without the debugger to recover and review the report.";
+"crash_diagnostics_copy_json" = "Copy JSON";
+"crash_diagnostics_save_json" = "Save JSON File";
+"crash_diagnostics_copied" = "Crash report copied";

--- a/Resources/OsmAnd-Info.plist
+++ b/Resources/OsmAnd-Info.plist
@@ -196,6 +196,8 @@
 	<string>This permission is required to use such features as: background GPX recording, navigation etc.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This permission is required to use such features as: background GPX recording, navigation etc. when OsmAnd is in foreground only.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>A developer can use local network access in a debug build to send an approved diagnostic report to a local test receiver.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>OsmAnd needs motion access to orient the astronomy sky map with device movement.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/Resources/PrivacyInfo.xcprivacy
+++ b/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,61 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Scripts/CrashReportReceiver/PrivacyReview.md
+++ b/Scripts/CrashReportReceiver/PrivacyReview.md
@@ -1,0 +1,41 @@
+# Crash diagnostics privacy-review notes
+
+Production upload is intentionally not configured by this change. Before the
+release capture flag or a production endpoint is enabled, the privacy reviewer
+should verify the serialized schema and approve the following external updates.
+
+## Suggested public-policy wording
+
+OsmAnd may keep a privacy-filtered diagnostic report on the device after a
+crash, hang, resource exception, or enumerated recoverable error. A report is
+not transmitted unless the user opens that report, reviews the exact diagnostic
+payload, and selects **Send once**. If that approved upload is interrupted, the
+same reviewed payload may be retried for up to seven days.
+
+The report can contain the app/build and OS versions, hardware model, numeric
+crash and termination codes, stack addresses and binary identifiers needed for
+symbolication, coarse app-state categories, stable screen and event identifiers,
+relative event times, and bucketed resource availability. It excludes precise
+location, routes, searches, favorites, custom names, region identifiers, online
+source URLs, file paths, logs, notification contents, account information,
+stack memory, register dumps, and persistent device or installation identifiers.
+Each report has an unrelated random identifier.
+
+Crash diagnostics are used to investigate reliability and performance. They
+are not used for tracking and are not linked to an identity. Production policy
+wording must also state the server retention period, deletion process, access
+controls, and contact channel once those values have been approved.
+
+## App Store Connect answers
+
+Declare these categories for diagnostics a user chooses to send:
+
+- Crash Data
+- Performance Data
+- Other Diagnostic Data
+- Product Interaction
+
+For each category, select purposes matching app functionality and analytics,
+and mark the data as not linked to the user's identity and not used for
+tracking. The submitted answers must be checked against the final production
+API, retention policy, and any authentication metadata before release.

--- a/Scripts/CrashReportReceiver/README.md
+++ b/Scripts/CrashReportReceiver/README.md
@@ -1,0 +1,77 @@
+# OsmAnd iOS local crash-report receiver
+
+This dependency-free server is for local development only. It accepts the
+version 1, privacy-filtered upload contract and writes one pretty-printed JSON
+file per `report_id`. It rejects unknown fields, known sensitive fields, paths,
+URLs, oversized requests, and unsupported schema versions.
+
+Start it for the iOS Simulator:
+
+```sh
+python3 receiver.py
+```
+
+The default endpoint is
+`http://127.0.0.1:8080/api/v1/crash-reports`, and reports are written outside
+the checkout to the system temporary directory under
+`osmand-crash-reports`.
+
+Open the human-readable reviewer at:
+
+```text
+http://127.0.0.1:8080/review
+```
+
+Drop an app-exported report or a JSON file saved by the receiver onto the page.
+The report is parsed entirely in the browser: it is not uploaded, stored, or
+modified. The readable view shows the crash summary, context, breadcrumbs, all
+captured threads, and all binary images. The exact payload remains available
+under the **Exact JSON** tab, with copy and download controls.
+
+Check receiver readiness with:
+
+```sh
+curl http://127.0.0.1:8080/health
+```
+
+For a physical device, bind explicitly to all interfaces and set the
+`OSMAND_CRASH_ENDPOINT` environment variable in the Debug run scheme to the
+Mac's LAN address:
+
+```sh
+python3 receiver.py --host 0.0.0.0
+OSMAND_CRASH_ENDPOINT=http://192.168.1.10:8080/api/v1/crash-reports
+```
+
+Only use the all-interfaces mode on a trusted test network. Release builds have
+no endpoint and cannot upload. Release capture is also off unless the internal
+`OSMAND_CRASH_CAPTURE_ENABLED` Info.plist flag is explicitly set after privacy
+review.
+
+## Manual end-to-end check
+
+1. Start this receiver and run a Debug simulator build.
+2. Open **Help → Crash diagnostics → Test crash**, choose one crash type, and
+   relaunch the app without the debugger.
+3. Open the non-blocking report banner and inspect the JSON. Choose **Later**,
+   then revisit the same payload from **Help → Crash diagnostics**.
+4. Verify **Delete** removes the local report without a request.
+5. Generate another report, choose **Send once**, and verify one JSON file is
+   written here. Reposting the same approved request must not create a second
+   file.
+6. Approve a report while the receiver is stopped, restart the receiver, and
+   foreground the app to exercise retry of the unchanged reviewed payload.
+7. Repeat with the Objective-C, C++, signal, and invalid-memory controls.
+
+Before any production rollout, archive in the permitted build environment and
+verify that the captured application binary UUID matches its dSYM UUID and that
+the recorded offsets can be symbolicated. Production upload remains blocked
+until authentication, retention, access control, and dSYM ingestion are
+implemented.
+
+The repository privacy manifest declares Crash Data, Performance Data, Other
+Diagnostic Data, and Product Interaction as neither linked to identity nor
+used for tracking. Before production upload is enabled, the matching App Store
+Connect privacy answers and public privacy policy must be updated outside this
+repository, and the production service must define authentication, retention,
+access control, and dSYM handling.

--- a/Scripts/CrashReportReceiver/receiver.py
+++ b/Scripts/CrashReportReceiver/receiver.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Strict local-only receiver for OsmAnd iOS crash diagnostic fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+import uuid
+import zlib
+from datetime import datetime
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+MAX_REQUEST_BYTES = 2 * 1024 * 1024
+MAX_STRING_LENGTH = 512
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SAFE_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+PROHIBITED_KEY_PARTS = {
+    "account",
+    "coordinate",
+    "favorite",
+    "filepath",
+    "installationid",
+    "latitude",
+    "longitude",
+    "notification",
+    "query",
+    "regionid",
+    "routepoints",
+    "search",
+    "stackmemory",
+    "url",
+}
+PROHIBITED_STRING_PATTERNS = (
+    re.compile(r"https?://", re.IGNORECASE),
+    re.compile(r"file://", re.IGNORECASE),
+    re.compile(r"(^|[\s\"'])/(?:private|var|users|documents|library|tmp)/", re.IGNORECASE),
+)
+
+
+class ValidationError(ValueError):
+    pass
+
+
+def _object(
+    value: Any,
+    *,
+    required: set[str],
+    optional: set[str] = frozenset(),
+    name: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValidationError(f"{name} must be an object")
+    keys = set(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise ValidationError(f"{name} is missing: {', '.join(sorted(missing))}")
+    if unknown:
+        raise ValidationError(f"{name} has unknown fields: {', '.join(sorted(unknown))}")
+    return value
+
+
+def _string(value: Any, name: str, *, maximum: int = MAX_STRING_LENGTH) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        raise ValidationError(f"{name} must be a non-empty string up to {maximum} characters")
+    for pattern in PROHIBITED_STRING_PATTERNS:
+        if pattern.search(value):
+            raise ValidationError(f"{name} contains prohibited path or URL data")
+    return value
+
+
+def _integer(value: Any, name: str, *, minimum: int = 0, maximum: int = 2**63 - 1) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise ValidationError(f"{name} must be an integer between {minimum} and {maximum}")
+    return value
+
+
+def _boolean(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValidationError(f"{name} must be a boolean")
+    return value
+
+
+def _identifier(value: Any, name: str, *, maximum: int = 128) -> str:
+    result = _string(value, name, maximum=maximum)
+    if not SAFE_ID_PATTERN.fullmatch(result):
+        raise ValidationError(f"{name} contains unsupported characters")
+    return result
+
+
+def _timestamp(value: Any, name: str) -> str:
+    result = _string(value, name, maximum=32)
+    try:
+        parsed = datetime.fromisoformat(result.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValidationError(f"{name} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise ValidationError(f"{name} must include a time zone")
+    return result
+
+
+def _optional_integer(
+    value: dict[str, Any],
+    key: str,
+    name: str,
+    *,
+    minimum: int = 0,
+    maximum: int = 2**63 - 1,
+) -> None:
+    if key in value:
+        _integer(value[key], f"{name}.{key}", minimum=minimum, maximum=maximum)
+
+
+def _optional_string(
+    value: dict[str, Any],
+    key: str,
+    name: str,
+    *,
+    identifier: bool = False,
+    maximum: int = MAX_STRING_LENGTH,
+) -> None:
+    if key in value:
+        validator = _identifier if identifier else _string
+        validator(value[key], f"{name}.{key}", maximum=maximum)
+
+
+def _validate_numeric_metadata(value: Any, name: str) -> None:
+    metadata = _object(value, required=set(), optional={
+        "attempt_count",
+        "bytes",
+        "duration_ms",
+        "item_count",
+        "retry_count",
+        "status_code",
+    }, name=name)
+    for key, number in metadata.items():
+        _integer(number, f"{name}.{key}", minimum=-1_000_000_000, maximum=1_000_000_000)
+
+
+def _validate_frame(value: Any, name: str) -> None:
+    frame = _object(
+        value,
+        required=set(),
+        optional={
+            "instruction_address",
+            "binary_address",
+            "binary_offset",
+            "binary_name",
+            "binary_uuid",
+            "symbol_address",
+            "symbol_name",
+        },
+        name=name,
+    )
+    for key in ("instruction_address", "binary_address", "binary_offset", "symbol_address"):
+        _optional_integer(frame, key, name, maximum=2**64 - 1)
+    _optional_string(frame, "binary_name", name, identifier=True)
+    _optional_string(frame, "symbol_name", name, maximum=256)
+    if "binary_uuid" in frame:
+        binary_uuid = _string(frame["binary_uuid"], f"{name}.binary_uuid", maximum=40)
+        compact = binary_uuid.replace("-", "")
+        if len(compact) not in {32, 40} or not all(character in "0123456789abcdefABCDEF" for character in compact):
+            raise ValidationError(f"{name}.binary_uuid is invalid")
+
+
+def _validate_diagnostic(value: Any) -> None:
+    diagnostic = _object(
+        value,
+        required={"kind", "threads", "binary_images"},
+        optional={
+            "exception_name",
+            "exception_type",
+            "exception_code",
+            "signal",
+            "signal_name",
+            "termination_reason",
+            "crashed_thread",
+            "hang_duration_ms",
+            "cpu_time_ms",
+            "sampled_time_ms",
+            "disk_writes_bytes",
+            "component",
+            "error_code",
+            "severity",
+            "numeric_metadata",
+        },
+        name="report.diagnostic",
+    )
+    kind = _identifier(diagnostic["kind"], "report.diagnostic.kind")
+    if kind not in {
+        "mach_exception", "signal", "cpp_exception", "objective_c_exception",
+        "memory_termination", "crash", "hang", "cpu_exception",
+        "disk_write_exception", "non_fatal", "unknown",
+    }:
+        raise ValidationError("report.diagnostic.kind is unsupported")
+    for key in ("exception_name", "signal_name"):
+        if key in diagnostic:
+            code_identifier = _string(
+                diagnostic[key],
+                f"report.diagnostic.{key}",
+                maximum=128,
+            )
+            if not re.fullmatch(r"[A-Za-z0-9_.$:+<>()\\[\\]-]+", code_identifier):
+                raise ValidationError(f"report.diagnostic.{key} is not a code identifier")
+    if "termination_reason" in diagnostic:
+        reason = _identifier(
+            diagnostic["termination_reason"],
+            "report.diagnostic.termination_reason",
+        )
+        if reason not in {
+            "watchdog", "memory_pressure", "resource_limit", "jetsam",
+            "namespace_signal", "unknown",
+        }:
+            raise ValidationError("report.diagnostic.termination_reason is unsupported")
+    for key in (
+        "exception_type", "exception_code", "hang_duration_ms", "cpu_time_ms",
+        "sampled_time_ms", "disk_writes_bytes",
+    ):
+        _optional_integer(diagnostic, key, "report.diagnostic", maximum=2**64 - 1)
+    for key in ("signal", "crashed_thread"):
+        _optional_integer(diagnostic, key, "report.diagnostic", maximum=1_000_000)
+    _optional_integer(
+        diagnostic, "error_code", "report.diagnostic",
+        minimum=-1_000_000, maximum=1_000_000,
+    )
+    if "component" in diagnostic:
+        component = _identifier(diagnostic["component"], "report.diagnostic.component")
+        if component not in {
+            "app_startup", "map_rendering", "navigation", "resources",
+            "networking", "storage", "unknown",
+        }:
+            raise ValidationError("report.diagnostic.component is unsupported")
+    if "severity" in diagnostic and diagnostic["severity"] not in {"warning", "error"}:
+        raise ValidationError("report.diagnostic.severity is unsupported")
+    if "numeric_metadata" in diagnostic:
+        _validate_numeric_metadata(diagnostic["numeric_metadata"], "report.diagnostic.numeric_metadata")
+
+    threads = diagnostic["threads"]
+    if not isinstance(threads, list) or len(threads) > 64:
+        raise ValidationError("report.diagnostic.threads must contain at most 64 entries")
+    for thread_index, thread_value in enumerate(threads):
+        thread = _object(
+            thread_value,
+            required={"index", "crashed", "frames"},
+            name=f"report.diagnostic.threads[{thread_index}]",
+        )
+        _integer(thread["index"], f"report.diagnostic.threads[{thread_index}].index", maximum=1_000_000)
+        _boolean(thread["crashed"], f"report.diagnostic.threads[{thread_index}].crashed")
+        frames = thread["frames"]
+        if not isinstance(frames, list) or len(frames) > 512:
+            raise ValidationError("a thread contains too many frames")
+        for frame_index, frame in enumerate(frames):
+            _validate_frame(frame, f"report.diagnostic.threads[{thread_index}].frames[{frame_index}]")
+
+    images = diagnostic["binary_images"]
+    if not isinstance(images, list) or len(images) > 512:
+        raise ValidationError("report.diagnostic.binary_images must contain at most 512 entries")
+    for image_index, image_value in enumerate(images):
+        image = _object(
+            image_value,
+            required={"name"},
+            optional={"uuid", "image_address"},
+            name=f"report.diagnostic.binary_images[{image_index}]",
+        )
+        _identifier(image["name"], f"report.diagnostic.binary_images[{image_index}].name")
+        _optional_string(image, "uuid", f"report.diagnostic.binary_images[{image_index}]", maximum=40)
+        _optional_integer(image, "image_address", f"report.diagnostic.binary_images[{image_index}]", maximum=2**64 - 1)
+
+
+def _validate_context(value: Any) -> None:
+    context = _object(
+        value,
+        required={
+            "navigation_active",
+            "route_calculation_state",
+            "profile_family",
+            "map_source_category",
+            "loaded_map_count",
+            "built_in_plugin_ids",
+            "custom_plugin_count",
+            "application_state",
+        },
+        optional={
+            "screen_identifier",
+            "zoom_bucket",
+            "memory_available_bucket_mb",
+            "disk_available_bucket_mb",
+        },
+        name="report.context",
+    )
+    _boolean(context["navigation_active"], "report.context.navigation_active")
+    allowed_values = {
+        "route_calculation_state": {"idle", "calculating", "calculated", "failed", "unknown"},
+        "profile_family": {
+            "default", "car", "bicycle", "pedestrian", "aircraft", "truck",
+            "motorcycle", "moped", "boat", "public_transport", "train", "ski",
+            "horse", "custom", "unknown",
+        },
+        "map_source_category": {"offline_vector", "offline_raster", "online_raster", "unknown"},
+        "application_state": {"active", "inactive", "background", "unknown"},
+    }
+    for key, allowed in allowed_values.items():
+        if _identifier(context[key], f"report.context.{key}") not in allowed:
+            raise ValidationError(f"report.context.{key} is unsupported")
+    _optional_string(context, "screen_identifier", "report.context", identifier=True)
+    _optional_integer(context, "zoom_bucket", "report.context", maximum=24)
+    _integer(context["loaded_map_count"], "report.context.loaded_map_count", maximum=1_000)
+    _integer(context["custom_plugin_count"], "report.context.custom_plugin_count", maximum=100)
+    for key in ("memory_available_bucket_mb", "disk_available_bucket_mb"):
+        _optional_integer(context, key, "report.context", maximum=1_048_576)
+    plugin_ids = context["built_in_plugin_ids"]
+    if not isinstance(plugin_ids, list) or len(plugin_ids) > 32:
+        raise ValidationError("report.context.built_in_plugin_ids must contain at most 32 entries")
+    for index, plugin_id in enumerate(plugin_ids):
+        _identifier(plugin_id, f"report.context.built_in_plugin_ids[{index}]")
+
+
+def _validate_breadcrumbs(value: Any) -> None:
+    if not isinstance(value, list) or len(value) > 100:
+        raise ValidationError("report.breadcrumbs must contain at most 100 entries")
+    for index, item in enumerate(value):
+        breadcrumb = _object(
+            item,
+            required={"elapsed_ms", "event"},
+            optional={"numeric_metadata", "screen_identifier"},
+            name=f"report.breadcrumbs[{index}]",
+        )
+        _integer(breadcrumb["elapsed_ms"], f"report.breadcrumbs[{index}].elapsed_ms", maximum=604_800_000)
+        event = _identifier(breadcrumb["event"], f"report.breadcrumbs[{index}].event")
+        if event not in {
+            "app_launched", "app_became_active", "app_entered_background",
+            "screen_changed", "navigation_started", "navigation_stopped",
+            "route_calculation_started", "route_calculation_finished",
+            "profile_changed", "plugin_changed", "map_source_changed",
+            "memory_warning",
+        }:
+            raise ValidationError(f"report.breadcrumbs[{index}].event is unsupported")
+        _optional_string(
+            breadcrumb,
+            "screen_identifier",
+            f"report.breadcrumbs[{index}]",
+            identifier=True,
+        )
+        if "numeric_metadata" in breadcrumb:
+            _validate_numeric_metadata(
+                breadcrumb["numeric_metadata"],
+                f"report.breadcrumbs[{index}].numeric_metadata",
+            )
+
+
+def _reject_prohibited_keys(value: Any, path: str = "request") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = re.sub(r"[^a-z]", "", key.lower())
+            if any(part in normalized for part in PROHIBITED_KEY_PARTS):
+                raise ValidationError(f"{path}.{key} is a prohibited field")
+            _reject_prohibited_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_prohibited_keys(child, f"{path}[{index}]")
+
+
+def validate_upload_request(value: Any) -> tuple[str, dict[str, Any]]:
+    request = _object(value, required={"report", "consent"}, name="request")
+    _reject_prohibited_keys(request)
+    report = _object(
+        request["report"],
+        required={
+            "schema_version", "report_id", "source", "occurred_at",
+            "app", "device", "diagnostic", "context", "breadcrumbs",
+        },
+        name="report",
+    )
+    if _integer(report["schema_version"], "report.schema_version", minimum=1, maximum=1) != 1:
+        raise ValidationError("report.schema_version must equal 1")
+    report_id = _string(report["report_id"], "report.report_id", maximum=36)
+    try:
+        uuid.UUID(report_id)
+    except ValueError as error:
+        raise ValidationError("report.report_id must be a UUID") from error
+    if report_id != report_id.lower():
+        raise ValidationError("report.report_id must be lowercase")
+    if report["source"] not in {"kscrash", "metrickit", "non_fatal"}:
+        raise ValidationError("report.source is unsupported")
+    _timestamp(report["occurred_at"], "report.occurred_at")
+
+    app = _object(report["app"], required={"version", "build"}, name="report.app")
+    _identifier(app["version"], "report.app.version")
+    _identifier(app["build"], "report.app.build")
+    device = _object(report["device"], required={"model", "os_version"}, name="report.device")
+    device_model = _string(device["model"], "report.device.model", maximum=64)
+    if not re.fullmatch(r"[A-Za-z0-9,._-]+", device_model):
+        raise ValidationError("report.device.model contains unsupported characters")
+    _identifier(device["os_version"], "report.device.os_version")
+    _validate_diagnostic(report["diagnostic"])
+    _validate_context(report["context"])
+    _validate_breadcrumbs(report["breadcrumbs"])
+
+    consent = _object(
+        request["consent"],
+        required={"mode", "approved_at", "reviewed_payload_sha256"},
+        name="consent",
+    )
+    if consent["mode"] != "per_report":
+        raise ValidationError("consent.mode must equal per_report")
+    _timestamp(consent["approved_at"], "consent.approved_at")
+    reviewed_hash = _string(
+        consent["reviewed_payload_sha256"],
+        "consent.reviewed_payload_sha256",
+        maximum=64,
+    )
+    if not SHA256_PATTERN.fullmatch(reviewed_hash):
+        raise ValidationError("consent.reviewed_payload_sha256 must be a lowercase SHA-256")
+    canonical_report = json.dumps(
+        report,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    if hashlib.sha256(canonical_report).hexdigest() != reviewed_hash:
+        raise ValidationError("consent hash does not match the report payload")
+    return report_id, request
+
+
+class CrashReportRequestHandler(BaseHTTPRequestHandler):
+    server_version = "OsmAndCrashReceiver/1"
+
+    def do_GET(self) -> None:  # noqa: N802
+        request_path = self.path.partition("?")[0]
+        if request_path == "/health":
+            self._json_response(HTTPStatus.OK, {"status": "ok"})
+            return
+        if request_path in {"/", "/review"}:
+            self._review_response()
+            return
+        self._json_response(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/api/v1/crash-reports":
+            self._json_response(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+        if self.headers.get_content_type() != "application/json":
+            self._json_response(HTTPStatus.UNSUPPORTED_MEDIA_TYPE, {"error": "application_json_required"})
+            return
+        try:
+            content_length = int(self.headers.get("Content-Length", ""))
+        except ValueError:
+            self._json_response(HTTPStatus.LENGTH_REQUIRED, {"error": "content_length_required"})
+            return
+        if content_length < 1 or content_length > MAX_REQUEST_BYTES:
+            self._json_response(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, {"error": "request_too_large"})
+            return
+
+        body = self.rfile.read(content_length)
+        encoding = self.headers.get("Content-Encoding", "identity").lower()
+        try:
+            if encoding == "gzip":
+                decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+                body = decompressor.decompress(body, MAX_REQUEST_BYTES + 1)
+                if (
+                    len(body) > MAX_REQUEST_BYTES
+                    or decompressor.unconsumed_tail
+                    or not decompressor.eof
+                ):
+                    self._json_response(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {"error": "request_too_large"},
+                    )
+                    return
+                if decompressor.unused_data:
+                    self._json_response(HTTPStatus.BAD_REQUEST, {"error": "invalid_gzip"})
+                    return
+            elif encoding != "identity":
+                self._json_response(HTTPStatus.UNSUPPORTED_MEDIA_TYPE, {"error": "unsupported_content_encoding"})
+                return
+        except zlib.error:
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": "invalid_gzip"})
+            return
+        if len(body) > MAX_REQUEST_BYTES:
+            self._json_response(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, {"error": "request_too_large"})
+            return
+
+        try:
+            parsed = json.loads(body)
+            report_id, request = validate_upload_request(parsed)
+        except (json.JSONDecodeError, UnicodeDecodeError, ValidationError) as error:
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": "invalid_report", "detail": str(error)})
+            return
+
+        idempotency_key = self.headers.get("Idempotency-Key")
+        if idempotency_key is None:
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": "idempotency_key_required"})
+            return
+        if idempotency_key != report_id:
+            self._json_response(HTTPStatus.CONFLICT, {"error": "idempotency_key_mismatch"})
+            return
+
+        output_directory: Path = self.server.output_directory  # type: ignore[attr-defined]
+        output_path = output_directory / f"{report_id}.json"
+        created = False
+        try:
+            descriptor = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+                json.dump(request, output, indent=2, sort_keys=True, ensure_ascii=True)
+                output.write("\n")
+            created = True
+        except FileExistsError:
+            pass
+        self._json_response(
+            HTTPStatus.CREATED if created else HTTPStatus.OK,
+            {"accepted": True, "created": created, "report_id": report_id},
+        )
+
+    def log_message(self, format: str, *args: Any) -> None:
+        print(format % args)
+
+    def _json_response(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _review_response(self) -> None:
+        body = Path(__file__).with_name("review.html").read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'none'; style-src 'unsafe-inline'; "
+            "script-src 'unsafe-inline'; img-src data:; connect-src 'none'; "
+            "base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+        )
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=8080, type=int)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(tempfile.gettempdir()) / "osmand-crash-reports",
+        help="Report directory (default: the system temporary directory, outside the repository)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    output_directory = arguments.output.expanduser().resolve()
+    repository_root = Path(__file__).resolve().parents[2]
+    try:
+        output_directory.relative_to(repository_root)
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("Refusing to write crash reports inside the repository")
+    output_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(output_directory, 0o700)
+
+    server = ThreadingHTTPServer((arguments.host, arguments.port), CrashReportRequestHandler)
+    server.output_directory = output_directory  # type: ignore[attr-defined]
+    print(f"Listening on http://{arguments.host}:{arguments.port}")
+    print(f"Review reports at http://{arguments.host}:{arguments.port}/review")
+    print(f"Writing accepted reports to {output_directory}")
+    if arguments.host == "0.0.0.0":
+        print("Warning: receiver is reachable on all interfaces; use only on a trusted test network.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/CrashReportReceiver/review.html
+++ b/Scripts/CrashReportReceiver/review.html
@@ -1,0 +1,1077 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>OsmAnd crash report reviewer</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f3f6f4;
+      --surface: #ffffff;
+      --surface-soft: #f6f8f7;
+      --ink: #18201c;
+      --muted: #66716b;
+      --line: #dce3df;
+      --accent: #1b704a;
+      --accent-soft: #e5f4eb;
+      --danger: #b83a32;
+      --danger-soft: #fcecea;
+      --warning: #8f5b00;
+      --warning-soft: #fff3d6;
+      --code: #111a16;
+      --shadow: 0 18px 48px rgba(32, 53, 42, .09);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        color-scheme: dark;
+        --bg: #111613;
+        --surface: #1a211d;
+        --surface-soft: #222a25;
+        --ink: #edf3ef;
+        --muted: #a2afa8;
+        --line: #344039;
+        --accent: #72d39e;
+        --accent-soft: #173b2a;
+        --danger: #ff8b83;
+        --danger-soft: #472421;
+        --warning: #f1c56b;
+        --warning-soft: #3c321c;
+        --code: #eef6f1;
+        --shadow: 0 18px 48px rgba(0, 0, 0, .22);
+      }
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-width: 320px;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(27, 112, 74, .09), transparent 30rem),
+        var(--bg);
+      color: var(--ink);
+      font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    button, input { font: inherit; }
+    button { color: inherit; }
+
+    .topbar {
+      position: sticky;
+      z-index: 10;
+      top: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 68px;
+      padding: 12px max(22px, calc((100vw - 1180px) / 2));
+      border-bottom: 1px solid var(--line);
+      background: color-mix(in srgb, var(--bg) 88%, transparent);
+      backdrop-filter: blur(18px);
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 11px;
+      font-weight: 750;
+      letter-spacing: -.01em;
+    }
+
+    .brand-mark {
+      display: grid;
+      width: 34px;
+      height: 34px;
+      place-items: center;
+      border-radius: 11px;
+      background: var(--accent);
+      color: white;
+      font-size: 18px;
+      box-shadow: 0 6px 16px rgba(27, 112, 74, .24);
+    }
+
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      padding: 8px 14px;
+      border: 1px solid var(--line);
+      border-radius: 11px;
+      background: var(--surface);
+      cursor: pointer;
+      font-weight: 650;
+      transition: border-color .15s, transform .15s, background .15s;
+    }
+
+    .button:hover {
+      border-color: var(--accent);
+      transform: translateY(-1px);
+    }
+
+    .button.primary {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: white;
+    }
+
+    .button:focus-visible,
+    .tab:focus-visible,
+    .drop-zone:focus-visible,
+    input:focus-visible,
+    summary:focus-visible {
+      outline: 3px solid color-mix(in srgb, var(--accent) 35%, transparent);
+      outline-offset: 2px;
+    }
+
+    .shell {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 42px 0 72px;
+    }
+
+    .empty {
+      max-width: 760px;
+      margin: 7vh auto 0;
+      text-align: center;
+    }
+
+    .eyebrow {
+      margin: 0 0 8px;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .13em;
+      text-transform: uppercase;
+    }
+
+    h1, h2, h3, p { margin-top: 0; }
+
+    h1 {
+      margin-bottom: 13px;
+      font-size: clamp(32px, 5vw, 54px);
+      line-height: 1.06;
+      letter-spacing: -.045em;
+    }
+
+    h2 {
+      margin-bottom: 5px;
+      font-size: 20px;
+      letter-spacing: -.02em;
+    }
+
+    h3 {
+      margin-bottom: 4px;
+      font-size: 15px;
+    }
+
+    .lead {
+      max-width: 620px;
+      margin: 0 auto 27px;
+      color: var(--muted);
+      font-size: 17px;
+    }
+
+    .drop-zone {
+      display: grid;
+      min-height: 230px;
+      padding: 30px;
+      place-items: center;
+      border: 1.5px dashed color-mix(in srgb, var(--accent) 45%, var(--line));
+      border-radius: 24px;
+      background: color-mix(in srgb, var(--surface) 82%, transparent);
+      box-shadow: var(--shadow);
+      cursor: pointer;
+      transition: background .15s, border-color .15s, transform .15s;
+    }
+
+    .drop-zone:hover,
+    .drop-zone.dragging {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      transform: translateY(-2px);
+    }
+
+    .drop-icon {
+      display: grid;
+      width: 58px;
+      height: 58px;
+      margin: 0 auto 15px;
+      place-items: center;
+      border-radius: 18px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-size: 27px;
+      font-weight: 400;
+    }
+
+    .drop-title { margin-bottom: 4px; font-size: 18px; font-weight: 750; }
+    .drop-note { margin: 0; color: var(--muted); }
+
+    .privacy-note {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      max-width: 600px;
+      margin: 18px auto 0;
+      color: var(--muted);
+      text-align: left;
+      font-size: 13px;
+    }
+
+    .privacy-note strong { color: var(--ink); }
+    .error { margin-top: 14px; color: var(--danger); font-weight: 650; }
+
+    .hidden { display: none !important; }
+
+    .report-heading {
+      display: flex;
+      gap: 24px;
+      align-items: flex-end;
+      justify-content: space-between;
+      margin-bottom: 24px;
+    }
+
+    .report-heading h1 { margin-bottom: 5px; font-size: clamp(30px, 4vw, 44px); }
+    .report-heading p { margin-bottom: 0; color: var(--muted); }
+
+    .pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 7px;
+      margin-bottom: 10px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 27px;
+      padding: 3px 9px;
+      border-radius: 999px;
+      background: var(--surface-soft);
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 750;
+    }
+
+    .pill.bad { background: var(--danger-soft); color: var(--danger); }
+    .pill.good { background: var(--accent-soft); color: var(--accent); }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 22px;
+    }
+
+    .metric {
+      padding: 17px 18px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--surface);
+      box-shadow: 0 8px 25px rgba(32, 53, 42, .04);
+    }
+
+    .metric .value {
+      display: block;
+      overflow: hidden;
+      margin-bottom: 3px;
+      font-size: 20px;
+      font-weight: 780;
+      letter-spacing: -.025em;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .metric .label { color: var(--muted); font-size: 12px; }
+
+    .tabs {
+      display: inline-flex;
+      gap: 5px;
+      margin-bottom: 18px;
+      padding: 5px;
+      border: 1px solid var(--line);
+      border-radius: 13px;
+      background: var(--surface);
+    }
+
+    .tab {
+      padding: 8px 13px;
+      border: 0;
+      border-radius: 9px;
+      background: transparent;
+      cursor: pointer;
+      font-weight: 700;
+    }
+
+    .tab.active { background: var(--accent-soft); color: var(--accent); }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1.55fr) minmax(280px, .85fr);
+      gap: 18px;
+      align-items: start;
+    }
+
+    .column { display: grid; gap: 18px; }
+
+    .card {
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: var(--surface);
+      box-shadow: 0 8px 28px rgba(32, 53, 42, .045);
+    }
+
+    .card-header {
+      display: flex;
+      gap: 14px;
+      align-items: flex-start;
+      justify-content: space-between;
+      padding: 18px 20px 15px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .card-header p { margin-bottom: 0; color: var(--muted); font-size: 13px; }
+    .card-body { padding: 18px 20px; }
+
+    .notice {
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+      padding: 15px 17px;
+      border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
+      border-radius: 15px;
+      background: var(--accent-soft);
+      color: color-mix(in srgb, var(--accent) 75%, var(--ink));
+    }
+
+    .notice p { margin: 2px 0 0; color: inherit; font-size: 13px; }
+    .notice-icon { font-size: 18px; }
+
+    .facts {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0 20px;
+      margin: 0;
+    }
+
+    .fact {
+      min-width: 0;
+      padding: 11px 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .fact:nth-last-child(-n+2) { border-bottom: 0; }
+    .fact dt { margin-bottom: 3px; color: var(--muted); font-size: 12px; }
+    .fact dd { overflow-wrap: anywhere; margin: 0; font-weight: 650; }
+
+    .stack {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      counter-reset: frame -1;
+    }
+
+    .frame {
+      display: grid;
+      grid-template-columns: 36px minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: baseline;
+      padding: 9px 0;
+      border-bottom: 1px solid var(--line);
+      counter-increment: frame;
+    }
+
+    .frame:last-child { border-bottom: 0; }
+    .frame-number::before { content: counter(frame); }
+    .frame-number { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .frame-main { min-width: 0; }
+
+    .symbol {
+      display: block;
+      overflow: hidden;
+      color: var(--code);
+      font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .binary { display: block; color: var(--muted); font-size: 12px; }
+    .address { color: var(--muted); font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+    .breadcrumbs { margin: 0; padding: 0; list-style: none; }
+
+    .breadcrumb {
+      position: relative;
+      display: grid;
+      grid-template-columns: 76px minmax(0, 1fr);
+      gap: 14px;
+      padding: 0 0 18px 18px;
+      border-left: 1px solid var(--line);
+    }
+
+    .breadcrumb:last-child { padding-bottom: 0; border-color: transparent; }
+    .breadcrumb::before {
+      position: absolute;
+      top: 5px;
+      left: -5px;
+      width: 9px;
+      height: 9px;
+      border: 2px solid var(--surface);
+      border-radius: 50%;
+      background: var(--accent);
+      content: "";
+    }
+
+    .breadcrumb-time { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .breadcrumb-event { font-weight: 700; }
+    .breadcrumb-meta { color: var(--muted); font-size: 12px; }
+
+    details.thread {
+      border-bottom: 1px solid var(--line);
+    }
+
+    details.thread:last-child { border-bottom: 0; }
+    details.thread summary {
+      display: flex;
+      justify-content: space-between;
+      padding: 14px 20px;
+      cursor: pointer;
+      font-weight: 700;
+      list-style: none;
+    }
+
+    details.thread summary::-webkit-details-marker { display: none; }
+    details.thread summary::after { color: var(--muted); content: "＋"; }
+    details.thread[open] summary::after { content: "−"; }
+    details.thread .stack { padding: 0 20px 12px; }
+
+    .tag-list { display: flex; flex-wrap: wrap; gap: 6px; }
+    .tag { padding: 4px 8px; border-radius: 7px; background: var(--surface-soft); font-size: 12px; }
+
+    .binary-search {
+      width: min(220px, 100%);
+      height: 36px;
+      padding: 6px 10px;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      background: var(--surface-soft);
+      color: var(--ink);
+    }
+
+    .table-wrap { overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th, td { padding: 10px 13px; border-bottom: 1px solid var(--line); text-align: left; }
+    tr:last-child td { border-bottom: 0; }
+    th { color: var(--muted); font-size: 11px; letter-spacing: .04em; text-transform: uppercase; }
+    td.mono { font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+    .raw-toolbar {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-bottom: 12px;
+    }
+
+    pre {
+      overflow: auto;
+      max-height: 72vh;
+      margin: 0;
+      padding: 20px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--surface);
+      color: var(--code);
+      font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace;
+      tab-size: 2;
+      white-space: pre;
+    }
+
+    .empty-value { color: var(--muted); font-style: italic; }
+
+    .footer {
+      margin-top: 24px;
+      color: var(--muted);
+      font-size: 12px;
+      text-align: center;
+    }
+
+    @media (max-width: 820px) {
+      .layout { grid-template-columns: 1fr; }
+      .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .report-heading { display: block; }
+      .report-heading .button { margin-top: 16px; }
+    }
+
+    @media (max-width: 520px) {
+      .shell { width: min(100% - 20px, 1180px); padding-top: 26px; }
+      .topbar { min-height: 60px; padding: 10px; }
+      .brand span:last-child { display: none; }
+      .facts { grid-template-columns: 1fr; }
+      .fact:nth-last-child(2) { border-bottom: 1px solid var(--line); }
+      .frame { grid-template-columns: 28px minmax(0, 1fr); }
+      .address { display: none; }
+      .breadcrumb { grid-template-columns: 62px minmax(0, 1fr); }
+      .card-header { display: block; }
+      .binary-search { width: 100%; margin-top: 10px; }
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <span class="brand-mark" aria-hidden="true">O</span>
+      <span>OsmAnd crash reviewer</span>
+    </div>
+    <div class="header-actions">
+      <button id="openButton" class="button hidden" type="button">Open another</button>
+      <input id="fileInput" class="hidden" type="file" accept=".json,application/json">
+    </div>
+  </header>
+
+  <main class="shell">
+    <section id="emptyState" class="empty">
+      <p class="eyebrow">Local diagnostics tool</p>
+      <h1>Review a crash without reading raw JSON</h1>
+      <p class="lead">Open an exported OsmAnd crash report to see the failure, app state, breadcrumbs, threads, and binary images in a readable layout.</p>
+      <div id="dropZone" class="drop-zone" role="button" tabindex="0" aria-label="Open a crash report JSON file">
+        <div>
+          <span class="drop-icon" aria-hidden="true">↥</span>
+          <p class="drop-title">Drop a crash report here</p>
+          <p class="drop-note">or click to choose a .json file · maximum 2 MiB</p>
+        </div>
+      </div>
+      <p class="privacy-note">
+        <span aria-hidden="true">🔒</span>
+        <span><strong>Your report stays on this device.</strong> The browser reads the selected file locally. This page makes no network requests, stores nothing, and does not modify the report.</span>
+      </p>
+      <p id="errorMessage" class="error hidden" role="alert"></p>
+    </section>
+
+    <section id="reportView" class="hidden">
+      <div class="report-heading">
+        <div>
+          <div class="pills">
+            <span id="sourcePill" class="pill"></span>
+            <span id="kindPill" class="pill bad"></span>
+            <span id="consentPill" class="pill"></span>
+          </div>
+          <h1 id="reportTitle">Crash report</h1>
+          <p id="reportSubtitle"></p>
+        </div>
+        <button id="headingOpenButton" class="button" type="button">Open another report</button>
+      </div>
+
+      <div class="metrics">
+        <div class="metric"><span id="metricApp" class="value">—</span><span class="label">App version</span></div>
+        <div class="metric"><span id="metricDevice" class="value">—</span><span class="label">Device and iOS</span></div>
+        <div class="metric"><span id="metricThreads" class="value">—</span><span class="label">Threads captured</span></div>
+        <div class="metric"><span id="metricBreadcrumbs" class="value">—</span><span class="label">Breadcrumbs</span></div>
+      </div>
+
+      <div class="tabs" role="tablist" aria-label="Report view">
+        <button id="readableTab" class="tab active" type="button" role="tab" aria-selected="true">Readable review</button>
+        <button id="jsonTab" class="tab" type="button" role="tab" aria-selected="false">Exact JSON</button>
+      </div>
+
+      <div id="readablePanel" role="tabpanel">
+        <div class="layout">
+          <div class="column">
+            <div class="notice">
+              <span class="notice-icon" aria-hidden="true">✓</span>
+              <div>
+                <strong>Privacy-filtered report</strong>
+                <p>This viewer shows the transmitted payload. It does not look up symbols, attach logs, or add any data.</p>
+              </div>
+            </div>
+
+            <article class="card">
+              <header class="card-header">
+                <div><h2>Failure</h2><p>What the operating system or crash recorder observed.</p></div>
+              </header>
+              <div class="card-body"><dl id="diagnosticFacts" class="facts"></dl></div>
+            </article>
+
+            <article class="card">
+              <header class="card-header">
+                <div><h2>Crashed thread</h2><p id="crashedThreadDescription"></p></div>
+              </header>
+              <div class="card-body"><ol id="crashedStack" class="stack"></ol></div>
+            </article>
+
+            <article class="card">
+              <header class="card-header">
+                <div><h2>Breadcrumbs</h2><p>Sanitized app events leading up to the diagnostic.</p></div>
+              </header>
+              <div class="card-body"><ol id="breadcrumbList" class="breadcrumbs"></ol></div>
+            </article>
+
+            <article id="otherThreadsCard" class="card">
+              <header class="card-header">
+                <div><h2>Other threads</h2><p>Supporting stacks preserved in the report.</p></div>
+              </header>
+              <div id="otherThreads"></div>
+            </article>
+
+            <article class="card">
+              <header class="card-header">
+                <div><h2>Binary images</h2><p>UUID and load address identify the exact binaries needed for symbolication.</p></div>
+                <input id="binarySearch" class="binary-search" type="search" placeholder="Filter binaries" aria-label="Filter binary images">
+              </header>
+              <div class="table-wrap">
+                <table>
+                  <thead><tr><th>Name</th><th>UUID</th><th>Load address</th></tr></thead>
+                  <tbody id="binaryRows"></tbody>
+                </table>
+              </div>
+            </article>
+          </div>
+
+          <aside class="column">
+            <article class="card">
+              <header class="card-header"><div><h2>App state</h2><p>Coarsened context at the time.</p></div></header>
+              <div class="card-body"><dl id="contextFacts" class="facts"></dl></div>
+            </article>
+
+            <article class="card">
+              <header class="card-header"><div><h2>Plugins</h2><p>Built-in IDs and custom count only.</p></div></header>
+              <div class="card-body">
+                <div id="pluginTags" class="tag-list"></div>
+                <p id="customPluginCount" class="drop-note" style="margin-top: 12px"></p>
+              </div>
+            </article>
+
+            <article class="card">
+              <header class="card-header"><div><h2>Report identity</h2><p>Random per-report identifiers.</p></div></header>
+              <div class="card-body"><dl id="identityFacts" class="facts"></dl></div>
+            </article>
+
+            <article class="card">
+              <header class="card-header"><div><h2>Consent</h2><p id="consentDescription"></p></div></header>
+              <div class="card-body"><dl id="consentFacts" class="facts"></dl></div>
+            </article>
+          </aside>
+        </div>
+      </div>
+
+      <div id="jsonPanel" class="hidden" role="tabpanel">
+        <div class="raw-toolbar">
+          <button id="copyButton" class="button" type="button">Copy JSON</button>
+          <button id="downloadButton" class="button primary" type="button">Download a copy</button>
+        </div>
+        <pre id="rawJson" tabindex="0"></pre>
+      </div>
+      <p id="fileFooter" class="footer"></p>
+    </section>
+  </main>
+
+  <script>
+    "use strict";
+
+    const MAX_FILE_BYTES = 2 * 1024 * 1024;
+    const elements = Object.fromEntries(
+      Array.from(document.querySelectorAll("[id]")).map(element => [element.id, element])
+    );
+    let exactJson = "";
+    let currentFileName = "OsmAnd-Crash-Report.json";
+
+    const kindTitles = {
+      mach_exception: "Mach exception",
+      signal: "POSIX signal",
+      cpp_exception: "C++ exception",
+      objective_c_exception: "Objective-C exception",
+      memory_termination: "Memory termination",
+      crash: "Crash",
+      hang: "App hang",
+      cpu_exception: "CPU exception",
+      disk_write_exception: "Disk-write exception",
+      non_fatal: "Non-fatal error",
+      unknown: "Unknown diagnostic"
+    };
+
+    const labels = {
+      exception_name: "Exception name",
+      exception_type: "Exception type",
+      exception_code: "Exception code",
+      signal: "Signal number",
+      signal_name: "Signal name",
+      termination_reason: "Termination reason",
+      component: "Component",
+      error_code: "Error code",
+      severity: "Severity",
+      hang_duration_ms: "Hang duration",
+      cpu_time_ms: "CPU time",
+      sampled_time_ms: "Sampled time",
+      disk_writes_bytes: "Disk writes"
+    };
+
+    function humanize(value) {
+      return String(value ?? "").replaceAll("_", " ").replace(/\b\w/g, letter => letter.toUpperCase());
+    }
+
+    function displayValue(value) {
+      if (value === true) return "Yes";
+      if (value === false) return "No";
+      if (value === null || value === undefined || value === "") return "Not recorded";
+      return String(value);
+    }
+
+    function address(value) {
+      if (!Number.isSafeInteger(value)) return "—";
+      return "0x" + value.toString(16).toUpperCase();
+    }
+
+    function duration(value) {
+      if (!Number.isFinite(value)) return displayValue(value);
+      if (value < 1000) return value + " ms";
+      return (value / 1000).toLocaleString(undefined, { maximumFractionDigits: 2 }) + " s";
+    }
+
+    function bytes(value) {
+      if (!Number.isFinite(value)) return displayValue(value);
+      const units = ["B", "KiB", "MiB", "GiB"];
+      let size = value;
+      let unit = 0;
+      while (size >= 1024 && unit < units.length - 1) {
+        size /= 1024;
+        unit += 1;
+      }
+      return size.toLocaleString(undefined, { maximumFractionDigits: unit ? 1 : 0 }) + " " + units[unit];
+    }
+
+    function dateTime(value) {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return displayValue(value);
+      return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "medium" });
+    }
+
+    function addText(parent, tag, text, className) {
+      const child = document.createElement(tag);
+      if (className) child.className = className;
+      child.textContent = text;
+      parent.appendChild(child);
+      return child;
+    }
+
+    function renderFacts(container, facts) {
+      container.replaceChildren();
+      facts.forEach(([label, value]) => {
+        const wrapper = document.createElement("div");
+        wrapper.className = "fact";
+        addText(wrapper, "dt", label);
+        const item = addText(wrapper, "dd", displayValue(value));
+        if (value === null || value === undefined || value === "") item.className = "empty-value";
+        container.appendChild(wrapper);
+      });
+    }
+
+    function renderStack(container, frames) {
+      container.replaceChildren();
+      if (!frames.length) {
+        addText(container, "li", "No frames were recorded.", "empty-value");
+        return;
+      }
+      frames.forEach(frame => {
+        const item = document.createElement("li");
+        item.className = "frame";
+        addText(item, "span", "", "frame-number");
+        const main = document.createElement("span");
+        main.className = "frame-main";
+        addText(main, "span", frame.symbol_name || "Unsymbolicated frame", "symbol");
+        const offset = Number.isSafeInteger(frame.binary_offset) ? " + " + address(frame.binary_offset) : "";
+        addText(main, "span", (frame.binary_name || "Unknown binary") + offset, "binary");
+        item.appendChild(main);
+        addText(item, "span", address(frame.instruction_address), "address");
+        container.appendChild(item);
+      });
+    }
+
+    function renderDiagnostic(diagnostic) {
+      const facts = [];
+      Object.entries(labels).forEach(([key, label]) => {
+        if (!(key in diagnostic)) return;
+        let value = diagnostic[key];
+        if (key.endsWith("_ms")) value = duration(value);
+        if (key === "disk_writes_bytes") value = bytes(value);
+        if (key === "termination_reason" || key === "component" || key === "severity") value = humanize(value);
+        facts.push([label, value]);
+      });
+      facts.push(["Crashed thread", diagnostic.crashed_thread ?? findCrashedThread(diagnostic.threads)?.index]);
+      renderFacts(elements.diagnosticFacts, facts);
+    }
+
+    function findCrashedThread(threads) {
+      return threads.find(thread => thread.crashed) ||
+        threads.find(thread => thread.index === Number(threads.crashed_thread)) ||
+        threads[0];
+    }
+
+    function renderThreads(diagnostic) {
+      const threads = Array.isArray(diagnostic.threads) ? diagnostic.threads : [];
+      const crashed = findCrashedThread(threads);
+      elements.crashedThreadDescription.textContent = crashed
+        ? "Thread " + crashed.index + " · " + crashed.frames.length + " frame" + (crashed.frames.length === 1 ? "" : "s")
+        : "No crashed thread was identified.";
+      renderStack(elements.crashedStack, crashed?.frames || []);
+
+      const others = threads.filter(thread => thread !== crashed);
+      elements.otherThreadsCard.classList.toggle("hidden", others.length === 0);
+      elements.otherThreads.replaceChildren();
+      others.forEach(thread => {
+        const details = document.createElement("details");
+        details.className = "thread";
+        const summary = document.createElement("summary");
+        addText(summary, "span", "Thread " + thread.index);
+        addText(summary, "span", thread.frames.length + " frames", "drop-note");
+        details.appendChild(summary);
+        const stack = document.createElement("ol");
+        stack.className = "stack";
+        renderStack(stack, thread.frames);
+        details.appendChild(stack);
+        elements.otherThreads.appendChild(details);
+      });
+    }
+
+    function renderBreadcrumbs(breadcrumbs) {
+      elements.breadcrumbList.replaceChildren();
+      if (!breadcrumbs.length) {
+        addText(elements.breadcrumbList, "li", "No breadcrumbs were recorded.", "empty-value");
+        return;
+      }
+      breadcrumbs.forEach(item => {
+        const row = document.createElement("li");
+        row.className = "breadcrumb";
+        addText(row, "span", "−" + duration(item.elapsed_ms), "breadcrumb-time");
+        const content = document.createElement("div");
+        addText(content, "div", humanize(item.event), "breadcrumb-event");
+        const details = [];
+        if (item.screen_identifier) details.push("Screen: " + item.screen_identifier);
+        if (item.numeric_metadata) {
+          Object.entries(item.numeric_metadata).forEach(([key, value]) => details.push(humanize(key) + ": " + value));
+        }
+        if (details.length) addText(content, "div", details.join(" · "), "breadcrumb-meta");
+        row.appendChild(content);
+        elements.breadcrumbList.appendChild(row);
+      });
+    }
+
+    function renderContext(context) {
+      renderFacts(elements.contextFacts, [
+        ["Application state", humanize(context.application_state)],
+        ["Screen", context.screen_identifier],
+        ["Navigation active", context.navigation_active],
+        ["Route calculation", humanize(context.route_calculation_state)],
+        ["Profile family", humanize(context.profile_family)],
+        ["Zoom bucket", context.zoom_bucket],
+        ["Map source", humanize(context.map_source_category)],
+        ["Loaded maps", context.loaded_map_count],
+        ["Memory available", context.memory_available_bucket_mb === undefined ? null : context.memory_available_bucket_mb + " MiB bucket"],
+        ["Disk available", context.disk_available_bucket_mb === undefined ? null : context.disk_available_bucket_mb + " MiB bucket"]
+      ]);
+      elements.pluginTags.replaceChildren();
+      const plugins = Array.isArray(context.built_in_plugin_ids) ? context.built_in_plugin_ids : [];
+      if (!plugins.length) addText(elements.pluginTags, "span", "No built-in plugins recorded", "empty-value");
+      plugins.forEach(plugin => addText(elements.pluginTags, "span", plugin, "tag"));
+      elements.customPluginCount.textContent = context.custom_plugin_count + " custom plugin" +
+        (context.custom_plugin_count === 1 ? "" : "s") + " active; names are excluded.";
+    }
+
+    function renderImages(images) {
+      elements.binaryRows.replaceChildren();
+      if (!images.length) {
+        const row = document.createElement("tr");
+        const cell = addText(row, "td", "No binary images were recorded.", "empty-value");
+        cell.colSpan = 3;
+        elements.binaryRows.appendChild(row);
+        return;
+      }
+      images.forEach(image => {
+        const row = document.createElement("tr");
+        row.dataset.search = ((image.name || "") + " " + (image.uuid || "")).toLowerCase();
+        addText(row, "td", image.name || "—");
+        addText(row, "td", image.uuid || "—", "mono");
+        addText(row, "td", address(image.image_address), "mono");
+        elements.binaryRows.appendChild(row);
+      });
+    }
+
+    function renderConsent(consent) {
+      const approved = consent && consent.approved_at;
+      elements.consentPill.textContent = approved ? "Approved payload" : "Not yet approved";
+      elements.consentPill.className = "pill " + (approved ? "good" : "");
+      elements.consentDescription.textContent = approved
+        ? "This receiver file includes the approval attached to the exact payload."
+        : "The exported app envelope has not been wrapped in an upload consent record.";
+      renderFacts(elements.consentFacts, [
+        ["Mode", consent?.mode ? humanize(consent.mode) : null],
+        ["Approved", approved ? dateTime(consent.approved_at) : null],
+        ["Reviewed SHA-256", consent?.reviewed_payload_sha256 || null]
+      ]);
+    }
+
+    function renderReport(parsed, fileName, fileSize) {
+      const wrapped = parsed && typeof parsed === "object" && !Array.isArray(parsed) && parsed.report;
+      const report = wrapped ? parsed.report : parsed;
+      if (!report || typeof report !== "object" || Array.isArray(report)) {
+        throw new Error("The selected file does not contain a crash report object.");
+      }
+      if (report.schema_version !== 1 || typeof report.report_id !== "string" ||
+          !report.diagnostic || !report.context || !Array.isArray(report.breadcrumbs)) {
+        throw new Error("This is not a supported OsmAnd crash report (schema version 1).");
+      }
+
+      const diagnostic = report.diagnostic;
+      const threads = Array.isArray(diagnostic.threads) ? diagnostic.threads : [];
+      const images = Array.isArray(diagnostic.binary_images) ? diagnostic.binary_images : [];
+      const title = kindTitles[diagnostic.kind] || humanize(diagnostic.kind);
+      const detail = diagnostic.signal_name || diagnostic.exception_name ||
+        diagnostic.termination_reason || diagnostic.component;
+
+      currentFileName = fileName || "OsmAnd-Crash-Report-" + report.report_id + ".json";
+      exactJson = JSON.stringify(parsed, null, 2);
+      elements.rawJson.textContent = exactJson;
+      elements.reportTitle.textContent = title;
+      elements.reportSubtitle.textContent = (detail ? humanize(detail) + " · " : "") + dateTime(report.occurred_at);
+      elements.sourcePill.textContent = humanize(report.source);
+      elements.kindPill.textContent = humanize(diagnostic.kind);
+      elements.metricApp.textContent = report.app?.version + " (" + report.app?.build + ")";
+      elements.metricDevice.textContent = report.device?.model + " · iOS " + report.device?.os_version;
+      elements.metricThreads.textContent = threads.length.toLocaleString();
+      elements.metricBreadcrumbs.textContent = report.breadcrumbs.length.toLocaleString();
+      elements.fileFooter.textContent = currentFileName + " · " + bytes(fileSize) + " · schema v" + report.schema_version;
+
+      renderDiagnostic(diagnostic);
+      renderThreads(diagnostic);
+      renderBreadcrumbs(report.breadcrumbs);
+      renderContext(report.context);
+      renderImages(images);
+      renderConsent(wrapped ? parsed.consent : null);
+      renderFacts(elements.identityFacts, [
+        ["Report ID", report.report_id],
+        ["Occurred", dateTime(report.occurred_at)],
+        ["Source", humanize(report.source)],
+        ["Schema", report.schema_version]
+      ]);
+
+      elements.emptyState.classList.add("hidden");
+      elements.reportView.classList.remove("hidden");
+      elements.openButton.classList.remove("hidden");
+      showTab("readable");
+      window.scrollTo({ top: 0, behavior: "instant" });
+      document.title = title + " · OsmAnd crash reviewer";
+    }
+
+    async function openFile(file) {
+      elements.errorMessage.classList.add("hidden");
+      if (!file) return;
+      if (file.size > MAX_FILE_BYTES) {
+        showError("That file is larger than the 2 MiB review limit.");
+        return;
+      }
+      try {
+        const text = await file.text();
+        const parsed = JSON.parse(text);
+        renderReport(parsed, file.name, file.size);
+      } catch (error) {
+        showError(error instanceof SyntaxError ? "The selected file is not valid JSON." : error.message);
+      } finally {
+        elements.fileInput.value = "";
+      }
+    }
+
+    function showError(message) {
+      elements.errorMessage.textContent = message;
+      elements.errorMessage.classList.remove("hidden");
+      elements.emptyState.classList.remove("hidden");
+    }
+
+    function showTab(name) {
+      const readable = name === "readable";
+      elements.readablePanel.classList.toggle("hidden", !readable);
+      elements.jsonPanel.classList.toggle("hidden", readable);
+      elements.readableTab.classList.toggle("active", readable);
+      elements.jsonTab.classList.toggle("active", !readable);
+      elements.readableTab.setAttribute("aria-selected", String(readable));
+      elements.jsonTab.setAttribute("aria-selected", String(!readable));
+    }
+
+    function chooseFile() {
+      elements.fileInput.click();
+    }
+
+    elements.dropZone.addEventListener("click", chooseFile);
+    elements.dropZone.addEventListener("keydown", event => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        chooseFile();
+      }
+    });
+    elements.fileInput.addEventListener("change", event => openFile(event.target.files[0]));
+    elements.openButton.addEventListener("click", chooseFile);
+    elements.headingOpenButton.addEventListener("click", chooseFile);
+    elements.readableTab.addEventListener("click", () => showTab("readable"));
+    elements.jsonTab.addEventListener("click", () => showTab("json"));
+
+    ["dragenter", "dragover"].forEach(type => {
+      elements.dropZone.addEventListener(type, event => {
+        event.preventDefault();
+        elements.dropZone.classList.add("dragging");
+      });
+    });
+    ["dragleave", "drop"].forEach(type => {
+      elements.dropZone.addEventListener(type, event => {
+        event.preventDefault();
+        elements.dropZone.classList.remove("dragging");
+      });
+    });
+    elements.dropZone.addEventListener("drop", event => openFile(event.dataTransfer.files[0]));
+
+    elements.binarySearch.addEventListener("input", event => {
+      const query = event.target.value.trim().toLowerCase();
+      elements.binaryRows.querySelectorAll("tr[data-search]").forEach(row => {
+        row.classList.toggle("hidden", query && !row.dataset.search.includes(query));
+      });
+    });
+
+    elements.copyButton.addEventListener("click", async () => {
+      const original = elements.copyButton.textContent;
+      try {
+        await navigator.clipboard.writeText(exactJson);
+      } catch (_) {
+        const area = document.createElement("textarea");
+        area.value = exactJson;
+        area.style.position = "fixed";
+        area.style.opacity = "0";
+        document.body.appendChild(area);
+        area.select();
+        document.execCommand("copy");
+        area.remove();
+      }
+      elements.copyButton.textContent = "Copied";
+      setTimeout(() => { elements.copyButton.textContent = original; }, 1400);
+    });
+
+    elements.downloadButton.addEventListener("click", () => {
+      const blob = new Blob([exactJson + "\n"], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = currentFileName;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    });
+  </script>
+</body>
+</html>

--- a/Scripts/CrashReportReceiver/test_receiver.py
+++ b/Scripts/CrashReportReceiver/test_receiver.py
@@ -1,0 +1,197 @@
+import copy
+import gzip
+import hashlib
+import http.client
+import json
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+from receiver import (
+    MAX_REQUEST_BYTES,
+    CrashReportRequestHandler,
+    ValidationError,
+    validate_upload_request,
+)
+
+
+def valid_request():
+    request = {
+        "report": {
+            "schema_version": 1,
+            "report_id": "12345678-1234-4234-8234-123456789abc",
+            "source": "kscrash",
+            "occurred_at": "2026-07-24T12:00:00Z",
+            "app": {"version": "5.2.0", "build": "5200"},
+            "device": {"model": "iPhone16.2", "os_version": "18.5"},
+            "diagnostic": {
+                "kind": "signal",
+                "signal": 6,
+                "threads": [
+                    {
+                        "index": 0,
+                        "crashed": True,
+                        "frames": [
+                            {
+                                "instruction_address": 4096,
+                                "binary_name": "OsmAnd",
+                                "binary_uuid": "00112233445566778899AABBCCDDEEFF",
+                            }
+                        ],
+                    }
+                ],
+                "binary_images": [
+                    {
+                        "name": "OsmAnd",
+                        "uuid": "00112233445566778899AABBCCDDEEFF",
+                        "image_address": 4096,
+                    }
+                ],
+            },
+            "context": {
+                "navigation_active": False,
+                "route_calculation_state": "idle",
+                "profile_family": "car",
+                "map_source_category": "offline_vector",
+                "loaded_map_count": 2,
+                "built_in_plugin_ids": ["osmand.nautical"],
+                "custom_plugin_count": 0,
+                "application_state": "active",
+            },
+            "breadcrumbs": [{"elapsed_ms": 1200, "event": "app_became_active"}],
+        },
+        "consent": {
+            "mode": "per_report",
+            "approved_at": "2026-07-24T12:01:00Z",
+            "reviewed_payload_sha256": "pending",
+        },
+    }
+    canonical_report = json.dumps(
+        request["report"],
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    request["consent"]["reviewed_payload_sha256"] = hashlib.sha256(canonical_report).hexdigest()
+    return request
+
+
+class ReceiverValidationTests(unittest.TestCase):
+    def test_accepts_valid_envelope(self):
+        report_id, _ = validate_upload_request(valid_request())
+        self.assertEqual(report_id, "12345678-1234-4234-8234-123456789abc")
+
+    def test_rejects_unknown_field(self):
+        request = valid_request()
+        request["report"]["coordinates"] = [51.5, -0.1]
+        with self.assertRaises(ValidationError):
+            validate_upload_request(request)
+
+    def test_rejects_sensitive_keys_at_any_depth(self):
+        for key in ("search_query", "file_path", "notification_contents", "custom_plugin_name"):
+            request = valid_request()
+            request["report"]["diagnostic"][key] = "private"
+            with self.subTest(key=key), self.assertRaises(ValidationError):
+                validate_upload_request(request)
+
+    def test_rejects_paths_and_urls_in_allowed_string_fields(self):
+        for value in ("https://tiles.example/private", "/private/var/mobile/secret"):
+            request = copy.deepcopy(valid_request())
+            request["report"]["diagnostic"]["exception_name"] = value
+            with self.subTest(value=value), self.assertRaises(ValidationError):
+                validate_upload_request(request)
+
+    def test_rejects_unapproved_numeric_metadata(self):
+        request = valid_request()
+        request["report"]["diagnostic"]["numeric_metadata"] = {"latitude": 51500000}
+        with self.assertRaises(ValidationError):
+            validate_upload_request(request)
+
+    def test_rejects_payload_changed_after_consent(self):
+        request = valid_request()
+        request["report"]["context"]["loaded_map_count"] = 3
+        with self.assertRaisesRegex(ValidationError, "consent hash"):
+            validate_upload_request(request)
+
+
+class ReceiverHTTPTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), CrashReportRequestHandler)
+        self.server.output_directory = Path(self.temporary_directory.name)
+        self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.server_thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.server_thread.join(timeout=2)
+        self.temporary_directory.cleanup()
+
+    def request(self, method, path, body=None, headers=None):
+        connection = http.client.HTTPConnection("127.0.0.1", self.server.server_port, timeout=5)
+        connection.request(method, path, body=body, headers=headers or {})
+        response = connection.getresponse()
+        payload = json.loads(response.read())
+        connection.close()
+        return response.status, payload
+
+    def test_health(self):
+        status, payload = self.request("GET", "/health")
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"status": "ok"})
+
+    def test_review_page_is_local_only(self):
+        connection = http.client.HTTPConnection(
+            "127.0.0.1", self.server.server_port, timeout=5
+        )
+        connection.request("GET", "/review")
+        response = connection.getresponse()
+        body = response.read()
+        content_security_policy = response.getheader("Content-Security-Policy")
+        connection.close()
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.getheader("Content-Type"), "text/html; charset=utf-8")
+        self.assertIn(b"OsmAnd crash report reviewer", body)
+        self.assertIsNotNone(content_security_policy)
+        self.assertIn("connect-src 'none'", content_security_policy)
+
+    def test_gzip_and_idempotency(self):
+        report_id = valid_request()["report"]["report_id"]
+        body = gzip.compress(json.dumps(valid_request()).encode("utf-8"))
+        headers = {
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+            "Idempotency-Key": report_id,
+        }
+
+        first_status, first_payload = self.request(
+            "POST", "/api/v1/crash-reports", body, headers
+        )
+        second_status, second_payload = self.request(
+            "POST", "/api/v1/crash-reports", body, headers
+        )
+
+        self.assertEqual(first_status, 201)
+        self.assertTrue(first_payload["created"])
+        self.assertEqual(second_status, 200)
+        self.assertFalse(second_payload["created"])
+        self.assertEqual(len(list(Path(self.temporary_directory.name).glob("*.json"))), 1)
+
+    def test_rejects_request_over_two_mib(self):
+        body = b" " * (MAX_REQUEST_BYTES + 1)
+        status, payload = self.request(
+            "POST",
+            "/api/v1/crash-reports",
+            body,
+            {"Content-Type": "application/json"},
+        )
+        self.assertEqual(status, 413)
+        self.assertEqual(payload["error"], "request_too_large")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Sources/AppHost/OAAppDelegate.mm
+++ b/Sources/AppHost/OAAppDelegate.mm
@@ -39,6 +39,7 @@
 #import "OARootViewController.h"
 #import <AFNetworking/AFNetworkReachabilityManager.h>
 #import "StartupLogging.h"
+#import "OsmAnd_Maps-Swift.h"
 
 #include <QDir>
 #include <QFile>
@@ -210,6 +211,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 
             _appInitDone = YES;
             _appInitializing = NO;
+            [[CrashDiagnosticsService shared] applicationStartupDidComplete];
 
             [[UIApplication sharedApplication] endBackgroundTask:_appInitTask];
             _appInitTask = UIBackgroundTaskInvalid;
@@ -292,6 +294,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 }
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [[CrashDiagnosticsService shared] startWithLaunchOptions:launchOptions];
     LogStartupContext(launchOptions);
     LogStartup(@"willFinishLaunchingWithOptions");
     return YES;
@@ -365,6 +368,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 - (void)applicationWillResignActive
 {
     NSLog(@"OAAppDelegate applicationWillResignActive %d", _appInitDone);
+    [[CrashDiagnosticsService shared] applicationStateDidChange:@"inactive"];
     if (_appInitDone)
         [_app onApplicationWillResignActive];
 }
@@ -372,6 +376,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 - (void)applicationDidEnterBackground
 {
     NSLog(@"OAAppDelegate applicationDidEnterBackground %d", _appInitDone);
+    [[CrashDiagnosticsService shared] applicationStateDidChange:@"background"];
     [self invalidateIfNeededCheckUpdatesTimer];
     if (_appInitDone)
         [_app onApplicationDidEnterBackground];
@@ -403,6 +408,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
 - (void)applicationDidBecomeActive
 {
     NSLog(@"OAAppDelegate applicationDidBecomeActive %d", _appInitDone);
+    [[CrashDiagnosticsService shared] applicationStateDidChange:@"active"];
     if (_appInitDone)
     {
         [self initCheckUpdatesTimer];

--- a/Sources/Controllers/Help/OAHelpViewController.mm
+++ b/Sources/Controllers/Help/OAHelpViewController.mm
@@ -56,6 +56,16 @@ static NSString * const kLinkExternalType = @"ext_link";
     }
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    if (_data)
+    {
+        [self generateData];
+        [self.tableView reloadData];
+    }
+}
+
 #pragma mark - Base UI
 
 - (NSString *)getTitle
@@ -215,6 +225,17 @@ static NSString * const kLinkExternalType = @"ext_link";
     [openIssueOnGitHubRow setIconName:@"ic_custom_logo_github"];
     [openIssueOnGitHubRow setObj:kLinkExternalType forKey:@"linkType"];
     [openIssueOnGitHubRow setObj:kOpenIssueOnGitHub forKey:@"url"];
+
+    OATableRowData *crashDiagnosticsRow = [reportAnIssuesSection createNewRow];
+    [crashDiagnosticsRow setCellType:[OASimpleTableViewCell getCellIdentifier]];
+    [crashDiagnosticsRow setKey:@"crashDiagnostics"];
+    [crashDiagnosticsRow setTitle:OALocalizedString(@"crash_diagnostics")];
+    NSInteger pendingReportCount = [CrashDiagnosticsService shared].pendingReportCount;
+    NSString *crashDiagnosticsDescription = pendingReportCount > 0
+        ? [NSString stringWithFormat:OALocalizedString(@"crash_diagnostics_pending_count"), pendingReportCount]
+        : OALocalizedString(@"crash_diagnostics_description");
+    [crashDiagnosticsRow setDescr:crashDiagnosticsDescription];
+    [crashDiagnosticsRow setIconName:@"ic_custom_file_crashlog_send_outlined"];
     
     OATableRowData *sendLogRow = [reportAnIssuesSection createNewRow];
     [sendLogRow setCellType:[OASimpleTableViewCell getCellIdentifier]];
@@ -385,6 +406,11 @@ static NSString * const kLinkExternalType = @"ext_link";
     else if ([key isEqualToString:@"sendLog"])
     {
         [self sendLogFile];
+    }
+    else if ([key isEqualToString:@"crashDiagnostics"])
+    {
+        CrashDiagnosticsViewController *viewController = [[CrashDiagnosticsViewController alloc] initWithReportIDToOpen:nil];
+        [self.navigationController pushViewController:viewController animated:YES];
     }
 }
 

--- a/Sources/OsmAnd Maps-Bridging-Header.h
+++ b/Sources/OsmAnd Maps-Bridging-Header.h
@@ -120,6 +120,7 @@
 #import "OAFavoriteFolderBridgeItem.h"
 #import "OAFavoritePointBridgeItem.h"
 #import "OATrackPreviewMapRenderer.h"
+#import "OACrashDiagnosticsKSCrashBridge.h"
 
 // Widgets
 #import "OAMapWidgetRegistry.h"

--- a/Sources/Services/CrashDiagnostics/CrashDiagnosticsBannerPresenter.swift
+++ b/Sources/Services/CrashDiagnostics/CrashDiagnosticsBannerPresenter.swift
@@ -1,0 +1,118 @@
+//
+//  CrashDiagnosticsBannerPresenter.swift
+//  OsmAnd Maps
+//
+
+import UIKit
+
+final class CrashDiagnosticsBannerPresenter {
+    static let shared = CrashDiagnosticsBannerPresenter()
+
+    private weak var banner: UIView?
+    private var reportID: String?
+
+    private init() {}
+
+    func present(reportID: String) {
+        guard banner == nil, let window = keyWindow() else { return }
+        self.reportID = reportID
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = .secondarySystemBackground
+        container.layer.cornerRadius = 12
+        container.layer.shadowColor = UIColor.black.cgColor
+        container.layer.shadowOpacity = 0.18
+        container.layer.shadowRadius = 8
+        container.layer.shadowOffset = CGSize(width: 0, height: 3)
+        container.accessibilityViewIsModal = false
+
+        let openButton = UIButton(type: .system)
+        openButton.translatesAutoresizingMaskIntoConstraints = false
+        openButton.contentHorizontalAlignment = .leading
+        openButton.titleLabel?.numberOfLines = 2
+        openButton.titleLabel?.font = .preferredFont(forTextStyle: .body)
+        openButton.setTitle(localizedString("crash_diagnostics_banner"), for: .normal)
+        openButton.addTarget(self, action: #selector(openReport), for: .touchUpInside)
+
+        let closeButton = UIButton(type: .system)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
+        closeButton.accessibilityLabel = localizedString("crash_diagnostics_later")
+        closeButton.addTarget(self, action: #selector(dismissBanner), for: .touchUpInside)
+
+        container.addSubview(openButton)
+        container.addSubview(closeButton)
+        window.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: window.safeAreaLayoutGuide.topAnchor, constant: 8),
+            container.leadingAnchor.constraint(equalTo: window.leadingAnchor, constant: 16),
+            container.trailingAnchor.constraint(equalTo: window.trailingAnchor, constant: -16),
+            openButton.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            openButton.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -12),
+            openButton.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            openButton.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -8),
+            closeButton.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+            closeButton.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            closeButton.widthAnchor.constraint(equalToConstant: 44),
+            closeButton.heightAnchor.constraint(equalToConstant: 44),
+        ])
+        banner = container
+
+        container.alpha = 0
+        container.transform = CGAffineTransform(translationX: 0, y: -20)
+        UIView.animate(withDuration: 0.25) {
+            container.alpha = 1
+            container.transform = .identity
+        }
+        UIAccessibility.post(notification: .announcement, argument: localizedString("crash_diagnostics_banner"))
+    }
+
+    @objc private func openReport() {
+        guard let reportID else {
+            dismissBanner()
+            return
+        }
+        dismissBanner()
+        let diagnostics = CrashDiagnosticsViewController(reportIDToOpen: reportID)
+        guard let presenter = topViewController() else { return }
+        if let navigationController = presenter.navigationController {
+            navigationController.pushViewController(diagnostics, animated: true)
+        } else {
+            presenter.present(UINavigationController(rootViewController: diagnostics), animated: true)
+        }
+    }
+
+    @objc private func dismissBanner() {
+        reportID = nil
+        guard let banner else { return }
+        UIView.animate(withDuration: 0.2, animations: {
+            banner.alpha = 0
+            banner.transform = CGAffineTransform(translationX: 0, y: -20)
+        }, completion: { _ in
+            banner.removeFromSuperview()
+        })
+    }
+
+    private func keyWindow() -> UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+    }
+
+    private func topViewController() -> UIViewController? {
+        var current = keyWindow()?.rootViewController
+        while true {
+            if let navigation = current as? UINavigationController {
+                current = navigation.visibleViewController
+            } else if let tab = current as? UITabBarController {
+                current = tab.selectedViewController
+            } else if let presented = current?.presentedViewController {
+                current = presented
+            } else {
+                return current
+            }
+        }
+    }
+}

--- a/Sources/Services/CrashDiagnostics/CrashDiagnosticsModels.swift
+++ b/Sources/Services/CrashDiagnostics/CrashDiagnosticsModels.swift
@@ -1,0 +1,328 @@
+//
+//  CrashDiagnosticsModels.swift
+//  OsmAnd Maps
+//
+//  Privacy-preserving crash diagnostics wire and storage models.
+//
+
+import Foundation
+
+enum CrashReportSource: String, Codable {
+    case kscrash
+    case metricKit = "metrickit"
+    case nonFatal = "non_fatal"
+}
+
+enum CrashDiagnosticKind: String, Codable {
+    case machException = "mach_exception"
+    case signal
+    case cppException = "cpp_exception"
+    case objectiveCException = "objective_c_exception"
+    case memoryTermination = "memory_termination"
+    case crash
+    case hang
+    case cpuException = "cpu_exception"
+    case diskWriteException = "disk_write_exception"
+    case nonFatal = "non_fatal"
+    case unknown
+}
+
+struct CrashAppInfo: Codable, Equatable {
+    let version: String
+    let build: String
+}
+
+struct CrashDeviceInfo: Codable, Equatable {
+    let model: String
+    let osVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case osVersion = "os_version"
+    }
+}
+
+struct CrashStackFrame: Codable, Equatable {
+    let instructionAddress: UInt64?
+    let binaryAddress: UInt64?
+    let binaryOffset: UInt64?
+    let binaryName: String?
+    let binaryUUID: String?
+    let symbolAddress: UInt64?
+    let symbolName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case instructionAddress = "instruction_address"
+        case binaryAddress = "binary_address"
+        case binaryOffset = "binary_offset"
+        case binaryName = "binary_name"
+        case binaryUUID = "binary_uuid"
+        case symbolAddress = "symbol_address"
+        case symbolName = "symbol_name"
+    }
+}
+
+struct CrashThread: Codable, Equatable {
+    let index: Int
+    let crashed: Bool
+    let frames: [CrashStackFrame]
+}
+
+struct CrashBinaryImage: Codable, Equatable {
+    let name: String
+    let uuid: String?
+    let imageAddress: UInt64?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case uuid
+        case imageAddress = "image_address"
+    }
+}
+
+struct CrashDiagnostic: Codable, Equatable {
+    let kind: CrashDiagnosticKind
+    let exceptionName: String?
+    let exceptionType: UInt64?
+    let exceptionCode: UInt64?
+    let signal: Int?
+    let signalName: String?
+    let terminationReason: String?
+    let crashedThread: Int?
+    let hangDurationMilliseconds: Int64?
+    let cpuTimeMilliseconds: Int64?
+    let sampledTimeMilliseconds: Int64?
+    let diskWritesBytes: Int64?
+    let component: String?
+    let errorCode: Int?
+    let severity: String?
+    let numericMetadata: [String: Int64]?
+    let threads: [CrashThread]
+    let binaryImages: [CrashBinaryImage]
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case exceptionName = "exception_name"
+        case exceptionType = "exception_type"
+        case exceptionCode = "exception_code"
+        case signal
+        case signalName = "signal_name"
+        case terminationReason = "termination_reason"
+        case crashedThread = "crashed_thread"
+        case hangDurationMilliseconds = "hang_duration_ms"
+        case cpuTimeMilliseconds = "cpu_time_ms"
+        case sampledTimeMilliseconds = "sampled_time_ms"
+        case diskWritesBytes = "disk_writes_bytes"
+        case component
+        case errorCode = "error_code"
+        case severity
+        case numericMetadata = "numeric_metadata"
+        case threads
+        case binaryImages = "binary_images"
+    }
+}
+
+struct CrashContextSnapshot: Codable, Equatable {
+    var screenIdentifier: String?
+    var navigationActive = false
+    var routeCalculationState = "idle"
+    var profileFamily = "unknown"
+    var zoomBucket: Int?
+    var mapSourceCategory = "unknown"
+    var loadedMapCount = 0
+    var builtInPluginIDs: [String] = []
+    var customPluginCount = 0
+    var applicationState = "unknown"
+    var memoryAvailableBucketMB: Int?
+    var diskAvailableBucketMB: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case screenIdentifier = "screen_identifier"
+        case navigationActive = "navigation_active"
+        case routeCalculationState = "route_calculation_state"
+        case profileFamily = "profile_family"
+        case zoomBucket = "zoom_bucket"
+        case mapSourceCategory = "map_source_category"
+        case loadedMapCount = "loaded_map_count"
+        case builtInPluginIDs = "built_in_plugin_ids"
+        case customPluginCount = "custom_plugin_count"
+        case applicationState = "application_state"
+        case memoryAvailableBucketMB = "memory_available_bucket_mb"
+        case diskAvailableBucketMB = "disk_available_bucket_mb"
+    }
+}
+
+struct CrashBreadcrumb: Codable, Equatable {
+    let elapsedMilliseconds: Int64
+    let event: String
+    let numericMetadata: [String: Int64]?
+    let screenIdentifier: String?
+
+    init(
+        elapsedMilliseconds: Int64,
+        event: String,
+        numericMetadata: [String: Int64]?,
+        screenIdentifier: String? = nil
+    ) {
+        self.elapsedMilliseconds = elapsedMilliseconds
+        self.event = event
+        self.numericMetadata = numericMetadata
+        self.screenIdentifier = screenIdentifier
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case elapsedMilliseconds = "elapsed_ms"
+        case event
+        case numericMetadata = "numeric_metadata"
+        case screenIdentifier = "screen_identifier"
+    }
+}
+
+struct CrashReportEnvelope: Codable, Equatable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let reportID: String
+    let source: CrashReportSource
+    let occurredAt: String
+    let app: CrashAppInfo
+    let device: CrashDeviceInfo
+    let diagnostic: CrashDiagnostic
+    let context: CrashContextSnapshot
+    let breadcrumbs: [CrashBreadcrumb]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case reportID = "report_id"
+        case source
+        case occurredAt = "occurred_at"
+        case app
+        case device
+        case diagnostic
+        case context
+        case breadcrumbs
+    }
+}
+
+struct CrashReportConsent: Codable, Equatable {
+    let mode: String
+    let approvedAt: String
+    let reviewedPayloadSHA256: String
+
+    enum CodingKeys: String, CodingKey {
+        case mode
+        case approvedAt = "approved_at"
+        case reviewedPayloadSHA256 = "reviewed_payload_sha256"
+    }
+}
+
+struct CrashUploadRequest: Codable, Equatable {
+    let report: CrashReportEnvelope
+    let consent: CrashReportConsent
+}
+
+enum CrashUploadState: String, Codable {
+    case pending
+    case approved
+    case rejected
+}
+
+struct StoredCrashReport: Codable, Equatable {
+    var report: CrashReportEnvelope
+    var uploadState: CrashUploadState
+    var consent: CrashReportConsent?
+    var createdAt: Date
+    var uploadAttempts: Int
+    var nextRetryAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case report
+        case uploadState = "upload_state"
+        case consent
+        case createdAt = "created_at"
+        case uploadAttempts = "upload_attempts"
+        case nextRetryAt = "next_retry_at"
+    }
+}
+
+struct CrashReportSummary: Equatable {
+    let reportID: String
+    let source: CrashReportSource
+    let kind: CrashDiagnosticKind
+    let occurredAt: String
+    let uploadState: CrashUploadState
+}
+
+struct CrashSessionState: Codable, Equatable {
+    var context: CrashContextSnapshot
+    var breadcrumbs: [CrashBreadcrumb]
+}
+
+enum CrashNonFatalComponent: String {
+    case appStartup = "app_startup"
+    case mapRendering = "map_rendering"
+    case navigation
+    case resources
+    case networking
+    case storage
+    case unknown
+}
+
+enum CrashNonFatalSeverity: String {
+    case warning
+    case error
+}
+
+struct CrashNonFatalEvent {
+    let component: CrashNonFatalComponent
+    let code: Int
+    let severity: CrashNonFatalSeverity
+    let numericMetadata: [String: Int64]
+}
+
+@objc enum CrashBreadcrumbEvent: Int {
+    case appLaunched
+    case appBecameActive
+    case appEnteredBackground
+    case screenChanged
+    case navigationStarted
+    case navigationStopped
+    case routeCalculationStarted
+    case routeCalculationFinished
+    case profileChanged
+    case pluginChanged
+    case mapSourceChanged
+    case memoryWarning
+
+    var wireName: String {
+        switch self {
+        case .appLaunched: return "app_launched"
+        case .appBecameActive: return "app_became_active"
+        case .appEnteredBackground: return "app_entered_background"
+        case .screenChanged: return "screen_changed"
+        case .navigationStarted: return "navigation_started"
+        case .navigationStopped: return "navigation_stopped"
+        case .routeCalculationStarted: return "route_calculation_started"
+        case .routeCalculationFinished: return "route_calculation_finished"
+        case .profileChanged: return "profile_changed"
+        case .pluginChanged: return "plugin_changed"
+        case .mapSourceChanged: return "map_source_changed"
+        case .memoryWarning: return "memory_warning"
+        }
+    }
+}
+
+enum CrashDiagnosticsJSON {
+    static func encoder(prettyPrinted: Bool = false) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = prettyPrinted ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes] : [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/Services/CrashDiagnostics/CrashDiagnosticsSanitizer.swift
+++ b/Sources/Services/CrashDiagnostics/CrashDiagnosticsSanitizer.swift
@@ -1,0 +1,593 @@
+//
+//  CrashDiagnosticsSanitizer.swift
+//  OsmAnd Maps
+//
+
+import CryptoKit
+import Foundation
+import UIKit
+
+enum CrashDiagnosticsSanitizer {
+    private static let maximumThreads = 64
+    private static let maximumFramesPerThread = 128
+    private static let maximumTotalKSCrashFrames = 1_024
+    private static let maximumBinaryImages = 512
+    private static let maximumMetricKitFrames = 512
+    private static let allowedNumericMetadataKeys: Set<String> = [
+        "attempt_count",
+        "bytes",
+        "duration_ms",
+        "item_count",
+        "retry_count",
+        "status_code",
+    ]
+    private static let allowedBreadcrumbEvents: Set<String> = [
+        "app_launched",
+        "app_became_active",
+        "app_entered_background",
+        "screen_changed",
+        "navigation_started",
+        "navigation_stopped",
+        "route_calculation_started",
+        "route_calculation_finished",
+        "profile_changed",
+        "plugin_changed",
+        "map_source_changed",
+        "memory_warning",
+    ]
+
+    static func normalizeKSCrashReport(
+        _ rawReport: [String: Any],
+        session: CrashSessionState
+    ) -> CrashReportEnvelope? {
+        let report = dictionary(rawReport["report"])
+        let system = dictionary(rawReport["system"])
+        let crash = dictionary(rawReport["crash"])
+        let error = dictionary(crash["error"])
+
+        let kind = kscrashKind(error["type"] as? String)
+        let occurredAt = sanitizedTimestamp(report["timestamp"] as? String)
+        let app = CrashAppInfo(
+            version: safeIdentifier(system["CFBundleShortVersionString"] as? String, fallback: currentAppVersion()),
+            build: safeIdentifier(system["CFBundleVersion"] as? String, fallback: currentAppBuild())
+        )
+        let device = CrashDeviceInfo(
+            model: safeHardwareModel(system["machine"] as? String) ?? currentDeviceModel(),
+            osVersion: safeIdentifier(system["system_version"] as? String, fallback: ProcessInfo.processInfo.operatingSystemVersionString)
+        )
+
+        let mach = dictionary(error["mach"])
+        let signal = dictionary(error["signal"])
+        let nsException = dictionary(error["nsexception"])
+        let cppException = dictionary(error["cpp_exception"])
+        let threads = normalizeKSCrashThreads(array(crash["threads"]))
+        let crashedThread = threads.first(where: { $0.crashed })?.index
+        let images = normalizeKSCrashImages(array(rawReport["binary_images"]))
+        let exceptionName = safeCodeIdentifier(
+            (nsException["name"] as? String)
+                ?? (cppException["name"] as? String)
+                ?? (mach["exception_name"] as? String)
+        )
+
+        let diagnostic = CrashDiagnostic(
+            kind: kind,
+            exceptionName: exceptionName,
+            exceptionType: uint64(mach["exception"]),
+            exceptionCode: uint64(mach["code"]),
+            signal: integer(signal["signal"]),
+            signalName: safeCodeIdentifier(signal["name"] as? String),
+            terminationReason: nil,
+            crashedThread: crashedThread,
+            hangDurationMilliseconds: nil,
+            cpuTimeMilliseconds: nil,
+            sampledTimeMilliseconds: nil,
+            diskWritesBytes: nil,
+            component: nil,
+            errorCode: nil,
+            severity: nil,
+            numericMetadata: nil,
+            threads: threads,
+            binaryImages: images
+        )
+
+        return makeEnvelope(
+            source: .kscrash,
+            occurredAt: occurredAt,
+            app: app,
+            device: device,
+            diagnostic: diagnostic,
+            context: sanitizeContext(session.context),
+            breadcrumbs: sanitizeBreadcrumbs(session.breadcrumbs)
+        )
+    }
+
+    static func makeMetricKitEnvelope(
+        kind: CrashDiagnosticKind,
+        occurredAt: Date,
+        appVersion: String,
+        appBuild: String,
+        deviceModel: String,
+        osVersion: String,
+        exceptionType: NSNumber? = nil,
+        exceptionCode: NSNumber? = nil,
+        signal: NSNumber? = nil,
+        terminationReason: String? = nil,
+        hangDurationMilliseconds: Int64? = nil,
+        cpuTimeMilliseconds: Int64? = nil,
+        sampledTimeMilliseconds: Int64? = nil,
+        diskWritesBytes: Int64? = nil,
+        callStackTreeData: Data?
+    ) -> CrashReportEnvelope {
+        let frames = normalizeMetricKitFrames(callStackTreeData)
+        let diagnostic = CrashDiagnostic(
+            kind: kind,
+            exceptionName: nil,
+            exceptionType: exceptionType?.uint64Value,
+            exceptionCode: exceptionCode?.uint64Value,
+            signal: signal?.intValue,
+            signalName: nil,
+            terminationReason: safeTerminationReason(terminationReason),
+            crashedThread: frames.isEmpty ? nil : 0,
+            hangDurationMilliseconds: boundedNonNegative(hangDurationMilliseconds),
+            cpuTimeMilliseconds: boundedNonNegative(cpuTimeMilliseconds),
+            sampledTimeMilliseconds: boundedNonNegative(sampledTimeMilliseconds),
+            diskWritesBytes: boundedNonNegative(diskWritesBytes),
+            component: nil,
+            errorCode: nil,
+            severity: nil,
+            numericMetadata: nil,
+            threads: frames.isEmpty ? [] : [CrashThread(index: 0, crashed: kind == .crash, frames: frames)],
+            binaryImages: metricKitImages(from: frames)
+        )
+
+        return makeEnvelope(
+            source: .metricKit,
+            occurredAt: iso8601Minute(occurredAt),
+            app: CrashAppInfo(
+                version: safeIdentifier(appVersion, fallback: currentAppVersion()),
+                build: safeIdentifier(appBuild, fallback: currentAppBuild())
+            ),
+            device: CrashDeviceInfo(
+                model: safeHardwareModel(deviceModel) ?? currentDeviceModel(),
+                osVersion: safeIdentifier(osVersion, fallback: ProcessInfo.processInfo.operatingSystemVersionString)
+            ),
+            diagnostic: diagnostic,
+            context: CrashContextSnapshot(),
+            breadcrumbs: []
+        )
+    }
+
+    static func makeNonFatalEnvelope(
+        _ event: CrashNonFatalEvent,
+        session: CrashSessionState
+    ) -> CrashReportEnvelope {
+        let numericMetadata = sanitizeNumericMetadata(event.numericMetadata)
+        let diagnostic = CrashDiagnostic(
+            kind: .nonFatal,
+            exceptionName: nil,
+            exceptionType: nil,
+            exceptionCode: nil,
+            signal: nil,
+            signalName: nil,
+            terminationReason: nil,
+            crashedThread: nil,
+            hangDurationMilliseconds: nil,
+            cpuTimeMilliseconds: nil,
+            sampledTimeMilliseconds: nil,
+            diskWritesBytes: nil,
+            component: event.component.rawValue,
+            errorCode: min(max(event.code, -1_000_000), 1_000_000),
+            severity: event.severity.rawValue,
+            numericMetadata: numericMetadata.isEmpty ? nil : numericMetadata,
+            threads: [],
+            binaryImages: []
+        )
+
+        return makeEnvelope(
+            source: .nonFatal,
+            occurredAt: iso8601Minute(Date()),
+            app: CrashAppInfo(version: currentAppVersion(), build: currentAppBuild()),
+            device: CrashDeviceInfo(model: currentDeviceModel(), osVersion: currentOSVersion()),
+            diagnostic: diagnostic,
+            context: sanitizeContext(session.context),
+            breadcrumbs: sanitizeBreadcrumbs(session.breadcrumbs)
+        )
+    }
+
+    static func sanitizeContext(_ context: CrashContextSnapshot) -> CrashContextSnapshot {
+        var result = context
+        result.screenIdentifier = safeScreenIdentifier(context.screenIdentifier)
+        result.routeCalculationState = allowedValue(
+            context.routeCalculationState,
+            allowed: ["idle", "calculating", "calculated", "failed"]
+        )
+        result.profileFamily = allowedValue(
+            context.profileFamily,
+            allowed: ["default", "car", "bicycle", "pedestrian", "aircraft", "truck", "motorcycle", "moped", "boat", "public_transport", "train", "ski", "horse", "custom", "unknown"]
+        )
+        result.zoomBucket = context.zoomBucket.map { min(max($0, 0), 24) }
+        result.mapSourceCategory = allowedValue(
+            context.mapSourceCategory,
+            allowed: ["offline_vector", "offline_raster", "online_raster", "unknown"]
+        )
+        result.loadedMapCount = min(max(context.loadedMapCount, 0), 1_000)
+        result.builtInPluginIDs = Array(
+            Set(context.builtInPluginIDs.compactMap(safeIdentifier))
+        ).sorted().prefix(32).map { $0 }
+        result.customPluginCount = min(max(context.customPluginCount, 0), 100)
+        result.applicationState = allowedValue(
+            context.applicationState,
+            allowed: ["active", "inactive", "background", "unknown"]
+        )
+        result.memoryAvailableBucketMB = sanitizeResourceBucket(context.memoryAvailableBucketMB)
+        result.diskAvailableBucketMB = sanitizeResourceBucket(context.diskAvailableBucketMB)
+        return result
+    }
+
+    static func sanitizeBreadcrumbs(_ breadcrumbs: [CrashBreadcrumb]) -> [CrashBreadcrumb] {
+        Array(breadcrumbs.suffix(100)).compactMap { breadcrumb in
+            guard allowedBreadcrumbEvents.contains(breadcrumb.event) else { return nil }
+            let metadata = sanitizeNumericMetadata(breadcrumb.numericMetadata ?? [:])
+            return CrashBreadcrumb(
+                elapsedMilliseconds: min(max(breadcrumb.elapsedMilliseconds, 0), 7 * 24 * 60 * 60 * 1_000),
+                event: breadcrumb.event,
+                numericMetadata: metadata.isEmpty ? nil : metadata,
+                screenIdentifier: safeScreenIdentifier(breadcrumb.screenIdentifier)
+            )
+        }
+    }
+
+    static func canonicalData(for report: CrashReportEnvelope) throws -> Data {
+        try CrashDiagnosticsJSON.encoder().encode(report)
+    }
+
+    static func prettyPrintedData(for report: CrashReportEnvelope) throws -> Data {
+        try CrashDiagnosticsJSON.encoder(prettyPrinted: true).encode(report)
+    }
+
+    static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func makeEnvelope(
+        source: CrashReportSource,
+        occurredAt: String,
+        app: CrashAppInfo,
+        device: CrashDeviceInfo,
+        diagnostic: CrashDiagnostic,
+        context: CrashContextSnapshot,
+        breadcrumbs: [CrashBreadcrumb]
+    ) -> CrashReportEnvelope {
+        let reportID = UUID().uuidString.lowercased()
+        return CrashReportEnvelope(
+            schemaVersion: CrashReportEnvelope.currentSchemaVersion,
+            reportID: reportID,
+            source: source,
+            occurredAt: occurredAt,
+            app: app,
+            device: device,
+            diagnostic: diagnostic,
+            context: context,
+            breadcrumbs: breadcrumbs
+        )
+    }
+
+    private static func normalizeKSCrashThreads(_ rawThreads: [Any]) -> [CrashThread] {
+        var remainingFrames = maximumTotalKSCrashFrames
+        var threads: [CrashThread] = []
+        for (offset, rawThread) in rawThreads.prefix(maximumThreads).enumerated() {
+            let thread = dictionary(rawThread)
+            guard !thread.isEmpty else { continue }
+            let backtrace = dictionary(thread["backtrace"])
+            let frameLimit = min(maximumFramesPerThread, remainingFrames)
+            let frames = array(backtrace["contents"])
+                .prefix(frameLimit)
+                .compactMap(normalizeKSCrashFrame)
+            threads.append(
+                CrashThread(
+                    index: integer(thread["index"]) ?? offset,
+                    crashed: boolean(thread["crashed"]),
+                    frames: frames
+                )
+            )
+            remainingFrames -= frames.count
+            if remainingFrames == 0 {
+                break
+            }
+        }
+        return threads
+    }
+
+    private static func normalizeKSCrashFrame(_ rawFrame: Any) -> CrashStackFrame? {
+        let frame = dictionary(rawFrame)
+        guard !frame.isEmpty else { return nil }
+        let instructionAddress = uint64(frame["instruction_addr"])
+        let binaryAddress = uint64(frame["object_addr"])
+        let binaryOffset: UInt64?
+        if let instructionAddress, let binaryAddress, instructionAddress >= binaryAddress {
+            binaryOffset = instructionAddress - binaryAddress
+        } else {
+            binaryOffset = nil
+        }
+        let binaryName = safeBasename(frame["object_name"] as? String)
+        let symbolAddress = uint64(frame["symbol_addr"])
+        let symbolName = safeSymbol(frame["symbol_name"] as? String)
+        guard instructionAddress != nil
+                || binaryAddress != nil
+                || binaryName != nil
+                || symbolAddress != nil
+                || symbolName != nil else {
+            return nil
+        }
+        return CrashStackFrame(
+            instructionAddress: instructionAddress,
+            binaryAddress: binaryAddress,
+            binaryOffset: binaryOffset,
+            binaryName: binaryName,
+            binaryUUID: nil,
+            symbolAddress: symbolAddress,
+            symbolName: symbolName
+        )
+    }
+
+    private static func normalizeKSCrashImages(_ rawImages: [Any]) -> [CrashBinaryImage] {
+        rawImages.prefix(maximumBinaryImages).compactMap { rawImage in
+            let image = dictionary(rawImage)
+            guard let name = safeBasename(image["name"] as? String) else { return nil }
+            return CrashBinaryImage(
+                name: name,
+                uuid: safeUUID(image["uuid"] as? String),
+                imageAddress: uint64(image["image_addr"])
+            )
+        }
+    }
+
+    private static func normalizeMetricKitFrames(_ data: Data?) -> [CrashStackFrame] {
+        guard let data,
+              let root = try? JSONSerialization.jsonObject(with: data) else {
+            return []
+        }
+        var frames: [CrashStackFrame] = []
+        collectMetricKitFrames(root, into: &frames)
+        return Array(frames.prefix(maximumMetricKitFrames))
+    }
+
+    private static func collectMetricKitFrames(_ value: Any, into frames: inout [CrashStackFrame]) {
+        guard frames.count < maximumMetricKitFrames else { return }
+        if let dictionary = value as? [String: Any] {
+            let binaryName = (dictionary["binaryName"] as? String)
+                ?? (dictionary["binary_name"] as? String)
+            let binaryUUID = (dictionary["binaryUUID"] as? String)
+                ?? (dictionary["binary_uuid"] as? String)
+            let address = uint64(dictionary["address"])
+            let offset = uint64(
+                dictionary["offsetIntoBinaryTextSegment"]
+                    ?? dictionary["offset_into_binary_text_segment"]
+            )
+            if binaryName != nil || binaryUUID != nil || address != nil || offset != nil {
+                frames.append(
+                    CrashStackFrame(
+                        instructionAddress: address,
+                        binaryAddress: nil,
+                        binaryOffset: offset,
+                        binaryName: safeBasename(binaryName),
+                        binaryUUID: safeUUID(binaryUUID),
+                        symbolAddress: nil,
+                        symbolName: nil
+                    )
+                )
+            }
+            for key in dictionary.keys.sorted() {
+                collectMetricKitFrames(dictionary[key] as Any, into: &frames)
+            }
+        } else if let array = value as? [Any] {
+            for item in array {
+                collectMetricKitFrames(item, into: &frames)
+            }
+        }
+    }
+
+    private static func metricKitImages(from frames: [CrashStackFrame]) -> [CrashBinaryImage] {
+        var seen = Set<String>()
+        return frames.compactMap { frame in
+            guard let name = frame.binaryName else { return nil }
+            let key = "\(name)|\(frame.binaryUUID ?? "")"
+            guard seen.insert(key).inserted else { return nil }
+            return CrashBinaryImage(name: name, uuid: frame.binaryUUID, imageAddress: nil)
+        }
+    }
+
+    private static func kscrashKind(_ rawType: String?) -> CrashDiagnosticKind {
+        switch rawType {
+        case "mach": return .machException
+        case "signal": return .signal
+        case "cpp_exception": return .cppException
+        case "nsexception": return .objectiveCException
+        case "memory_termination": return .memoryTermination
+        default: return .unknown
+        }
+    }
+
+    private static func safeIdentifier(_ value: String?, fallback: String) -> String {
+        safeIdentifier(value) ?? safeIdentifier(fallback) ?? "unknown"
+    }
+
+    private static func safeIdentifier(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        let scalars = value.unicodeScalars.filter { allowed.contains($0) }
+        let sanitized = String(String.UnicodeScalarView(scalars)).prefix(128)
+        return sanitized.isEmpty ? nil : String(sanitized)
+    }
+
+    private static func safeScreenIdentifier(_ value: String?) -> String? {
+        guard let identifier = safeIdentifier(value),
+              identifier.contains("ViewController")
+                || identifier.hasSuffix("Controller")
+                || identifier.hasSuffix("Screen")
+                || identifier.hasSuffix("Sheet")
+                || identifier.hasSuffix("Fragment") else {
+            return nil
+        }
+        return identifier
+    }
+
+    private static func safeHardwareModel(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let allowed = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789,._-"
+        )
+        guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return String(value.prefix(64))
+    }
+
+    private static func safeSymbol(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.$:+-<>[]() ")
+        let scalars = value.unicodeScalars.filter { allowed.contains($0) }
+        let sanitized = String(String.UnicodeScalarView(scalars)).prefix(256)
+        return sanitized.isEmpty ? nil : String(sanitized)
+    }
+
+    private static func safeCodeIdentifier(_ value: String?) -> String? {
+        guard let value, !value.isEmpty, value.count <= 128 else { return nil }
+        let allowed = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.$:+-<>[]()"
+        )
+        guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return value
+    }
+
+    private static func safeBasename(_ value: String?) -> String? {
+        guard let value else { return nil }
+        return safeIdentifier((value as NSString).lastPathComponent)
+    }
+
+    private static func safeUUID(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let compact = value.replacingOccurrences(of: "-", with: "")
+        let allowed = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard (compact.count == 32 || compact.count == 40),
+              compact.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            return nil
+        }
+        return value.uppercased()
+    }
+
+    private static func safeTerminationReason(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value.lowercased()
+        if normalized.contains("watchdog") || normalized.contains("8badf00d") {
+            return "watchdog"
+        }
+        if normalized.contains("jetsam") {
+            return "jetsam"
+        }
+        if normalized.contains("memory") {
+            return "memory_pressure"
+        }
+        if normalized.contains("resource") || normalized.contains("cpu") || normalized.contains("disk") {
+            return "resource_limit"
+        }
+        if normalized.contains("signal") {
+            return "namespace_signal"
+        }
+        return "unknown"
+    }
+
+    private static func sanitizeNumericMetadata(_ metadata: [String: Int64]) -> [String: Int64] {
+        var sanitized: [String: Int64] = [:]
+        for key in metadata.keys.sorted().prefix(16) {
+            guard allowedNumericMetadataKeys.contains(key),
+                  let safeKey = safeIdentifier(key),
+                  let value = metadata[key] else {
+                continue
+            }
+            sanitized[safeKey] = min(max(value, -1_000_000_000), 1_000_000_000)
+        }
+        return sanitized
+    }
+
+    private static func sanitizeResourceBucket(_ value: Int?) -> Int? {
+        value.map { min(max($0, 0), 1_048_576) }
+    }
+
+    private static func allowedValue(_ value: String, allowed: Set<String>) -> String {
+        allowed.contains(value) ? value : "unknown"
+    }
+
+    private static func boundedNonNegative(_ value: Int64?) -> Int64? {
+        value.map { min(max($0, 0), Int64.max / 2) }
+    }
+
+    private static func sanitizedTimestamp(_ value: String?) -> String {
+        guard let value, let date = ISO8601DateFormatter().date(from: value) else {
+            return iso8601Minute(Date())
+        }
+        return iso8601Minute(date)
+    }
+
+    static func iso8601Minute(_ date: Date) -> String {
+        let interval = floor(date.timeIntervalSince1970 / 60) * 60
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: Date(timeIntervalSince1970: interval))
+    }
+
+    private static func currentAppVersion() -> String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    }
+
+    private static func currentAppBuild() -> String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+    }
+
+    private static func currentOSVersion() -> String {
+        UIDevice.current.systemVersion
+    }
+
+    private static func currentDeviceModel() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let identifier = Mirror(reflecting: systemInfo.machine).children.reduce(into: "") { result, element in
+            guard let value = element.value as? Int8, value != 0 else { return }
+            result.append(String(UnicodeScalar(UInt8(value))))
+        }
+        return identifier.isEmpty ? "unknown" : identifier
+    }
+
+    private static func dictionary(_ value: Any?) -> [String: Any] {
+        value as? [String: Any] ?? [:]
+    }
+
+    private static func array(_ value: Any?) -> [Any] {
+        value as? [Any] ?? []
+    }
+
+    private static func boolean(_ value: Any?) -> Bool {
+        (value as? Bool) ?? (value as? NSNumber)?.boolValue ?? false
+    }
+
+    private static func integer(_ value: Any?) -> Int? {
+        if let number = value as? NSNumber {
+            return number.intValue
+        }
+        if let string = value as? String {
+            return Int(string)
+        }
+        return nil
+    }
+
+    private static func uint64(_ value: Any?) -> UInt64? {
+        if let number = value as? NSNumber {
+            return number.uint64Value
+        }
+        if let string = value as? String {
+            if string.hasPrefix("0x") {
+                return UInt64(string.dropFirst(2), radix: 16)
+            }
+            return UInt64(string)
+        }
+        return nil
+    }
+}

--- a/Sources/Services/CrashDiagnostics/CrashDiagnosticsService.swift
+++ b/Sources/Services/CrashDiagnostics/CrashDiagnosticsService.swift
@@ -1,0 +1,607 @@
+//
+//  CrashDiagnosticsService.swift
+//  OsmAnd Maps
+//
+
+import Foundation
+import MetricKit
+import UIKit
+import os
+
+extension Notification.Name {
+    static let crashDiagnosticsReportsDidChange = Notification.Name("OACrashDiagnosticsReportsDidChange")
+}
+
+@objcMembers
+final class CrashDiagnosticsService: NSObject {
+    static let shared = CrashDiagnosticsService()
+
+    private let fileManager = FileManager.default
+    private let stateQueue = DispatchQueue(label: "net.osmand.crash-diagnostics.session")
+    private let processStartUptime = ProcessInfo.processInfo.systemUptime
+    private let baseDirectory: URL
+    private let sessionStateURL: URL
+    private let store: CrashDiagnosticsStore
+    private lazy var uploader = CrashDiagnosticsUploader(store: store) { [weak self] in
+        self?.notifyReportsChanged()
+    }
+    private lazy var metricKitSubscriber = CrashDiagnosticsMetricKitSubscriber { [weak self] payloads in
+        self?.processMetricKitPayloads(payloads)
+    }
+    private var currentSession = CrashSessionState(context: CrashContextSnapshot(), breadcrumbs: [])
+    private var didStart = false
+    private var didOfferPendingReport = false
+    private var applicationContextReady = false
+    private var contextRefreshTimer: Timer?
+
+    override private init() {
+        let applicationSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        baseDirectory = applicationSupport.appendingPathComponent("CrashDiagnostics", isDirectory: true)
+        sessionStateURL = baseDirectory.appendingPathComponent("CurrentSession.json")
+        store = CrashDiagnosticsStore(baseDirectory: baseDirectory)
+        super.init()
+    }
+
+    @objc(startWithLaunchOptions:)
+    func start(launchOptions: NSDictionary?) {
+        guard Self.isCaptureEnabled else { return }
+        let startup: (shouldStart: Bool, previousSession: CrashSessionState?) = stateQueue.sync {
+            guard !didStart else { return (false, nil) }
+            didStart = true
+            configureBaseDirectory()
+            return (true, loadSessionStateLocked())
+        }
+        guard startup.shouldStart else { return }
+
+        installKSCrash()
+        processPendingKSCrashReports(previousSession: startup.previousSession)
+
+        stateQueue.sync {
+            currentSession = CrashSessionState(context: CrashContextSnapshot(), breadcrumbs: [])
+            currentSession.context.applicationState = "inactive"
+            appendBreadcrumbLocked(event: .appLaunched, numericMetadata: [:])
+            persistSessionStateLocked()
+        }
+
+        let metricManager = MXMetricManager.shared
+        metricManager.add(metricKitSubscriber)
+        processMetricKitPayloads(metricManager.pastDiagnosticPayloads)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceiveMemoryWarning),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
+        retryApprovedReports()
+    }
+
+    private static var isCaptureEnabled: Bool {
+#if DEBUG
+        true
+#else
+        Bundle.main.object(forInfoDictionaryKey: "OSMAND_CRASH_CAPTURE_ENABLED") as? Bool ?? false
+#endif
+    }
+
+    private var isStarted: Bool {
+        stateQueue.sync { didStart }
+    }
+
+    func recordBreadcrumb(_ event: CrashBreadcrumbEvent) {
+        recordBreadcrumb(event, numericMetadata: [:])
+    }
+
+    func recordBreadcrumb(_ event: CrashBreadcrumbEvent, numericMetadata: [String: Int64]) {
+        guard isStarted else { return }
+        stateQueue.sync {
+            appendBreadcrumbLocked(event: event, numericMetadata: numericMetadata)
+            persistSessionStateLocked()
+        }
+    }
+
+    func updateContext(_ context: CrashContextSnapshot) {
+        guard isStarted else { return }
+        stateQueue.sync {
+            let sanitized = CrashDiagnosticsSanitizer.sanitizeContext(context)
+            let previous = currentSession.context
+            guard sanitized != previous else { return }
+            currentSession.context = sanitized
+            if sanitized.screenIdentifier != previous.screenIdentifier {
+                appendBreadcrumbLocked(event: .screenChanged, numericMetadata: [:])
+            }
+            if sanitized.navigationActive != previous.navigationActive {
+                appendBreadcrumbLocked(
+                    event: sanitized.navigationActive ? .navigationStarted : .navigationStopped,
+                    numericMetadata: [:]
+                )
+            }
+            if sanitized.routeCalculationState != previous.routeCalculationState {
+                appendBreadcrumbLocked(
+                    event: sanitized.routeCalculationState == "calculating"
+                        ? .routeCalculationStarted
+                        : .routeCalculationFinished,
+                    numericMetadata: [:]
+                )
+            }
+            if sanitized.profileFamily != previous.profileFamily {
+                appendBreadcrumbLocked(event: .profileChanged, numericMetadata: [:])
+            }
+            if sanitized.builtInPluginIDs != previous.builtInPluginIDs
+                || sanitized.customPluginCount != previous.customPluginCount {
+                appendBreadcrumbLocked(event: .pluginChanged, numericMetadata: [:])
+            }
+            if sanitized.mapSourceCategory != previous.mapSourceCategory
+                || sanitized.loadedMapCount != previous.loadedMapCount {
+                appendBreadcrumbLocked(event: .mapSourceChanged, numericMetadata: [:])
+            }
+            persistSessionStateLocked()
+        }
+    }
+
+    func recordNonFatal(_ event: CrashNonFatalEvent) {
+        guard isStarted else { return }
+        let session = stateQueue.sync { currentSession }
+        let report = CrashDiagnosticsSanitizer.makeNonFatalEnvelope(event, session: session)
+        do {
+            if try store.save(report) {
+                notifyReportsChanged()
+            }
+        } catch {
+            NSLog("[CrashDiagnostics] Failed to save non-fatal report: %@", error.localizedDescription)
+        }
+    }
+
+    func pendingReports() -> [CrashReportSummary] {
+        store.summaries()
+    }
+
+    var pendingReportCount: Int {
+        pendingReports().count
+    }
+
+    var canUpload: Bool {
+        uploader.canUpload
+    }
+
+    func prettyPrintedReport(reportID: String) throws -> String {
+        let data = try store.prettyPrintedReportData(reportID: reportID)
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    func approveAndSend(
+        reportID: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard uploader.canUpload else {
+            completion(.failure(CrashDiagnosticsUploadError.endpointUnavailable))
+            return
+        }
+        do {
+            _ = try store.approve(reportID: reportID)
+            notifyReportsChanged()
+            uploader.uploadApprovedReport(reportID: reportID) { [weak self] result in
+                self?.notifyReportsChanged()
+                completion(result)
+            }
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    @objc(deleteReportWithID:)
+    func delete(reportID: String) {
+        store.delete(reportID: reportID)
+        notifyReportsChanged()
+    }
+
+    func deleteAll() {
+        store.deleteAll()
+        notifyReportsChanged()
+    }
+
+    @objc(applicationStateDidChange:)
+    func applicationStateDidChange(_ state: String) {
+        guard isStarted else { return }
+        switch state {
+        case "active":
+            recordBreadcrumb(.appBecameActive)
+            retryApprovedReports()
+            if stateQueue.sync(execute: { applicationContextReady }) {
+                startContextRefreshTimerIfReady()
+                presentPendingReportBannerIfNeeded()
+            }
+        case "background":
+            recordBreadcrumb(.appEnteredBackground)
+            stopContextRefreshTimer()
+        case "inactive":
+            stopContextRefreshTimer()
+        default:
+            break
+        }
+        updateApplicationContext(state: state)
+    }
+
+    func applicationStartupDidComplete() {
+        guard isStarted else { return }
+        stateQueue.sync {
+            applicationContextReady = true
+        }
+        applicationStateDidChange(applicationStateName(UIApplication.shared.applicationState))
+    }
+
+    func didReceiveMemoryWarning() {
+        guard isStarted else { return }
+        recordBreadcrumb(.memoryWarning)
+        updateApplicationContext(state: applicationStateName(UIApplication.shared.applicationState))
+    }
+
+    func presentPendingReportBannerIfNeeded() {
+        guard isStarted else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            guard !self.didOfferPendingReport,
+                  let report = self.pendingReports().first(where: {
+                      $0.source != .nonFatal && $0.uploadState == .pending
+                  }) else {
+                return
+            }
+            self.didOfferPendingReport = true
+            CrashDiagnosticsBannerPresenter.shared.present(reportID: report.reportID)
+        }
+    }
+
+    private func installKSCrash() {
+        guard OACrashDiagnosticsKSCrashBridge.install(atPath: baseDirectory.path) else { return }
+        configureProtectionRecursively(at: baseDirectory.appendingPathComponent("RawReports", isDirectory: true))
+    }
+
+    private func retryApprovedReports() {
+        uploader.retryApprovedReports()
+    }
+
+    private func processPendingKSCrashReports(previousSession: CrashSessionState?) {
+        let session = previousSession ?? CrashSessionState(context: CrashContextSnapshot(), breadcrumbs: [])
+        for entry in OACrashDiagnosticsKSCrashBridge.pendingReports() {
+            guard let reportID = (entry["report_id"] as? NSNumber)?.int64Value,
+                  let rawReport = entry["report"] as? [String: Any] else {
+                continue
+            }
+            guard let normalized = CrashDiagnosticsSanitizer.normalizeKSCrashReport(rawReport, session: session) else {
+                OACrashDiagnosticsKSCrashBridge.deleteReport(withID: reportID)
+                continue
+            }
+            do {
+                let saved = try store.save(normalized)
+                OACrashDiagnosticsKSCrashBridge.deleteReport(withID: reportID)
+                if saved {
+                    notifyReportsChanged()
+                }
+            } catch {
+                NSLog("[CrashDiagnostics] Failed to normalize KSCrash report: %@", error.localizedDescription)
+            }
+        }
+    }
+
+    private func updateApplicationContext(state: String) {
+        let shouldReadApplicationObjects = stateQueue.sync {
+            currentSession.context.applicationState = allowedApplicationState(state)
+            persistSessionStateLocked()
+            return applicationContextReady
+        }
+        guard shouldReadApplicationObjects else { return }
+
+        DispatchQueue.main.async {
+            var context = self.stateQueue.sync { self.currentSession.context }
+
+            let routingHelper = OARoutingHelper.sharedInstance()
+            context.navigationActive = routingHelper.isFollowingMode()
+            if routingHelper.isRouteBeingCalculated() {
+                context.routeCalculationState = "calculating"
+            } else if routingHelper.isRouteCalculated() {
+                context.routeCalculationState = "calculated"
+            } else {
+                context.routeCalculationState = "idle"
+            }
+
+            let settings = OAAppSettings.sharedManager()
+            let mode = settings.currentMode
+            let baseMode = mode.parent ?? mode
+            context.profileFamily = self.safeProfileFamily(baseMode.stringKey)
+
+            let plugins = OAPluginsHelper.getEnabledPlugins()
+            var builtInPluginIDs: [String] = []
+            var customPluginCount = 0
+            for plugin in plugins {
+                let className = NSStringFromClass(type(of: plugin))
+                if className.hasSuffix("OACustomPlugin") {
+                    customPluginCount += 1
+                } else if let pluginID = plugin.getId() {
+                    builtInPluginIDs.append(pluginID)
+                }
+            }
+            context.builtInPluginIDs = builtInPluginIDs
+            context.customPluginCount = customPluginCount
+
+            if let appData = OsmAndApp.swiftInstance().data {
+                let activeMapSources = [
+                    appData.lastMapSource,
+                    appData.overlayMapSource,
+                    appData.underlayMapSource,
+                ].compactMap { $0 }
+                context.loadedMapCount = activeMapSources.count
+                context.mapSourceCategory = self.mapSourceCategory(appData.lastMapSource)
+            } else {
+                context.loadedMapCount = 0
+                context.mapSourceCategory = "unknown"
+            }
+
+            if let appDelegate = UIApplication.shared.delegate as? OAAppDelegate,
+               let root = appDelegate.rootViewController,
+               root.mapPanel.mapViewController.mapViewLoaded {
+                context.zoomBucket = Int(root.mapPanel.mapViewController.getMapZoom().rounded())
+            }
+            context.screenIdentifier = self.topViewControllerName()
+            context.memoryAvailableBucketMB = self.resourceBucket(
+                bytes: UInt64(os_proc_available_memory())
+            )
+            context.diskAvailableBucketMB = self.availableDiskBytes().map(self.resourceBucket)
+            self.updateContext(context)
+        }
+    }
+
+    private func appendBreadcrumbLocked(
+        event: CrashBreadcrumbEvent,
+        numericMetadata: [String: Int64]
+    ) {
+        let elapsed = max(ProcessInfo.processInfo.systemUptime - processStartUptime, 0)
+        currentSession.breadcrumbs.append(
+            CrashBreadcrumb(
+                elapsedMilliseconds: Int64(elapsed * 1_000),
+                event: event.wireName,
+                numericMetadata: numericMetadata.isEmpty ? nil : numericMetadata,
+                screenIdentifier: currentSession.context.screenIdentifier
+            )
+        )
+        currentSession.breadcrumbs = Array(currentSession.breadcrumbs.suffix(100))
+    }
+
+    private func configureBaseDirectory() {
+        try? fileManager.createDirectory(
+            at: baseDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        )
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        var directory = baseDirectory
+        try? directory.setResourceValues(resourceValues)
+        configureProtectionRecursively(at: baseDirectory)
+    }
+
+    private func startContextRefreshTimerIfReady() {
+        let isReady = stateQueue.sync { applicationContextReady }
+        guard isReady else { return }
+        DispatchQueue.main.async {
+            self.contextRefreshTimer?.invalidate()
+            self.contextRefreshTimer = Timer.scheduledTimer(
+                withTimeInterval: 10,
+                repeats: true
+            ) { [weak self] _ in
+                guard let self else { return }
+                self.updateApplicationContext(
+                    state: self.applicationStateName(UIApplication.shared.applicationState)
+                )
+            }
+        }
+    }
+
+    private func stopContextRefreshTimer() {
+        DispatchQueue.main.async {
+            self.contextRefreshTimer?.invalidate()
+            self.contextRefreshTimer = nil
+        }
+    }
+
+    private func configureProtectionRecursively(at url: URL) {
+        try? fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func loadSessionStateLocked() -> CrashSessionState? {
+        guard let data = try? Data(contentsOf: sessionStateURL) else { return nil }
+        return try? CrashDiagnosticsJSON.decoder().decode(CrashSessionState.self, from: data)
+    }
+
+    private func persistSessionStateLocked() {
+        guard let data = try? CrashDiagnosticsJSON.encoder().encode(currentSession) else { return }
+        try? data.write(
+            to: sessionStateURL,
+            options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+        )
+    }
+
+    private func notifyReportsChanged() {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .crashDiagnosticsReportsDidChange, object: self)
+        }
+    }
+
+    private func safeProfileFamily(_ rawValue: String) -> String {
+        let allowed: Set<String> = [
+            "default", "car", "bicycle", "pedestrian", "aircraft", "truck",
+            "motorcycle", "moped", "boat", "public_transport", "train", "ski", "horse",
+        ]
+        return allowed.contains(rawValue) ? rawValue : "custom"
+    }
+
+    private func mapSourceCategory(_ mapSource: OAMapSource?) -> String {
+        guard let mapSource else { return "unknown" }
+        if mapSource.type?.caseInsensitiveCompare("sqlitedb") == .orderedSame {
+            return "offline_raster"
+        }
+        if mapSource.resourceId?.caseInsensitiveCompare("online_tiles") == .orderedSame {
+            return "online_raster"
+        }
+        return "offline_vector"
+    }
+
+    private func topViewControllerName() -> String? {
+        let window = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+        var current = window?.rootViewController
+        while true {
+            if let navigation = current as? UINavigationController {
+                current = navigation.visibleViewController
+            } else if let tab = current as? UITabBarController {
+                current = tab.selectedViewController
+            } else if let presented = current?.presentedViewController {
+                current = presented
+            } else {
+                break
+            }
+        }
+        guard let current else { return nil }
+        return NSStringFromClass(type(of: current)).components(separatedBy: ".").last
+    }
+
+    private func allowedApplicationState(_ state: String) -> String {
+        ["active", "inactive", "background"].contains(state) ? state : "unknown"
+    }
+
+    private func applicationStateName(_ state: UIApplication.State) -> String {
+        switch state {
+        case .active: return "active"
+        case .inactive: return "inactive"
+        case .background: return "background"
+        @unknown default: return "unknown"
+        }
+    }
+
+    private func availableDiskBytes() -> UInt64? {
+        let values = try? baseDirectory.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        guard let bytes = values?.volumeAvailableCapacityForImportantUsage, bytes >= 0 else {
+            return nil
+        }
+        return UInt64(bytes)
+    }
+
+    private func resourceBucket(bytes: UInt64) -> Int {
+        let megabytes = Int(min(bytes / 1_024 / 1_024, UInt64(Int.max)))
+        let buckets = [0, 64, 128, 256, 512, 1_024, 2_048, 4_096, 8_192, 16_384, 32_768, 65_536, 131_072]
+        return buckets.last(where: { $0 <= megabytes }) ?? 0
+    }
+}
+
+private extension CrashDiagnosticsService {
+    func processMetricKitPayloads(_ payloads: [MXDiagnosticPayload]) {
+        for payload in payloads {
+            let occurredAt = payload.timeStampEnd
+            for diagnostic in payload.crashDiagnostics ?? [] {
+                saveMetricKitReport(
+                    kind: .crash,
+                    diagnostic: diagnostic,
+                    occurredAt: occurredAt,
+                    exceptionType: diagnostic.exceptionType,
+                    exceptionCode: diagnostic.exceptionCode,
+                    signal: diagnostic.signal,
+                    terminationReason: diagnostic.terminationReason,
+                    callStackTreeData: diagnostic.callStackTree.jsonRepresentation()
+                )
+            }
+            for diagnostic in payload.hangDiagnostics ?? [] {
+                saveMetricKitReport(
+                    kind: .hang,
+                    diagnostic: diagnostic,
+                    occurredAt: occurredAt,
+                    hangDurationMilliseconds: Int64(
+                        diagnostic.hangDuration.converted(to: .milliseconds).value.rounded()
+                    ),
+                    callStackTreeData: diagnostic.callStackTree.jsonRepresentation()
+                )
+            }
+            for diagnostic in payload.cpuExceptionDiagnostics ?? [] {
+                saveMetricKitReport(
+                    kind: .cpuException,
+                    diagnostic: diagnostic,
+                    occurredAt: occurredAt,
+                    cpuTimeMilliseconds: Int64(
+                        diagnostic.totalCPUTime.converted(to: .milliseconds).value.rounded()
+                    ),
+                    sampledTimeMilliseconds: Int64(
+                        diagnostic.totalSampledTime.converted(to: .milliseconds).value.rounded()
+                    ),
+                    callStackTreeData: diagnostic.callStackTree.jsonRepresentation()
+                )
+            }
+            for diagnostic in payload.diskWriteExceptionDiagnostics ?? [] {
+                saveMetricKitReport(
+                    kind: .diskWriteException,
+                    diagnostic: diagnostic,
+                    occurredAt: occurredAt,
+                    diskWritesBytes: Int64(
+                        diagnostic.totalWritesCaused.converted(to: .bytes).value.rounded()
+                    ),
+                    callStackTreeData: diagnostic.callStackTree.jsonRepresentation()
+                )
+            }
+        }
+        presentPendingReportBannerIfNeeded()
+    }
+
+    private func saveMetricKitReport(
+        kind: CrashDiagnosticKind,
+        diagnostic: MXDiagnostic,
+        occurredAt: Date,
+        exceptionType: NSNumber? = nil,
+        exceptionCode: NSNumber? = nil,
+        signal: NSNumber? = nil,
+        terminationReason: String? = nil,
+        hangDurationMilliseconds: Int64? = nil,
+        cpuTimeMilliseconds: Int64? = nil,
+        sampledTimeMilliseconds: Int64? = nil,
+        diskWritesBytes: Int64? = nil,
+        callStackTreeData: Data?
+    ) {
+        let metaData = diagnostic.metaData
+        let report = CrashDiagnosticsSanitizer.makeMetricKitEnvelope(
+            kind: kind,
+            occurredAt: occurredAt,
+            appVersion: diagnostic.applicationVersion,
+            appBuild: metaData.applicationBuildVersion,
+            deviceModel: metaData.deviceType,
+            osVersion: metaData.osVersion,
+            exceptionType: exceptionType,
+            exceptionCode: exceptionCode,
+            signal: signal,
+            terminationReason: terminationReason,
+            hangDurationMilliseconds: hangDurationMilliseconds,
+            cpuTimeMilliseconds: cpuTimeMilliseconds,
+            sampledTimeMilliseconds: sampledTimeMilliseconds,
+            diskWritesBytes: diskWritesBytes,
+            callStackTreeData: callStackTreeData
+        )
+        do {
+            if try store.save(report) {
+                notifyReportsChanged()
+            }
+        } catch {
+            NSLog("[CrashDiagnostics] Failed to save MetricKit report: %@", error.localizedDescription)
+        }
+    }
+}
+
+private final class CrashDiagnosticsMetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
+    private let payloadHandler: ([MXDiagnosticPayload]) -> Void
+
+    init(payloadHandler: @escaping ([MXDiagnosticPayload]) -> Void) {
+        self.payloadHandler = payloadHandler
+        super.init()
+    }
+
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        payloadHandler(payloads)
+    }
+}

--- a/Sources/Services/CrashDiagnostics/CrashDiagnosticsStore.swift
+++ b/Sources/Services/CrashDiagnostics/CrashDiagnosticsStore.swift
@@ -1,0 +1,306 @@
+//
+//  CrashDiagnosticsStore.swift
+//  OsmAnd Maps
+//
+
+import Foundation
+
+enum CrashDiagnosticsStoreError: Error {
+    case reportNotFound
+    case consentIntegrityFailure
+}
+
+final class CrashDiagnosticsStore {
+    static let maximumReportCount = 3
+    static let maximumTotalBytes = 5 * 1_024 * 1_024
+    static let maximumAge: TimeInterval = 7 * 24 * 60 * 60
+
+    private let fileManager: FileManager
+    private let reportsDirectory: URL
+    private let queue = DispatchQueue(label: "net.osmand.crash-diagnostics.store")
+
+    init(baseDirectory: URL? = nil, fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        if let baseDirectory {
+            reportsDirectory = baseDirectory.appendingPathComponent("Reports", isDirectory: true)
+        } else {
+            let applicationSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            reportsDirectory = applicationSupport
+                .appendingPathComponent("CrashDiagnostics", isDirectory: true)
+                .appendingPathComponent("Reports", isDirectory: true)
+        }
+        queue.sync {
+            configureDirectoryLocked()
+            pruneLocked(now: Date())
+        }
+    }
+
+    @discardableResult
+    func save(_ report: CrashReportEnvelope, now: Date = Date()) throws -> Bool {
+        try queue.sync {
+            configureDirectoryLocked()
+            let existing = loadAllLocked()
+            guard !existing.contains(where: { isLikelyDuplicate($0.report, report) }) else {
+                return false
+            }
+            let stored = StoredCrashReport(
+                report: report,
+                uploadState: .pending,
+                consent: nil,
+                createdAt: now,
+                uploadAttempts: 0,
+                nextRetryAt: nil
+            )
+            try writeLocked(stored)
+            pruneLocked(now: now)
+            return fileManager.fileExists(atPath: reportURL(reportID: report.reportID).path)
+        }
+    }
+
+    func summaries() -> [CrashReportSummary] {
+        queue.sync {
+            pruneLocked(now: Date())
+            return loadAllLocked()
+                .sorted { $0.createdAt > $1.createdAt }
+                .map {
+                    CrashReportSummary(
+                        reportID: $0.report.reportID,
+                        source: $0.report.source,
+                        kind: $0.report.diagnostic.kind,
+                        occurredAt: $0.report.occurredAt,
+                        uploadState: $0.uploadState
+                    )
+                }
+        }
+    }
+
+    func storedReport(reportID: String) -> StoredCrashReport? {
+        queue.sync {
+            loadLocked(reportID: reportID)
+        }
+    }
+
+    func prettyPrintedReportData(reportID: String) throws -> Data {
+        try queue.sync {
+            pruneLocked(now: Date())
+            guard let stored = loadLocked(reportID: reportID) else {
+                throw CrashDiagnosticsStoreError.reportNotFound
+            }
+            return try CrashDiagnosticsSanitizer.prettyPrintedData(for: stored.report)
+        }
+    }
+
+    func approve(reportID: String, now: Date = Date()) throws -> CrashUploadRequest {
+        try queue.sync {
+            pruneLocked(now: now)
+            guard var stored = loadLocked(reportID: reportID) else {
+                throw CrashDiagnosticsStoreError.reportNotFound
+            }
+            let canonicalData = try CrashDiagnosticsSanitizer.canonicalData(for: stored.report)
+            let consent = CrashReportConsent(
+                mode: "per_report",
+                approvedAt: CrashDiagnosticsSanitizer.iso8601Minute(now),
+                reviewedPayloadSHA256: CrashDiagnosticsSanitizer.sha256Hex(canonicalData)
+            )
+            stored.uploadState = .approved
+            stored.consent = consent
+            stored.uploadAttempts = 0
+            stored.nextRetryAt = now
+            try writeLocked(stored)
+            return CrashUploadRequest(report: stored.report, consent: consent)
+        }
+    }
+
+    func verifiedUploadRequest(reportID: String) throws -> CrashUploadRequest {
+        try queue.sync {
+            pruneLocked(now: Date())
+            guard let stored = loadLocked(reportID: reportID),
+                  let consent = stored.consent,
+                  stored.uploadState == .approved else {
+                throw CrashDiagnosticsStoreError.reportNotFound
+            }
+            let canonicalData = try CrashDiagnosticsSanitizer.canonicalData(for: stored.report)
+            guard CrashDiagnosticsSanitizer.sha256Hex(canonicalData) == consent.reviewedPayloadSHA256 else {
+                throw CrashDiagnosticsStoreError.consentIntegrityFailure
+            }
+            return CrashUploadRequest(report: stored.report, consent: consent)
+        }
+    }
+
+    func approvedReportsDue(now: Date = Date()) -> [String] {
+        queue.sync {
+            pruneLocked(now: now)
+            return loadAllLocked().compactMap { stored in
+                guard stored.uploadState == .approved,
+                      (stored.nextRetryAt ?? .distantPast) <= now else {
+                    return nil
+                }
+                return stored.report.reportID
+            }
+        }
+    }
+
+    func markUploadFailure(reportID: String, now: Date = Date()) -> Date? {
+        queue.sync {
+            guard var stored = loadLocked(reportID: reportID) else { return nil }
+            stored.uploadAttempts += 1
+            let delays: [TimeInterval] = [
+                60,
+                15 * 60,
+                60 * 60,
+                6 * 60 * 60,
+                24 * 60 * 60,
+            ]
+            let delay = delays[min(max(stored.uploadAttempts - 1, 0), delays.count - 1)]
+            stored.nextRetryAt = now.addingTimeInterval(delay)
+            try? writeLocked(stored)
+            return stored.nextRetryAt
+        }
+    }
+
+    func markUploadRejected(reportID: String) {
+        queue.sync {
+            guard var stored = loadLocked(reportID: reportID) else { return }
+            stored.uploadState = .rejected
+            stored.nextRetryAt = nil
+            try? writeLocked(stored)
+        }
+    }
+
+    func delete(reportID: String) {
+        queue.sync {
+            try? fileManager.removeItem(at: reportURL(reportID: reportID))
+        }
+    }
+
+    func deleteAll() {
+        queue.sync {
+            for url in reportFileURLsLocked() {
+                try? fileManager.removeItem(at: url)
+            }
+        }
+    }
+
+    private func configureDirectoryLocked() {
+        try? fileManager.createDirectory(
+            at: reportsDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+        )
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        var directory = reportsDirectory
+        try? directory.setResourceValues(resourceValues)
+        try? fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: reportsDirectory.path
+        )
+    }
+
+    private func writeLocked(_ report: StoredCrashReport) throws {
+        let data = try CrashDiagnosticsJSON.encoder().encode(report)
+        let target = reportURL(reportID: report.report.reportID)
+        try data.write(to: target, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+    }
+
+    private func loadLocked(reportID: String) -> StoredCrashReport? {
+        let url = reportURL(reportID: reportID)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? CrashDiagnosticsJSON.decoder().decode(StoredCrashReport.self, from: data)
+    }
+
+    private func loadAllLocked() -> [StoredCrashReport] {
+        reportFileURLsLocked().compactMap { url in
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return try? CrashDiagnosticsJSON.decoder().decode(StoredCrashReport.self, from: data)
+        }
+    }
+
+    private func reportFileURLsLocked() -> [URL] {
+        (try? fileManager.contentsOfDirectory(
+            at: reportsDirectory,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ))?.filter { $0.pathExtension == "json" } ?? []
+    }
+
+    private func pruneLocked(now: Date) {
+        var reports = loadAllLocked()
+        for report in reports where now.timeIntervalSince(report.createdAt) > Self.maximumAge {
+            try? fileManager.removeItem(at: reportURL(reportID: report.report.reportID))
+        }
+
+        reports = loadAllLocked().sorted(by: retentionPriority)
+        if reports.count > Self.maximumReportCount {
+            for report in reports.dropFirst(Self.maximumReportCount) {
+                try? fileManager.removeItem(at: reportURL(reportID: report.report.reportID))
+            }
+        }
+
+        reports = loadAllLocked().sorted(by: retentionPriority)
+        var retainedBytes = 0
+        for report in reports {
+            let url = reportURL(reportID: report.report.reportID)
+            let bytes = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+            if retainedBytes + bytes > Self.maximumTotalBytes {
+                try? fileManager.removeItem(at: url)
+            } else {
+                retainedBytes += bytes
+            }
+        }
+    }
+
+    private func reportURL(reportID: String) -> URL {
+        reportsDirectory.appendingPathComponent(reportID).appendingPathExtension("json")
+    }
+
+    private func isLikelyDuplicate(
+        _ first: CrashReportEnvelope,
+        _ second: CrashReportEnvelope
+    ) -> Bool {
+        guard first.app.build == second.app.build,
+              diagnosticFamily(first.diagnostic.kind) == diagnosticFamily(second.diagnostic.kind),
+              first.diagnostic.component == second.diagnostic.component,
+              first.diagnostic.errorCode == second.diagnostic.errorCode,
+              topFrameSignature(first.diagnostic.threads) == topFrameSignature(second.diagnostic.threads) else {
+            return false
+        }
+        let formatter = ISO8601DateFormatter()
+        guard let firstDate = formatter.date(from: first.occurredAt),
+              let secondDate = formatter.date(from: second.occurredAt) else {
+            return first.occurredAt == second.occurredAt
+        }
+        let isCrossSourceFatal = first.source != second.source
+            && diagnosticFamily(first.diagnostic.kind) == "fatal"
+        let tolerance: TimeInterval = isCrossSourceFatal ? 24 * 60 * 60 : 5 * 60
+        return abs(firstDate.timeIntervalSince(secondDate)) <= tolerance
+    }
+
+    private func diagnosticFamily(_ kind: CrashDiagnosticKind) -> String {
+        switch kind {
+        case .machException, .signal, .cppException, .objectiveCException,
+             .memoryTermination, .crash, .unknown:
+            return "fatal"
+        default:
+            return kind.rawValue
+        }
+    }
+
+    private func topFrameSignature(_ threads: [CrashThread]) -> [String] {
+        let frames = threads.first(where: { $0.crashed })?.frames
+            ?? threads.first?.frames
+            ?? []
+        return frames.prefix(8).map {
+            "\($0.binaryName ?? "unknown")@\($0.binaryOffset ?? $0.instructionAddress ?? 0)"
+        }
+    }
+
+    private func retentionPriority(_ lhs: StoredCrashReport, _ rhs: StoredCrashReport) -> Bool {
+        let lhsFatal = lhs.report.source != .nonFatal
+        let rhsFatal = rhs.report.source != .nonFatal
+        if lhsFatal != rhsFatal {
+            return lhsFatal
+        }
+        return lhs.createdAt > rhs.createdAt
+    }
+}

--- a/Sources/Services/CrashDiagnostics/CrashDiagnosticsUploader.swift
+++ b/Sources/Services/CrashDiagnostics/CrashDiagnosticsUploader.swift
@@ -1,0 +1,181 @@
+//
+//  CrashDiagnosticsUploader.swift
+//  OsmAnd Maps
+//
+
+import Foundation
+
+enum CrashDiagnosticsUploadError: LocalizedError {
+    case endpointUnavailable
+    case invalidEndpoint
+    case reportTooLarge
+    case rejected(statusCode: Int)
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .endpointUnavailable:
+            return "Crash report upload is unavailable in this build."
+        case .invalidEndpoint:
+            return "The crash report endpoint is invalid."
+        case .reportTooLarge:
+            return "The privacy-filtered crash report exceeds the two MiB transport limit."
+        case let .rejected(statusCode):
+            return "The crash report receiver rejected the report (HTTP \(statusCode))."
+        case .invalidResponse:
+            return "The crash report receiver returned an invalid response."
+        }
+    }
+}
+
+final class CrashDiagnosticsUploader {
+    private let store: CrashDiagnosticsStore
+    private let endpoint: URL?
+    private let session: URLSession
+    private let stateChanged: () -> Void
+    private let callbackQueue = DispatchQueue(label: "net.osmand.crash-diagnostics.uploader")
+    private var reportsInFlight = Set<String>()
+
+    var canUpload: Bool {
+        endpoint != nil
+    }
+
+    init(
+        store: CrashDiagnosticsStore,
+        endpoint: URL? = CrashDiagnosticsUploader.configuredEndpoint(),
+        stateChanged: @escaping () -> Void = {}
+    ) {
+        self.store = store
+        self.endpoint = endpoint
+        self.stateChanged = stateChanged
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.httpShouldSetCookies = false
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 60
+        configuration.waitsForConnectivity = true
+        session = URLSession(configuration: configuration)
+    }
+
+    func uploadApprovedReport(
+        reportID: String,
+        completion: ((Result<Void, Error>) -> Void)? = nil
+    ) {
+        callbackQueue.async {
+            guard !self.reportsInFlight.contains(reportID) else { return }
+            guard let endpoint = self.endpoint else {
+                DispatchQueue.main.async {
+                    completion?(.failure(CrashDiagnosticsUploadError.endpointUnavailable))
+                }
+                return
+            }
+
+            do {
+                let uploadRequest = try self.store.verifiedUploadRequest(reportID: reportID)
+                let body = try CrashDiagnosticsJSON.encoder().encode(uploadRequest)
+                guard body.count <= 2 * 1_024 * 1_024 else {
+                    self.store.markUploadRejected(reportID: reportID)
+                    self.notifyStateChanged()
+                    DispatchQueue.main.async {
+                        completion?(.failure(CrashDiagnosticsUploadError.reportTooLarge))
+                    }
+                    return
+                }
+                var request = URLRequest(url: endpoint)
+                request.httpMethod = "POST"
+                request.httpBody = body
+                request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue(reportID, forHTTPHeaderField: "Idempotency-Key")
+                request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
+
+                self.reportsInFlight.insert(reportID)
+                self.session.dataTask(with: request) { _, response, error in
+                    self.callbackQueue.async {
+                        self.reportsInFlight.remove(reportID)
+                        if let error {
+                            let retryAt = self.store.markUploadFailure(reportID: reportID)
+                            self.notifyStateChanged()
+                            self.scheduleRetry(reportID: reportID, retryAt: retryAt)
+                            DispatchQueue.main.async { completion?(.failure(error)) }
+                            return
+                        }
+                        guard let response = response as? HTTPURLResponse else {
+                            let retryAt = self.store.markUploadFailure(reportID: reportID)
+                            self.notifyStateChanged()
+                            self.scheduleRetry(reportID: reportID, retryAt: retryAt)
+                            DispatchQueue.main.async {
+                                completion?(.failure(CrashDiagnosticsUploadError.invalidResponse))
+                            }
+                            return
+                        }
+                        if (200..<300).contains(response.statusCode) {
+                            self.store.delete(reportID: reportID)
+                            self.notifyStateChanged()
+                            DispatchQueue.main.async { completion?(.success(())) }
+                        } else {
+                            if response.statusCode == 408 || response.statusCode == 429 || response.statusCode >= 500 {
+                                let retryAt = self.store.markUploadFailure(reportID: reportID)
+                                self.scheduleRetry(reportID: reportID, retryAt: retryAt)
+                            } else {
+                                self.store.markUploadRejected(reportID: reportID)
+                            }
+                            self.notifyStateChanged()
+                            DispatchQueue.main.async {
+                                completion?(.failure(
+                                    CrashDiagnosticsUploadError.rejected(statusCode: response.statusCode)
+                                ))
+                            }
+                        }
+                    }
+                }.resume()
+            } catch {
+                self.notifyStateChanged()
+                DispatchQueue.main.async { completion?(.failure(error)) }
+            }
+        }
+    }
+
+    func retryApprovedReports() {
+        for reportID in store.approvedReportsDue() {
+            uploadApprovedReport(reportID: reportID)
+        }
+    }
+
+    private func scheduleRetry(reportID: String, retryAt: Date?) {
+        guard let retryAt else { return }
+        let delay = max(retryAt.timeIntervalSinceNow, 0)
+        callbackQueue.asyncAfter(deadline: .now() + delay) {
+            self.uploadApprovedReport(reportID: reportID)
+        }
+    }
+
+    private func notifyStateChanged() {
+        DispatchQueue.main.async {
+            self.stateChanged()
+        }
+    }
+
+    private static func configuredEndpoint() -> URL? {
+#if DEBUG
+        let environment = ProcessInfo.processInfo.environment
+        if let override = environment["OSMAND_CRASH_ENDPOINT"], !override.isEmpty {
+            guard let url = URL(string: override),
+                  url.scheme == "http" || url.scheme == "https" else {
+                return nil
+            }
+            return url
+        }
+#if targetEnvironment(simulator)
+        return URL(string: "http://127.0.0.1:8080/api/v1/crash-reports")
+#else
+        return nil
+#endif
+#else
+        return nil
+#endif
+    }
+}

--- a/Sources/Services/CrashDiagnostics/CrashDiagnosticsViewController.swift
+++ b/Sources/Services/CrashDiagnostics/CrashDiagnosticsViewController.swift
@@ -1,0 +1,457 @@
+//
+//  CrashDiagnosticsViewController.swift
+//  OsmAnd Maps
+//
+
+import UIKit
+
+@objcMembers
+final class CrashDiagnosticsViewController: UITableViewController {
+    private var reports: [CrashReportSummary] = []
+    private var reportIDToOpen: String?
+
+    @objc(initWithReportIDToOpen:)
+    init(reportIDToOpen: String? = nil) {
+        self.reportIDToOpen = reportIDToOpen
+        super.init(style: .insetGrouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = localizedString("crash_diagnostics")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "CrashReportCell")
+        tableView.backgroundColor = .groupTableViewBackground
+        navigationItem.largeTitleDisplayMode = .never
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reloadReports),
+            name: .crashDiagnosticsReportsDidChange,
+            object: nil
+        )
+#if DEBUG
+        let testItem = UIBarButtonItem(
+            title: localizedString("crash_diagnostics_test"),
+            style: .plain,
+            target: nil,
+            action: nil
+        )
+        testItem.menu = testCrashMenu()
+        navigationItem.rightBarButtonItem = testItem
+#endif
+        reloadReports()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+        configureLeftNavigationItem()
+    }
+
+    override func isNavbarVisible() -> Bool {
+        true
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard let reportIDToOpen else { return }
+        self.reportIDToOpen = nil
+        showReport(reportID: reportIDToOpen)
+    }
+
+    @objc private func reloadReports() {
+        reports = CrashDiagnosticsService.shared.pendingReports()
+        tableView.reloadData()
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        2
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 0 {
+            return 1
+        }
+        return max(reports.count, 1)
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        section == 1 ? localizedString("crash_diagnostics_pending_reports") : nil
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "CrashReportCell")
+        cell.textLabel?.numberOfLines = 0
+        cell.detailTextLabel?.numberOfLines = 0
+        cell.selectionStyle = .default
+
+        if indexPath.section == 0 {
+            cell.textLabel?.text = localizedString("crash_diagnostics_privacy_title")
+            cell.detailTextLabel?.text = localizedString("crash_diagnostics_privacy_description")
+            cell.imageView?.image = UIImage.templateImageNamed("ic_custom_file_info")
+            cell.imageView?.tintColor = .iconColorDefault
+            cell.selectionStyle = .none
+            return cell
+        }
+
+        guard !reports.isEmpty else {
+            cell.textLabel?.text = localizedString("crash_diagnostics_no_reports")
+            cell.detailTextLabel?.text = nil
+            cell.selectionStyle = .none
+            return cell
+        }
+
+        let report = reports[indexPath.row]
+        cell.textLabel?.text = title(for: report)
+        cell.detailTextLabel?.text = "\(report.occurredAt) · \(stateTitle(report.uploadState))"
+        cell.imageView?.image = UIImage.templateImageNamed("ic_custom_file_crashlog_send_outlined")
+        cell.imageView?.tintColor = .iconColorDefault
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.section == 1, !reports.isEmpty else { return }
+        showReport(reportID: reports[indexPath.row].reportID)
+    }
+
+    private func showReport(reportID: String) {
+        let viewController = CrashReportReviewViewController(reportID: reportID)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    private func configureLeftNavigationItem() {
+        guard let navigationController,
+              navigationController.viewControllers.first === self else {
+            navigationItem.leftBarButtonItem = nil
+            navigationItem.hidesBackButton = false
+            return
+        }
+        let closeItem = UIBarButtonItem(
+            title: localizedString("shared_string_close"),
+            style: .plain,
+            target: self,
+            action: #selector(closeScreen)
+        )
+        closeItem.accessibilityLabel = localizedString("shared_string_close")
+        navigationItem.leftBarButtonItem = closeItem
+    }
+
+    @objc private func closeScreen() {
+        dismiss(animated: true)
+    }
+
+    private func title(for report: CrashReportSummary) -> String {
+        switch report.kind {
+        case .hang:
+            return localizedString("crash_diagnostics_hang")
+        case .cpuException:
+            return localizedString("crash_diagnostics_cpu")
+        case .diskWriteException:
+            return localizedString("crash_diagnostics_disk")
+        case .nonFatal:
+            return localizedString("crash_diagnostics_non_fatal")
+        default:
+            return localizedString("crash_diagnostics_crash")
+        }
+    }
+
+    private func stateTitle(_ state: CrashUploadState) -> String {
+        switch state {
+        case .pending:
+            return localizedString("crash_diagnostics_not_sent")
+        case .approved:
+            return localizedString("crash_diagnostics_approved")
+        case .rejected:
+            return localizedString("crash_diagnostics_rejected")
+        }
+    }
+
+#if DEBUG
+    private func testCrashMenu() -> UIMenu {
+        let actions: [(String, Selector)] = [
+            ("Objective-C", #selector(triggerObjectiveCException)),
+            ("C++", #selector(triggerCPPException)),
+            ("SIGABRT", #selector(triggerSignalCrash)),
+            ("Invalid memory", #selector(triggerInvalidMemoryAccess)),
+        ]
+        return UIMenu(
+            title: localizedString("crash_diagnostics_test_warning"),
+            children: actions.map { title, selector in
+                UIAction(title: title, attributes: .destructive) { [weak self] _ in
+                    self?.confirmTestCrash(title: title, selector: selector)
+                }
+            }
+        )
+    }
+
+    private func confirmTestCrash(title: String, selector: Selector) {
+        let alert = UIAlertController(
+            title: localizedString("crash_diagnostics_test"),
+            message: localizedString("crash_diagnostics_test_confirmation"),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: localizedString("shared_string_cancel"), style: .cancel))
+        alert.addAction(UIAlertAction(title: title, style: .destructive) { [weak self] _ in
+            _ = self?.perform(selector)
+        })
+        present(alert, animated: true)
+    }
+
+    @objc private func triggerObjectiveCException() {
+        OACrashDiagnosticsKSCrashBridge.triggerObjectiveCException()
+    }
+
+    @objc private func triggerCPPException() {
+        OACrashDiagnosticsKSCrashBridge.triggerCPPException()
+    }
+
+    @objc private func triggerSignalCrash() {
+        OACrashDiagnosticsKSCrashBridge.triggerSignalCrash()
+    }
+
+    @objc private func triggerInvalidMemoryAccess() {
+        OACrashDiagnosticsKSCrashBridge.triggerInvalidMemoryAccess()
+    }
+#endif
+}
+
+private final class CrashReportReviewViewController: UIViewController, UIDocumentPickerDelegate {
+    private let reportID: String
+    private let textView = UITextView()
+    private let sendButton = UIButton(type: .system)
+    private let deleteButton = UIButton(type: .system)
+    private let laterButton = UIButton(type: .system)
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
+    private var reportJSON: String?
+    private var temporaryExportURL: URL?
+
+    init(reportID: String) {
+        self.reportID = reportID
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = localizedString("crash_diagnostics_review")
+        view.backgroundColor = .systemBackground
+        configureTextView()
+        configureButtons()
+        loadReport()
+        configureExportMenu()
+    }
+
+    private func configureTextView() {
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isEditable = false
+        textView.alwaysBounceVertical = true
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.backgroundColor = .secondarySystemBackground
+        textView.accessibilityLabel = localizedString("crash_diagnostics_payload")
+        view.addSubview(textView)
+    }
+
+    private func configureButtons() {
+        configureButton(sendButton, title: localizedString("crash_diagnostics_send_once"), action: #selector(sendReport))
+        configureButton(deleteButton, title: localizedString("shared_string_delete"), action: #selector(confirmDelete))
+        configureButton(laterButton, title: localizedString("crash_diagnostics_later"), action: #selector(close))
+        deleteButton.tintColor = .systemRed
+        sendButton.isHidden = !CrashDiagnosticsService.shared.canUpload
+
+        let stack = UIStackView(arrangedSubviews: [sendButton, deleteButton, laterButton])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.alignment = .fill
+        stack.distribution = .fillEqually
+        stack.spacing = 8
+        view.addSubview(stack)
+
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(activityIndicator)
+
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            textView.bottomAnchor.constraint(equalTo: stack.topAnchor, constant: -12),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12),
+            stack.heightAnchor.constraint(equalToConstant: 48),
+            activityIndicator.centerXAnchor.constraint(equalTo: sendButton.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: sendButton.centerYAnchor),
+        ])
+    }
+
+    private func configureButton(_ button: UIButton, title: String, action: Selector) {
+        button.setTitle(title, for: .normal)
+        button.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        button.addTarget(self, action: action, for: .touchUpInside)
+    }
+
+    private func loadReport() {
+        do {
+            let json = try CrashDiagnosticsService.shared.prettyPrintedReport(reportID: reportID)
+            reportJSON = json
+            textView.text = json
+        } catch {
+            textView.text = localizedString("crash_diagnostics_report_unavailable")
+            sendButton.isEnabled = false
+            deleteButton.isEnabled = false
+        }
+    }
+
+    private func configureExportMenu() {
+        guard reportJSON != nil else { return }
+        let copyAction = UIAction(
+            title: localizedString("crash_diagnostics_copy_json"),
+            image: UIImage(systemName: "doc.on.doc")
+        ) { [weak self] _ in
+            self?.copyJSON()
+        }
+        let saveAction = UIAction(
+            title: localizedString("crash_diagnostics_save_json"),
+            image: UIImage(systemName: "folder")
+        ) { [weak self] _ in
+            self?.saveJSONFile()
+        }
+        let exportItem = UIBarButtonItem(
+            image: UIImage(systemName: "square.and.arrow.up"),
+            menu: UIMenu(children: [copyAction, saveAction])
+        )
+        exportItem.accessibilityLabel = localizedString("shared_string_export")
+        navigationItem.rightBarButtonItem = exportItem
+    }
+
+    private func copyJSON() {
+        guard let reportJSON else { return }
+        UIPasteboard.general.string = reportJSON
+        navigationItem.prompt = localizedString("crash_diagnostics_copied")
+        UIAccessibility.post(
+            notification: .announcement,
+            argument: localizedString("crash_diagnostics_copied")
+        )
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.navigationItem.prompt = nil
+        }
+    }
+
+    private func saveJSONFile() {
+        guard let reportJSON, let data = reportJSON.data(using: .utf8) else { return }
+        removeTemporaryExport()
+
+        let safeReportID = reportID.filter { $0.isLetter || $0.isNumber || $0 == "-" }
+        let filenameID = safeReportID.isEmpty ? "report" : String(safeReportID.prefix(64))
+        let exportURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OsmAnd-Crash-Report-\(filenameID).json")
+        do {
+            try data.write(
+                to: exportURL,
+                options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+            )
+            temporaryExportURL = exportURL
+            let documentPicker = UIDocumentPickerViewController(
+                forExporting: [exportURL],
+                asCopy: true
+            )
+            documentPicker.delegate = self
+            present(documentPicker, animated: true)
+        } catch {
+            showExportError(error)
+        }
+    }
+
+    func documentPicker(
+        _ controller: UIDocumentPickerViewController,
+        didPickDocumentsAt urls: [URL]
+    ) {
+        removeTemporaryExport()
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        removeTemporaryExport()
+    }
+
+    private func removeTemporaryExport() {
+        guard let temporaryExportURL else { return }
+        try? FileManager.default.removeItem(at: temporaryExportURL)
+        self.temporaryExportURL = nil
+    }
+
+    private func showExportError(_ error: Error) {
+        let alert = UIAlertController(
+            title: localizedString("shared_string_error"),
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: localizedString("shared_string_ok"), style: .default))
+        present(alert, animated: true)
+    }
+
+    @objc private func sendReport() {
+        setSending(true)
+        CrashDiagnosticsService.shared.approveAndSend(reportID: reportID) { [weak self] result in
+            guard let self else { return }
+            self.setSending(false)
+            switch result {
+            case .success:
+                self.finish()
+            case let .failure(error):
+                let alert = UIAlertController(
+                    title: localizedString("shared_string_error"),
+                    message: error.localizedDescription,
+                    preferredStyle: .alert
+                )
+                alert.addAction(UIAlertAction(title: localizedString("shared_string_ok"), style: .default))
+                self.present(alert, animated: true)
+            }
+        }
+    }
+
+    @objc private func confirmDelete() {
+        let alert = UIAlertController(
+            title: localizedString("crash_diagnostics_delete_title"),
+            message: localizedString("crash_diagnostics_delete_description"),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: localizedString("shared_string_cancel"), style: .cancel))
+        alert.addAction(UIAlertAction(title: localizedString("shared_string_delete"), style: .destructive) { [weak self] _ in
+            guard let self else { return }
+            CrashDiagnosticsService.shared.delete(reportID: self.reportID)
+            self.finish()
+        })
+        present(alert, animated: true)
+    }
+
+    @objc private func close() {
+        finish()
+    }
+
+    private func setSending(_ sending: Bool) {
+        sendButton.setTitle(sending ? nil : localizedString("crash_diagnostics_send_once"), for: .normal)
+        sendButton.isEnabled = !sending
+        deleteButton.isEnabled = !sending
+        laterButton.isEnabled = !sending
+        sending ? activityIndicator.startAnimating() : activityIndicator.stopAnimating()
+    }
+
+    private func finish() {
+        if let navigationController, navigationController.viewControllers.first != self {
+            navigationController.popViewController(animated: true)
+        } else {
+            dismiss(animated: true)
+        }
+    }
+}

--- a/Sources/Services/CrashDiagnostics/OACrashDiagnosticsKSCrashBridge.h
+++ b/Sources/Services/CrashDiagnostics/OACrashDiagnosticsKSCrashBridge.h
@@ -1,0 +1,25 @@
+//
+//  OACrashDiagnosticsKSCrashBridge.h
+//  OsmAnd Maps
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OACrashDiagnosticsKSCrashBridge : NSObject
+
++ (BOOL)installAtPath:(NSString *)installPath NS_SWIFT_NAME(install(atPath:));
++ (NSArray<NSDictionary<NSString *, id> *> *)pendingReports;
++ (void)deleteReportWithID:(int64_t)reportID NS_SWIFT_NAME(deleteReport(withID:));
+
+#if DEBUG
++ (void)triggerObjectiveCException;
++ (void)triggerSignalCrash;
++ (void)triggerInvalidMemoryAccess;
++ (void)triggerCPPException;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Services/CrashDiagnostics/OACrashDiagnosticsKSCrashBridge.mm
+++ b/Sources/Services/CrashDiagnostics/OACrashDiagnosticsKSCrashBridge.mm
@@ -1,0 +1,101 @@
+//
+//  OACrashDiagnosticsKSCrashBridge.mm
+//  OsmAnd Maps
+//
+
+#import "OACrashDiagnosticsKSCrashBridge.h"
+
+#import <KSCrash.h>
+#import <KSCrashConfiguration.h>
+#import <KSCrashReport.h>
+#import <KSCrashReportStore.h>
+
+#include <signal.h>
+#include <stdexcept>
+
+@implementation OACrashDiagnosticsKSCrashBridge
+
++ (BOOL)installAtPath:(NSString *)installPath
+{
+    static BOOL installed = NO;
+    if (installed)
+        return YES;
+
+    KSCrashConfiguration *configuration = [KSCrashConfiguration new];
+    configuration.installPath = installPath;
+    configuration.reportStoreConfiguration.reportsPath = [installPath stringByAppendingPathComponent:@"RawReports"];
+    configuration.reportStoreConfiguration.maxReportCount = 3;
+    configuration.reportStoreConfiguration.reportCleanupPolicy = KSCrashReportCleanupPolicyNever;
+    configuration.monitors = KSCrashMonitorTypeMachException
+        | KSCrashMonitorTypeSignal
+        | KSCrashMonitorTypeCPPException
+        | KSCrashMonitorTypeNSException
+        | KSCrashMonitorTypeSystem
+        | KSCrashMonitorTypeApplicationState;
+    configuration.deadlockWatchdogInterval = 0;
+    configuration.enableQueueNameSearch = NO;
+    configuration.enableMemoryIntrospection = NO;
+    configuration.doNotIntrospectClasses = @[];
+    configuration.addConsoleLogToReport = NO;
+    configuration.printPreviousLogOnStartup = NO;
+    configuration.enableSigTermMonitoring = NO;
+    configuration.userInfoJSON = @{ @"privacy_schema" : @1 };
+
+    NSError *error = nil;
+    installed = [KSCrash.sharedInstance installWithConfiguration:configuration error:&error];
+    if (!installed)
+        NSLog(@"[CrashDiagnostics] KSCrash installation failed: %@", error.localizedDescription ?: @"unknown");
+    return installed;
+}
+
++ (NSArray<NSDictionary<NSString *, id> *> *)pendingReports
+{
+    KSCrashReportStore *store = KSCrash.sharedInstance.reportStore;
+    if (store == nil)
+        return @[];
+
+    NSMutableArray<NSDictionary<NSString *, id> *> *reports = [NSMutableArray array];
+    for (NSNumber *reportID in store.reportIDs)
+    {
+        KSCrashReportDictionary *report = [store reportForID:reportID.longLongValue];
+        if (report != nil)
+        {
+            [reports addObject:@{
+                @"report_id" : reportID,
+                @"report" : report.value,
+            }];
+        }
+    }
+    return reports;
+}
+
++ (void)deleteReportWithID:(int64_t)reportID
+{
+    [KSCrash.sharedInstance.reportStore deleteReportWithID:reportID];
+}
+
+#if DEBUG
++ (void)triggerObjectiveCException
+{
+    [NSException raise:@"OsmAndCrashDiagnosticsTest"
+                format:@"Intentional crash generated from the diagnostics developer menu"];
+}
+
++ (void)triggerSignalCrash
+{
+    raise(SIGABRT);
+}
+
++ (void)triggerInvalidMemoryAccess
+{
+    volatile int *invalidAddress = (int *)0x1;
+    *invalidAddress = 1;
+}
+
++ (void)triggerCPPException
+{
+    throw std::runtime_error("Intentional OsmAnd crash diagnostics C++ test");
+}
+#endif
+
+@end


### PR DESCRIPTION
- integrate KSCrash through SPM and collect MetricKit diagnostics
- sanitize and persist crash context, breadcrumbs, and non-fatal reports
- require per-report review and consent before upload
- add pending-report banner, diagnostics screen, and test crash controls
- add local Python receiver and human-readable HTML reviewer
- update privacy declarations, documentation, fixtures, and tests