### PR TITLE
Support routing params in route deep links

### DIFF
--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -1726,6 +1726,7 @@
 		CE7F960C30025BA0000F2F22 /* StarMapObjectContextMenuBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F960B30025BA0000F2F22 /* StarMapObjectContextMenuBuilder.swift */; };
 		CE8215E52FFF6376002A8617 /* StarMapArControlCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8215E42FFF6376002A8617 /* StarMapArControlCard.swift */; };
 		CE8215E72FFF6AF9002A8617 /* StarMapPlainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8215E62FFF6AF9002A8617 /* StarMapPlainButton.swift */; };
+		CE826BA1301B5B5700BD0DCE /* OARoutingParamsDeepLinkBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = CE826BA0301B5B5700BD0DCE /* OARoutingParamsDeepLinkBridge.mm */; };
 		CE83DB4A2FEE4B20002D7685 /* StarMapSearchSortFilterChipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE83DB492FEE4B20002D7685 /* StarMapSearchSortFilterChipsView.swift */; };
 		CE83DB4C2FEE4B20002D7685 /* StarMapSearchSortFilterChipsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE83DB4B2FEE4B20002D7685 /* StarMapSearchSortFilterChipsProvider.swift */; };
 		CE8A82A92FCFE11F00EADFD8 /* MapVariantReplacementManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8A82A82FCFE11F00EADFD8 /* MapVariantReplacementManager.swift */; };
@@ -5781,6 +5782,8 @@
 		CE7F960B30025BA0000F2F22 /* StarMapObjectContextMenuBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarMapObjectContextMenuBuilder.swift; sourceTree = "<group>"; };
 		CE8215E42FFF6376002A8617 /* StarMapArControlCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarMapArControlCard.swift; sourceTree = "<group>"; };
 		CE8215E62FFF6AF9002A8617 /* StarMapPlainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarMapPlainButton.swift; sourceTree = "<group>"; };
+		CE826B9F301B5B4500BD0DCE /* OARoutingParamsDeepLinkBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OARoutingParamsDeepLinkBridge.h; sourceTree = "<group>"; };
+		CE826BA0301B5B5700BD0DCE /* OARoutingParamsDeepLinkBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OARoutingParamsDeepLinkBridge.mm; sourceTree = "<group>"; };
 		CE83DB492FEE4B20002D7685 /* StarMapSearchSortFilterChipsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarMapSearchSortFilterChipsView.swift; sourceTree = "<group>"; };
 		CE83DB4B2FEE4B20002D7685 /* StarMapSearchSortFilterChipsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarMapSearchSortFilterChipsProvider.swift; sourceTree = "<group>"; };
 		CE8A82A82FCFE11F00EADFD8 /* MapVariantReplacementManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapVariantReplacementManager.swift; sourceTree = "<group>"; };
@@ -14448,6 +14451,8 @@
 				DA5A810126C563A600F274C7 /* OAWaypointHelper.mm */,
 				DABC7F2027B65FD6005C76E2 /* OARoutingHelperUtils.h */,
 				DABC7F2127B65FD6005C76E2 /* OARoutingHelperUtils.mm */,
+				CE826B9F301B5B4500BD0DCE /* OARoutingParamsDeepLinkBridge.h */,
+				CE826BA0301B5B5700BD0DCE /* OARoutingParamsDeepLinkBridge.mm */,
 				46BB3677294BE72100155EC8 /* OAEmissionHelper.h */,
 				46BB3678294BE77200155EC8 /* OAEmissionHelper.mm */,
 				461FB12C2987FDFA00097673 /* OAAnnounceTimeDistances.h */,
@@ -17988,6 +17993,7 @@
 				DA5A857026C563A900F274C7 /* OARouteCalculationParams.mm in Sources */,
 				DA5A816D26C563A700F274C7 /* OsmAndAppImpl.mm in Sources */,
 				323F04CA2C6579280058DD78 /* ShowHideFitnessTrailsAction.swift in Sources */,
+				CE826BA1301B5B5700BD0DCE /* OARoutingParamsDeepLinkBridge.mm in Sources */,
 				DA5A856F26C563A900F274C7 /* OAAlarmInfo.mm in Sources */,
 				32D253B327F336C200324717 /* OACloudAccountLoginViewController.m in Sources */,
 				DA5A83CD26C563A800F274C7 /* OATransportRouteController.mm in Sources */,

--- a/Sources/Controllers/TargetMenu/Routing/OARouteDetailsViewController.xib
+++ b/Sources/Controllers/TargetMenu/Routing/OARouteDetailsViewController.xib
@@ -67,7 +67,7 @@
                     </subviews>
                     <color key="backgroundColor" name="groupBg"/>
                     <constraints>
-                        <constraint firstAttribute="bottom" secondItem="jdG-1m-7Mk" secondAttribute="bottom" constant="3" id="2yS-HP-COC"/>
+                        <constraint firstAttribute="bottom" secondItem="jdG-1m-7Mk" secondAttribute="bottom" constant="6" id="2yS-HP-COC"/>
                         <constraint firstItem="U3D-Z8-K0Z" firstAttribute="leading" secondItem="42a-aj-Np6" secondAttribute="trailing" constant="5" id="4yb-C0-cH5"/>
                         <constraint firstAttribute="bottom" secondItem="42a-aj-Np6" secondAttribute="bottom" constant="6" id="R2k-8F-djo"/>
                         <constraint firstItem="U3D-Z8-K0Z" firstAttribute="centerX" secondItem="PEh-9Y-73x" secondAttribute="centerX" id="UeG-wc-Nwq"/>

--- a/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
+++ b/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
@@ -393,7 +393,7 @@ final class DeepLinkParser: NSObject {
         var intermediatePointsParam: String?
         var endLatLonParam: String?
         var appModeKeyParam: String?
-        var routingParamsParam: String?
+        var routeParamsQueryValue: String?
         for item in queryItems {
             switch item.name.lowercased() {
             case "end":
@@ -406,7 +406,7 @@ final class DeepLinkParser: NSObject {
             case "via":
                 intermediatePointsParam = item.value
             case "params":
-                routingParamsParam = item.value
+                routeParamsQueryValue = item.value
             default:
                 break
             }
@@ -441,8 +441,8 @@ final class DeepLinkParser: NSObject {
         }
         
         let mode = appMode ?? OARoutingHelper.sharedInstance().getAppMode()
-        if let routingParamsParam, !routingParamsParam.isEmpty {
-            OARoutingHelperUtils.applyRoutingParamsQueryValue(routingParamsParam, forAppMode: mode)
+        if let routeParamsQueryValue, !routeParamsQueryValue.isEmpty {
+            OARoutingHelperUtils.applyRoutingParamsQueryValue(routeParamsQueryValue, forAppMode: mode)
         }
         
         let points = parseIntermediatePoints(intermediatePointsParam)

--- a/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
+++ b/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
@@ -442,7 +442,7 @@ final class DeepLinkParser: NSObject {
         
         let mode = appMode ?? OARoutingHelper.sharedInstance().getAppMode()
         if let routeParamsQueryValue, !routeParamsQueryValue.isEmpty {
-            OARoutingHelperUtils.applyRoutingParamsQueryValue(routeParamsQueryValue, forAppMode: mode)
+            OARoutingParamsDeepLinkBridge.applyRoutingParamsQueryValue(routeParamsQueryValue, forAppMode: mode)
         }
         
         let points = parseIntermediatePoints(intermediatePointsParam)

--- a/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
+++ b/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
@@ -393,7 +393,11 @@ final class DeepLinkParser: NSObject {
         var intermediatePointsParam: String?
         var endLatLonParam: String?
         var appModeKeyParam: String?
-        var routeParamsQueryValue: String?
+        
+        // TODO: Next release — apply deep-link routing `params`
+        // https://github.com/osmandapp/OsmAnd-Issues/issues/1860
+        // var routeParamsQueryValue: String?
+        
         for item in queryItems {
             switch item.name.lowercased() {
             case "end":
@@ -405,8 +409,13 @@ final class DeepLinkParser: NSObject {
                 appModeKeyParam = item.value
             case "via":
                 intermediatePointsParam = item.value
+                
+            // TODO: Next release — apply deep-link routing `params`
+            // https://github.com/osmandapp/OsmAnd-Issues/issues/1860
+            /*
             case "params":
                 routeParamsQueryValue = item.value
+            */
             default:
                 break
             }
@@ -440,10 +449,14 @@ final class DeepLinkParser: NSObject {
             NSLog("App mode with specified key not available, using default navigation app mode")
         }
         
+        // TODO: Next release — apply deep-link routing `params`
+        // https://github.com/osmandapp/OsmAnd-Issues/issues/1860
+        /*
         let mode = appMode ?? OARoutingHelper.sharedInstance().getAppMode()
         if let routeParamsQueryValue, !routeParamsQueryValue.isEmpty {
             OARoutingParamsDeepLinkBridge.applyRoutingParamsQueryValue(routeParamsQueryValue, forAppMode: mode)
         }
+         */
         
         let points = parseIntermediatePoints(intermediatePointsParam)
         rootViewController.mapPanel.buildRoute(startLatLon, end: endLatLon, appMode: appMode, points: points)

--- a/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
+++ b/Sources/Helpers/DeepLinkManager/DeepLinkParser.swift
@@ -393,6 +393,7 @@ final class DeepLinkParser: NSObject {
         var intermediatePointsParam: String?
         var endLatLonParam: String?
         var appModeKeyParam: String?
+        var routingParamsParam: String?
         for item in queryItems {
             switch item.name.lowercased() {
             case "end":
@@ -404,6 +405,8 @@ final class DeepLinkParser: NSObject {
                 appModeKeyParam = item.value
             case "via":
                 intermediatePointsParam = item.value
+            case "params":
+                routingParamsParam = item.value
             default:
                 break
             }
@@ -435,6 +438,11 @@ final class DeepLinkParser: NSObject {
         let appMode = OAApplicationMode.value(ofStringKey: appModeKeyParam, def: nil)
         if let appModeKeyParam, !appModeKeyParam.isEmpty, appMode == nil {
             NSLog("App mode with specified key not available, using default navigation app mode")
+        }
+        
+        let mode = appMode ?? OARoutingHelper.sharedInstance().getAppMode()
+        if let routingParamsParam, !routingParamsParam.isEmpty {
+            OARoutingHelperUtils.applyRoutingParamsQueryValue(routingParamsParam, forAppMode: mode)
         }
         
         let points = parseIntermediatePoints(intermediatePointsParam)

--- a/Sources/Helpers/DeepLinkManager/RouteDeepLinkBuilder.swift
+++ b/Sources/Helpers/DeepLinkManager/RouteDeepLinkBuilder.swift
@@ -17,7 +17,7 @@ final class RouteDeepLinkBuilder: NSObject {
         
         func percentEncodedQueryValue(_ value: String) -> String {
             var allowed = CharacterSet.urlQueryAllowed
-            allowed.remove(charactersIn: ",;")
+            allowed.remove(charactersIn: ",;:")
             return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
         }
         
@@ -29,7 +29,7 @@ final class RouteDeepLinkBuilder: NSObject {
         var components = URLComponents()
         components.scheme = kHttpsScheme
         components.host = kOsmAndHost
-        components.path = kOsmAndMapPathPrefix
+        components.path = kOsmAndMapPathPrefix + "/navigate"
 
         var items: [URLQueryItem] = []
 
@@ -47,10 +47,13 @@ final class RouteDeepLinkBuilder: NSObject {
             items.append(URLQueryItem(name: "end", value: formatLatLon(end.point)))
         }
 
-        items.append(URLQueryItem(
-            name: "profile",
-            value: OARoutingHelper.sharedInstance().getAppMode().stringKey
-        ))
+        let appMode = OARoutingHelper.sharedInstance().getAppMode()
+        items.append(URLQueryItem(name: "profile", value: appMode.stringKey))
+        
+        if let params = OARoutingHelperUtils.routingParamsQueryValue(forAppMode: appMode), !params.isEmpty {
+            items.append(URLQueryItem(name: "params", value: params))
+        }
+        
         components.percentEncodedQueryItems = items.map {
             URLQueryItem(name: $0.name, value: $0.value.map(percentEncodedQueryValue))
         }

--- a/Sources/Helpers/DeepLinkManager/RouteDeepLinkBuilder.swift
+++ b/Sources/Helpers/DeepLinkManager/RouteDeepLinkBuilder.swift
@@ -50,7 +50,7 @@ final class RouteDeepLinkBuilder: NSObject {
         let appMode = OARoutingHelper.sharedInstance().getAppMode()
         items.append(URLQueryItem(name: "profile", value: appMode.stringKey))
         
-        if let params = OARoutingHelperUtils.routingParamsQueryValue(forAppMode: appMode), !params.isEmpty {
+        if let params = OARoutingParamsDeepLinkBridge.routingParamsQueryValue(forAppMode: appMode), !params.isEmpty {
             items.append(URLQueryItem(name: "params", value: params))
         }
         

--- a/Sources/OsmAnd Maps-Bridging-Header.h
+++ b/Sources/OsmAnd Maps-Bridging-Header.h
@@ -120,7 +120,7 @@
 #import "OAFavoriteFolderBridgeItem.h"
 #import "OAFavoritePointBridgeItem.h"
 #import "OATrackPreviewMapRenderer.h"
-#import "OARoutingHelperUtils.h"
+#import "OARoutingParamsDeepLinkBridge.h"
 
 // Widgets
 #import "OAMapWidgetRegistry.h"

--- a/Sources/OsmAnd Maps-Bridging-Header.h
+++ b/Sources/OsmAnd Maps-Bridging-Header.h
@@ -120,6 +120,7 @@
 #import "OAFavoriteFolderBridgeItem.h"
 #import "OAFavoritePointBridgeItem.h"
 #import "OATrackPreviewMapRenderer.h"
+#import "OARoutingHelperUtils.h"
 
 // Widgets
 #import "OAMapWidgetRegistry.h"

--- a/Sources/Router/OARoutingHelperUtils.h
+++ b/Sources/Router/OARoutingHelperUtils.h
@@ -8,8 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
+#ifdef __cplusplus
 #include <routingConfiguration.h>
 #import "OACurrentStreetName.h"
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 @class OAApplicationMode, OARoutingHelper;
@@ -22,7 +24,7 @@ struct RoutingParameter;
                             ref:(NSString *)ref
                     destination:(NSString *)destination
                         towards:(NSString *)towards;
-
+#ifdef __cplusplus
 + (NSString *) formatStreetName:(NSString *)name
                             ref:(NSString *)ref
                     destination:(NSString *)destination
@@ -30,6 +32,7 @@ struct RoutingParameter;
                         shields:(nullable NSArray<RoadShield *> *)shields;
 
 + (RoutingParameter)getParameterForDerivedProfile:(NSString *)key appMode:(OAApplicationMode *)appMode router:(std::shared_ptr<GeneralRouter>)router;
+#endif
 
 + (int) lookAheadFindMinOrthogonalDistance:(CLLocation *)currentLocation routeNodes:(NSArray<CLLocation *> *)routeNodes currentRoute:(int)currentRoute iterations:(int)iterations;
 
@@ -39,6 +42,9 @@ struct RoutingParameter;
     previewNextTurn:(BOOL)previewNextTurn;
 
 + (void) updateDrivingRegionIfNeeded:(CLLocation *)newStartLocation force:(BOOL)force;
+
++ (nullable NSString *)routingParamsQueryValueForAppMode:(OAApplicationMode *)mode;
++ (void)applyRoutingParamsQueryValue:(nullable NSString *)params forAppMode:(OAApplicationMode *)mode;
 
 @end
 

--- a/Sources/Router/OARoutingHelperUtils.h
+++ b/Sources/Router/OARoutingHelperUtils.h
@@ -8,10 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
-#ifdef __cplusplus
 #include <routingConfiguration.h>
 #import "OACurrentStreetName.h"
-#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class OAApplicationMode, OARoutingHelper;
@@ -20,28 +19,27 @@ struct RoutingParameter;
 
 @interface OARoutingHelperUtils : NSObject
 
-+ (NSString *) formatStreetName:(NSString *)name
-                            ref:(NSString *)ref
-                    destination:(NSString *)destination
-                        towards:(NSString *)towards;
-#ifdef __cplusplus
-+ (NSString *) formatStreetName:(NSString *)name
-                            ref:(NSString *)ref
-                    destination:(NSString *)destination
-                        towards:(NSString *)towards
-                        shields:(nullable NSArray<RoadShield *> *)shields;
++ (NSString *)formatStreetName:(NSString *)name
+                           ref:(NSString *)ref
+                   destination:(NSString *)destination
+                       towards:(NSString *)towards;
+
++ (NSString *)formatStreetName:(NSString *)name
+                           ref:(NSString *)ref
+                   destination:(NSString *)destination
+                       towards:(NSString *)towards
+                       shields:(nullable NSArray<RoadShield *> *)shields;
 
 + (RoutingParameter)getParameterForDerivedProfile:(NSString *)key appMode:(OAApplicationMode *)appMode router:(std::shared_ptr<GeneralRouter>)router;
-#endif
 
-+ (int) lookAheadFindMinOrthogonalDistance:(CLLocation *)currentLocation routeNodes:(NSArray<CLLocation *> *)routeNodes currentRoute:(int)currentRoute iterations:(int)iterations;
++ (int)lookAheadFindMinOrthogonalDistance:(CLLocation *)currentLocation routeNodes:(NSArray<CLLocation *> *)routeNodes currentRoute:(int)currentRoute iterations:(int)iterations;
 
-+ (BOOL) checkWrongMovementDirection:(CLLocation *)currentLocation prevRouteLocation:(CLLocation *)prevRouteLocation nextRouteLocation:(CLLocation *)nextRouteLocation;
++ (BOOL)checkWrongMovementDirection:(CLLocation *)currentLocation prevRouteLocation:(CLLocation *)prevRouteLocation nextRouteLocation:(CLLocation *)nextRouteLocation;
 
-+ (CLLocation *) approximateBearingIfNeeded:(OARoutingHelper *)helper projection:(CLLocation *)projection location:(CLLocation *)location previousRouteLocation:(CLLocation *)previousRouteLocation currentRouteLocation:(CLLocation *)currentRouteLocation nextRouteLocation:(CLLocation *)nextRouteLocation
-    previewNextTurn:(BOOL)previewNextTurn;
++ (CLLocation *)approximateBearingIfNeeded:(OARoutingHelper *)helper projection:(CLLocation *)projection location:(CLLocation *)location previousRouteLocation:(CLLocation *)previousRouteLocation currentRouteLocation:(CLLocation *)currentRouteLocation nextRouteLocation:(CLLocation *)nextRouteLocation
+                           previewNextTurn:(BOOL)previewNextTurn;
 
-+ (void) updateDrivingRegionIfNeeded:(CLLocation *)newStartLocation force:(BOOL)force;
++ (void)updateDrivingRegionIfNeeded:(CLLocation *)newStartLocation force:(BOOL)force;
 
 + (nullable NSString *)routingParamsQueryValueForAppMode:(OAApplicationMode *)mode;
 + (void)applyRoutingParamsQueryValue:(nullable NSString *)params forAppMode:(OAApplicationMode *)mode;

--- a/Sources/Router/OARoutingHelperUtils.mm
+++ b/Sources/Router/OARoutingHelperUtils.mm
@@ -16,6 +16,7 @@
 #import "OAAppSettings.h"
 #import "OAMapViewTrackingUtilities.h"
 #import "CLLocation+Extension.h"
+#import "OsmAndApp.h"
 
 #define CACHE_RADIUS 100000
 #define MAX_BEARING_DEVIATION 45
@@ -194,6 +195,133 @@
         {
             [[OAMapViewTrackingUtilities instance] detectDrivingRegion:newStartLocation];
             [settings setLastStartPoint:newStartLocation];
+        }
+    }
+}
+
++ (NSString *)routingParamsQueryValueForAppMode:(OAApplicationMode *)mode
+{
+    if (!mode)
+        return nil;
+    
+    auto router = [OsmAndApp.instance getRouter:mode];
+    if (!router)
+        return nil;
+    
+    OAAppSettings *settings = OAAppSettings.sharedManager;
+    NSMutableArray<NSString *> *parts = [NSMutableArray arrayWithObject:mode.stringKey];
+    BOOL anyChanged = NO;
+    
+    auto parameters = [self getParametersForDerivedProfile:mode router:router];
+    for (const auto &it : parameters)
+    {
+        const auto &key = it.first;
+        const auto &pr = it.second;
+        NSString *attrName = @(key.c_str());
+        
+        if (key == GeneralRouterConstants::USE_SHORTEST_WAY ||
+            [attrName isEqualToString:kRouteParamShortWay])
+        {
+            BOOL shortWay = ![settings.fastRouteMode get:mode];
+            if (shortWay) {
+                anyChanged = YES;
+                [parts addObject:kRouteParamShortWay];
+            }
+            continue;
+        }
+        
+        if (pr.type == RoutingParameterType::BOOLEAN)
+        {
+            BOOL def = pr.defaultBoolean;
+            BOOL val = [[settings getCustomRoutingBooleanProperty:attrName defaultValue:def] get:mode];
+            if (val == def)
+                continue;
+            anyChanged = YES;
+            if (val)
+                [parts addObject:attrName];
+            else
+                [parts addObject:[NSString stringWithFormat:@"%@:false", attrName]];
+        }
+        else
+        {
+            NSString *defStr = @(pr.getDefaultString().c_str());
+            NSString *val = [[settings getCustomRoutingProperty:attrName defaultValue:defStr] get:mode];
+            if (!val.length || [val isEqualToString:defStr])
+                continue;
+            anyChanged = YES;
+            [parts addObject:[NSString stringWithFormat:@"%@:%@", attrName, val]];
+        }
+    }
+    
+    return anyChanged ? [parts componentsJoinedByString:@","] : nil;
+}
+
++ (void)applyRoutingParamsQueryValue:(NSString *)params forAppMode:(OAApplicationMode *)mode
+{
+    if (!mode || params.length == 0)
+        return;
+    
+    auto router = [OsmAndApp.instance getRouter:mode];
+    if (!router)
+        return;
+    
+    OAAppSettings *settings = OAAppSettings.sharedManager;
+    auto parameters = [self getParametersForDerivedProfile:mode router:router];
+    
+    for (const auto &it : parameters)
+    {
+        NSString *attr = @(it.first.c_str());
+        const auto &pr = it.second;
+        if (it.first == GeneralRouterConstants::USE_SHORTEST_WAY ||
+            [attr isEqualToString:kRouteParamShortWay])
+        {
+            [settings.fastRouteMode set:YES mode:mode];
+            continue;
+        }
+        if (pr.type == RoutingParameterType::BOOLEAN)
+            [[settings getCustomRoutingBooleanProperty:attr defaultValue:pr.defaultBoolean] set:pr.defaultBoolean mode:mode];
+        else
+            [[settings getCustomRoutingProperty:attr defaultValue:@(pr.getDefaultString().c_str())]
+             set:@(pr.getDefaultString().c_str()) mode:mode];
+    }
+    
+    for (NSString *raw in [params componentsSeparatedByString:@","])
+    {
+        NSString *token = [raw stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+        if (token.length == 0)
+            continue;
+        
+        NSString *key = token;
+        NSString *val = @"true";
+        NSRange sep = [token rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@":="]];
+        if (sep.location != NSNotFound)
+        {
+            key = [token substringToIndex:sep.location];
+            val = [token substringFromIndex:sep.location + 1];
+        }
+        
+        if ([key isEqualToString:mode.stringKey] || [key isEqualToString:mode.getRoutingProfile])
+            continue;
+        
+        if ([key isEqualToString:kRouteParamShortWay])
+        {
+            BOOL on = ![val isEqualToString:@"false"];
+            [settings.fastRouteMode set:!on mode:mode];
+            continue;
+        }
+        
+        auto it = parameters.find(key.UTF8String);
+        if (it == parameters.end())
+            continue;
+        
+        if (it->second.type == RoutingParameterType::BOOLEAN)
+        {
+            BOOL b = ![val isEqualToString:@"false"];
+            [[settings getCustomRoutingBooleanProperty:key defaultValue:it->second.defaultBoolean] set:b mode:mode];
+        }
+        else
+        {
+            [[settings getCustomRoutingProperty:key defaultValue:@(it->second.getDefaultString().c_str())] set:val mode:mode];
         }
     }
 }

--- a/Sources/Router/OARoutingParamsDeepLinkBridge.h
+++ b/Sources/Router/OARoutingParamsDeepLinkBridge.h
@@ -1,0 +1,20 @@
+//
+//  OARoutingParamsDeepLinkBridge.h
+//  OsmAnd
+//
+//  Created by Vitaliy Sova on 30.07.2026.
+//  Copyright © 2026 OsmAnd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OARoutingParamsDeepLinkBridge : NSObject
+
++ (nullable NSString *)routingParamsQueryValueForAppMode:(OAApplicationMode *)mode;
++ (void)applyRoutingParamsQueryValue:(nullable NSString *)params forAppMode:(OAApplicationMode *)mode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Router/OARoutingParamsDeepLinkBridge.mm
+++ b/Sources/Router/OARoutingParamsDeepLinkBridge.mm
@@ -1,0 +1,24 @@
+//
+//  OARoutingParamsDeepLinkBridge.m
+//  OsmAnd Maps
+//
+//  Created by Vitaliy Sova on 30.07.2026.
+//  Copyright © 2026 OsmAnd. All rights reserved.
+//
+
+#import "OARoutingParamsDeepLinkBridge.h"
+#import "OARoutingHelperUtils.h"
+
+@implementation OARoutingParamsDeepLinkBridge
+
++ (NSString *)routingParamsQueryValueForAppMode:(OAApplicationMode *)mode
+{
+    return [OARoutingHelperUtils routingParamsQueryValueForAppMode:mode];
+}
+
++ (void)applyRoutingParamsQueryValue:(NSString *)params forAppMode:(OAApplicationMode *)mode
+{
+    [OARoutingHelperUtils applyRoutingParamsQueryValue:params forAppMode:mode];
+}
+
+@end


### PR DESCRIPTION
Add support for a params query in route deep links: RouteDeepLinkBuilder now appends "/navigate", includes serialized routing params (percent-encoded) and uses appMode.stringKey. DeepLinkParser reads the "params" query and applies it via new OARoutingHelperUtils APIs. Implement routingParamsQueryValueForAppMode: and applyRoutingParamsQueryValue:forAppMode: in OARoutingHelperUtils.mm to serialize/deserialize per-profile routing parameters using OAAppSettings and the router. Import the utils in the Swift bridging header. Also adjust one XIB bottom constraint.