### PR TITLE
sync CommonWords and Abbreviations. Turn on fixed search tests

### DIFF
--- a/OsmAnd MapsTests/Search/SearchUICoreTest.mm
+++ b/OsmAnd MapsTests/Search/SearchUICoreTest.mm
@@ -69,7 +69,6 @@ static BOOL TEST_EXTRA_RESULTS = YES;
 
 - (void) testSearch
 {
-    XCTSkip(@"Temporarily disabled because the search test is broken.");
     _successCount = 0;
     _failedCount = 0;
     _firstResultCount = 0;

--- a/Sources/AppHost/OsmAndAppImpl.mm
+++ b/Sources/AppHost/OsmAndAppImpl.mm
@@ -1170,7 +1170,7 @@
     {
         qRegionNames.append(QString::fromNSString(region));
     }
-    OsmAnd::CommonWords::addAllRegions(qRegionNames);
+    OsmAnd::CommonWords::getInstance().addRegionNames(qRegionNames);
 }
 
 - (void)parseRegionNames:(OAWorldRegion *)region result:(NSMutableArray<NSString *> *)result

--- a/Sources/AppHost/OsmAndAppImpl.mm
+++ b/Sources/AppHost/OsmAndAppImpl.mm
@@ -1170,7 +1170,7 @@
     {
         qRegionNames.append(QString::fromNSString(region));
     }
-    OsmAnd::CommonWords::getInstance().addRegionNames(qRegionNames);
+    OsmAnd::CommonWords::getInstance(qRegionNames);
 }
 
 - (void)parseRegionNames:(OAWorldRegion *)region result:(NSMutableArray<NSString *> *)result

--- a/Sources/Search/OAAbbreviations.h
+++ b/Sources/Search/OAAbbreviations.h
@@ -6,14 +6,19 @@
 //  Copyright © 2021 OsmAnd. All rights reserved.
 //
 //  OsmAnd-java/src/main/java/net/osmand/binary/Abbreviations.java
-//  git revision /54e26c5a6195beb371c210746c5d89674016b9f7
+//  git revision 383f15bc221f56ee5a60072f8226898221c20076
 
 #import <Foundation/Foundation.h>
 
 @interface OAAbbreviations : NSObject
 
++ (BOOL) likelyPartOfRef:(NSString *)word wordSplit:(NSSet<NSString *> *)wordSplit;
++ (BOOL) likelyPartOfBuilding:(NSString *)word wordSplit:(NSSet<NSString *> *)wordSplit;
++ (NSDictionary<NSString *, NSString *> *) getSearchAbbreviations;
++ (BOOL) isCommonSkipOtherCnt:(NSString *)lowerCase;
 + (NSString *) replace:(NSString *)word;
 + (NSString *) replaceAll:(NSString *)phrase;
-+ (NSDictionary *) getAbbreviations;
++ (NSDictionary<NSString *, NSString *> *) getAbbreviations;
++ (BOOL) isConjunction:(NSString *)lowerCase;
 
 @end

--- a/Sources/Search/OAAbbreviations.mm
+++ b/Sources/Search/OAAbbreviations.mm
@@ -1,5 +1,5 @@
 //
-//  OAAbbreviations.m
+//  OAAbbreviations.mm
 //  OsmAnd Maps
 //
 //  Created by plotva on 30.04.2021.
@@ -8,59 +8,75 @@
 
 #import <Foundation/Foundation.h>
 #import "OAAbbreviations.h"
-#import "OASearchPhrase.h"
+
+#include <OsmAndCore/Search/Abbreviations.h>
+
+static QSet<QString> OAAbbreviationsToQSet(NSSet<NSString *> *values)
+{
+    QSet<QString> result;
+    for (NSString *value in values)
+    {
+        result.insert(QString::fromNSString(value));
+    }
+    return result;
+}
+
+static NSDictionary<NSString *, NSString *> *OAAbbreviationsToNSDictionary(
+    const QHash<QString, QString>& values)
+{
+    NSMutableDictionary<NSString *, NSString *> *result =
+        [NSMutableDictionary dictionaryWithCapacity:values.size()];
+    for (auto it = values.constBegin(); it != values.constEnd(); ++it)
+    {
+        result[it.key().toNSString()] = it.value().toNSString();
+    }
+    return [result copy];
+}
 
 @implementation OAAbbreviations
 
-static NSDictionary *ABBREVIATIONS = @{ @"e" : @"East",
-                                 @"w" : @"West",
-                                 @"s" : @"South",
-                                 @"n" : @"North",
-                                 @"sw" : @"Southwest",
-                                 @"se" : @"Southeast",
-                                 @"nw" : @"Northwest",
-                                 @"ne" : @"Northeast",
-                                 @"ln" : @"Lane",
-                                 @"dr" : @"Drive",
-                                 @"rd" : @"Road",
-                                 @"ave" : @"Avenue",
-                                 @"st"  : @"Street",
-                                 @"blvd" : @"Boulevard"
-};
++ (BOOL) likelyPartOfRef:(NSString *)word wordSplit:(NSSet<NSString *> *)wordSplit
+{
+    const QSet<QString> qWordSplit = OAAbbreviationsToQSet(wordSplit);
+    return OsmAnd::Abbreviations::likelyPartOfRef(QString::fromNSString(word), qWordSplit);
+}
+
++ (BOOL) likelyPartOfBuilding:(NSString *)word wordSplit:(NSSet<NSString *> *)wordSplit
+{
+    const QSet<QString> qWordSplit = OAAbbreviationsToQSet(wordSplit);
+    return OsmAnd::Abbreviations::likelyPartOfBuilding(
+        QString::fromNSString(word),
+        wordSplit == nil ? nullptr : &qWordSplit);
+}
+
++ (NSDictionary<NSString *, NSString *> *) getSearchAbbreviations
+{
+    return OAAbbreviationsToNSDictionary(OsmAnd::Abbreviations::getSearchabbreviations());
+}
+
++ (BOOL) isCommonSkipOtherCnt:(NSString *)lowerCase
+{
+    return OsmAnd::Abbreviations::isCommonSkipOtherCnt(QString::fromNSString(lowerCase));
+}
 
 + (NSString *) replace:(NSString *)word
 {
-    NSString *value = ABBREVIATIONS[[word lowercaseString]];
-    return value ? value : word;
+    return OsmAnd::Abbreviations::replace(QString::fromNSString(word)).toNSString();
 }
 
 + (NSString *) replaceAll:(NSString *)phrase
 {
-    NSArray<NSString *> *words = [phrase componentsSeparatedByString:[OASearchPhrase getDelimiter]];
-    NSMutableString *r = [NSMutableString new];
-    BOOL changed = NO;
-    for (NSString *word in words)
-    {
-        if ([r length] > 0)
-            [r appendString:[OASearchPhrase getDelimiter]];
-        
-        NSString *abbrRes = [ABBREVIATIONS objectForKey:[word lowercaseString]];
-        if (abbrRes == nil)
-        {
-            [r appendString:word];
-        }
-        else
-        {
-            changed = YES;
-            [r appendString:abbrRes];
-        }
-    }
-    return changed ? [NSString stringWithString:r] : phrase;
+    return OsmAnd::Abbreviations::replaceAll(QString::fromNSString(phrase)).toNSString();
 }
 
-+ (NSDictionary *) getAbbreviations
++ (NSDictionary<NSString *, NSString *> *) getAbbreviations
 {
-    return ABBREVIATIONS;
+    return OAAbbreviationsToNSDictionary(OsmAnd::Abbreviations::getAbbreviations());
+}
+
++ (BOOL) isConjunction:(NSString *)lowerCase
+{
+    return OsmAnd::Abbreviations::isConjunction(QString::fromNSString(lowerCase));
 }
 
 @end

--- a/Sources/Search/OAAbbreviations.mm
+++ b/Sources/Search/OAAbbreviations.mm
@@ -51,7 +51,7 @@ static NSDictionary<NSString *, NSString *> *OAAbbreviationsToNSDictionary(
 
 + (NSDictionary<NSString *, NSString *> *) getSearchAbbreviations
 {
-    return OAAbbreviationsToNSDictionary(OsmAnd::Abbreviations::getSearchabbreviations());
+    return OAAbbreviationsToNSDictionary(OsmAnd::Abbreviations::getSearchAbbreviations());
 }
 
 + (BOOL) isCommonSkipOtherCnt:(NSString *)lowerCase

--- a/Sources/Search/OASearchCoreFactory.mm
+++ b/Sources/Search/OASearchCoreFactory.mm
@@ -596,7 +596,7 @@
 {
     for (NSString * leftUnknownSearchWord in [res filterUnknownSearchWord:nil])
     {
-        BOOL isNumber2Letters = OsmAnd::CommonWords::isNumber2Letters(QString::fromNSString(leftUnknownSearchWord));
+        BOOL isNumber2Letters = OsmAnd::SearchAlgorithms::isNumber2Letters(QString::fromNSString(leftUnknownSearchWord));
         if (!isNumber2Letters)
         {
             return YES;
@@ -2210,7 +2210,7 @@
             }
         }
         QString streetIntersection = s->intersectedStreets.size() > 0 ? QString::fromNSString([phrase getUnknownWordToSearch]) : QString();
-        if (streetIntersection.isEmpty() || (!streetIntersection[0].isDigit() && OsmAnd::CommonWords::getCommonSearch(streetIntersection) == -1))
+        if (streetIntersection.isEmpty() || (!streetIntersection[0].isDigit() && OsmAnd::CommonWords::getInstance().getCommonSearch(streetIntersection) == -1))
         {
             for (const auto& street : s->intersectedStreets)
             {

--- a/Sources/Search/OASearchPhrase.mm
+++ b/Sources/Search/OASearchPhrase.mm
@@ -35,7 +35,6 @@ static NSString *ALLDELIMITERS = @"\\s|,";
 static NSString *ALLDELIMITERS_WITH_HYPHEN = @"\\s|,|-";
 static NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:ALLDELIMITERS options:0 error:nil];
 
-static NSSet<NSString *> *conjunctions;
 static NSCharacterSet *allDelimitersSet;
 
 static const int ZOOM_TO_SEARCH_POI = 16;
@@ -93,26 +92,6 @@ static NSCache<NSString*, NSNumber*> *sCommonWordWeightCache = nil;
     if (self == [OASearchPhrase class])
     {
         allDelimitersSet = [NSCharacterSet characterSetWithCharactersInString:ALLDELIMITERS];
-        conjunctions = [NSSet setWithObjects:
-                        // the
-                        @"the",
-                        @"der",
-                        @"den",
-                        @"die",
-                        @"das",
-                        @"la",
-                        @"le",
-                        @"el",
-                        @"il",
-                        // and
-                        @"and",
-                        @"und",
-                        @"en",
-                        @"et",
-                        @"y",
-                        @"и",
-                        // Don't add short names !  issues for perfect matching "Drive A", ...
-                        nil];
         sCommonWordWeightCache = [NSCache new];
         sCommonWordWeightCache.countLimit = 100;
     }
@@ -141,7 +120,7 @@ static NSCache<NSString*, NSNumber*> *sCommonWordWeightCache = nil;
             }
             else
             {
-                int value = OsmAnd::CommonWords::getCommonSearch(QString::fromNSString(key));
+                int value = OsmAnd::CommonWords::getInstance().getCommonSearch(QString::fromNSString(key));
                 NSNumber *num = @(value);
                 weights[w] = num;
                 [sCommonWordWeightCache setObject:num forKey:key];
@@ -205,7 +184,7 @@ static NSCache<NSString*, NSNumber*> *sCommonWordWeightCache = nil;
         for (NSInteger i = 0; i < ws.count; i++)
         {
             NSString *wd = [ws[i] trim];
-            BOOL conjunction = [conjunctions containsObject:wd.lowerCase];
+            BOOL conjunction = [OAAbbreviations isConjunction:wd.lowerCase];
             BOOL lastAndComplete = i == (ws.count - 1) && !sp.lastUnknownSearchWordComplete;
             BOOL decryptAbbreviations = [self needDecryptAbbreviations];
             if (wd.length > 0 && (!conjunction || lastAndComplete))


### PR DESCRIPTION

[test search after log.txt](https://github.com/user-attachments/files/30536727/test.search.after.log.txt)
[issue](https://github.com/osmandapp/OsmAnd/issues/24943#issuecomment-5043353152)

[related core request](https://github.com/osmandapp/OsmAnd-core/pull/1087)

---

- Synced [CommonWords.java](https://github.com/osmandapp/Osmand/blob/5e3cda75836097f09709f8266c75bdb42efd7f23/OsmAnd-java/src/main/java/net/osmand/binary/CommonWords.java)
- Synced [Abbreviations.java](https://github.com/osmandapp/OsmAnd/blob/5e3cda75836097f09709f8266c75bdb42efd7f23/OsmAnd-java/src/main/java/net/osmand/binary/Abbreviations.java)
- Turned on SearchUICoreTest.mm
- Fixed falling search tests in SearchUICoreTest.mm

<img width="300" alt="Screenshot 2026-07-30 at 12 43 00" src="https://github.com/user-attachments/assets/d75061b6-8d75-447d-b710-c4173bf76dda" />
<img width="300"  alt="Screenshot 2026-07-30 at 12 48 01" src="https://github.com/user-attachments/assets/9ded443e-627a-4037-ab40-cc6ce39bdf41" />

[test search before log.txt](https://github.com/user-attachments/files/30536726/test.search.before.log.txt)

[test search after log.txt](https://github.com/user-attachments/files/30536762/test.search.after.log.txt)


---

**Hauptstrasse 1** (before 8 sec / after 7 sec)

<img width="929" height="919" alt="Screenshot 2026-07-28 at 16 07 10" src="https://github.com/user-attachments/assets/522610ea-489d-4709-bddf-b2acb861ca5d" />

<details><summary>Video</summary>
  <table style="width:100%">
    <tr>
      <td><video src="https://github.com/user-attachments/assets/40fdd330-6f53-40f5-a736-4d5397be1973" width="300" height="auto"></video></td>
      <td><video src="https://github.com/user-attachments/assets/2c299514-0733-4486-9a86-f9cc5dbc3878" width="300" height="auto"></video></td>
    </tr>
  </table>
</details>

---

**Dorfstraße 6**  (before 8 sec / after 7 sec)

<img width="930" height="915" alt="Screenshot 2026-07-28 at 16 08 10" src="https://github.com/user-attachments/assets/decf41e1-e84e-433e-b0d0-ad9df15523d8" />

<details><summary>Video</summary>
  <table style="width:100%">
    <tr>
      <td><video src="https://github.com/user-attachments/assets/bd42cbb2-0149-48d6-9d93-ea4da818573e" width="300" height="auto"></video></td>
      <td><video src="https://github.com/user-attachments/assets/93b95a5b-5e77-444c-b096-9ca3e33f65d5" width="300" height="auto"></video></td>
    </tr>
  </table>
</details>

---

**Bahnhofstraße 10**  (before 6 sec / after 6 sec)

<img width="928" height="919" alt="Screenshot 2026-07-28 at 16 09 13" src="https://github.com/user-attachments/assets/60dc3ea6-c69a-4da4-b3f9-f964615d824a" />

<details><summary>Video</summary>
  <table style="width:100%">
    <tr>
      <td><video src="https://github.com/user-attachments/assets/ce906ed3-52a4-4883-8d14-4e21acf7a2d5" width="300" height="auto"></video></td>
      <td><video src="https://github.com/user-attachments/assets/37346a9c-c7cd-4463-b9f4-b61c26db51e4" width="300" height="auto"></video></td>
    </tr>
  </table>
</details>

---

**Dosse 1A hauptstr**   (before 11 sec / after 10 sec)

<img width="930" height="915" alt="Screenshot 2026-07-28 at 16 10 26" src="https://github.com/user-attachments/assets/b903d22c-b845-429b-b09b-30ca076c5ec0" />

<details><summary>Video</summary>
  <table style="width:100%">
    <tr>
      <td><video src="https://github.com/user-attachments/assets/c2616e32-c339-4cb1-b612-351dbb5b7452" width="300" height="auto"></video></td>
      <td><video src="https://github.com/user-attachments/assets/afed6133-2b7f-4a4b-be98-30b80cc069db" width="300" height="auto"></video></td>
    </tr>
  </table>
</details>


---

**Neustadt 1A hauptstrasse**   (before 10 sec / after 8 sec)

<img width="929" height="912" alt="Screenshot 2026-07-28 at 16 11 14" src="https://github.com/user-attachments/assets/65c714ed-fcc0-40c8-8e9d-0e6beb48f32d" />

<details><summary>Video</summary>
  <table style="width:100%">
    <tr>
      <td><video src="https://github.com/user-attachments/assets/ef9e1853-fde4-4805-a38d-a646acadec7b" width="300" height="auto"></video></td>
      <td><video src="https://github.com/user-attachments/assets/23d5499f-87dd-4218-9892-bb722fad737f" width="300" height="auto"></video></td>
    </tr>
  </table>
</details>


---

Testing context:
map center:  52.51739 13.39513
map files: all Germany and all Austria maps.

