### PR TITLE
DRAFT: search speed profiling and optimisation

### DIFF
--- a/Sources/Common/OACollatorStringMatcher.m
+++ b/Sources/Common/OACollatorStringMatcher.m
@@ -12,24 +12,21 @@
 #import "OASearchAlgorithms.h"
 
 static NSStringCompareOptions comparisonOptions = NSCaseInsensitiveSearch | NSWidthInsensitiveSearch | NSDiacriticInsensitiveSearch;
-static NSCharacterSet * _APOSTROPHES;
+
+@interface OACollatorStringMatcher ()
+
++ (BOOL) cstartsWithNormalized:(NSString *)searchIn
+                      theStart:(NSString *)theStart
+                checkBeginning:(BOOL)checkBeginning
+                   checkSpaces:(BOOL)checkSpaces
+                        equals:(BOOL)equals;
+
+@end
 
 @implementation OACollatorStringMatcher
 {
     StringMatcherMode _mode;
     NSString *_part;
-}
-
-+ (void) initialize
-{
-    if (self == [OACollatorStringMatcher class])
-    {
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            NSString *charString = @"'’ʼ´`ʹ‵′«»";
-            _APOSTROPHES = [NSCharacterSet characterSetWithCharactersInString:charString];
-        });
-    }
 }
 
 - (instancetype)initWithPart:(NSString *)part mode:(StringMatcherMode)mode
@@ -85,19 +82,19 @@ static NSCharacterSet * _APOSTROPHES;
         case CHECK_CONTAINS:
             return [self.class ccontains:fullName part:part];
         case CHECK_EQUALS_FROM_SPACE:
-            return [self.class cstartsWith:fullName theStart:part checkBeginning:YES checkSpaces:YES equals:YES];
+            return [self.class cstartsWithNormalized:fullName theStart:part checkBeginning:YES checkSpaces:YES equals:YES];
         case CHECK_STARTS_FROM_SPACE:
-            return [self.class cstartsWith:fullName theStart:part checkBeginning:YES checkSpaces:YES equals:NO];
+            return [self.class cstartsWithNormalized:fullName theStart:part checkBeginning:YES checkSpaces:YES equals:NO];
         case CHECK_STARTS_FROM_SPACE_NOT_BEGINNING:
-            return [self.class cstartsWith:fullName theStart:part checkBeginning:NO checkSpaces:YES equals:NO];
+            return [self.class cstartsWithNormalized:fullName theStart:part checkBeginning:NO checkSpaces:YES equals:NO];
         case CHECK_ONLY_STARTS_WITH:
-            return [self.class cstartsWith:fullName theStart:part checkBeginning:YES checkSpaces:NO equals:NO];
+            return [self.class cstartsWithNormalized:fullName theStart:part checkBeginning:YES checkSpaces:NO equals:NO];
         case TRIM_AND_CHECK_ONLY_STARTS_WITH:
             if (part.length > fullName.length)
                 part = [part substringWithRange:NSMakeRange(0, fullName.length)];
-            return [self.class cstartsWith:fullName theStart:part checkBeginning:YES checkSpaces:NO equals:NO];
+            return [self.class cstartsWithNormalized:fullName theStart:part checkBeginning:YES checkSpaces:NO equals:NO];
         case CHECK_EQUALS:
-            return [self.class cstartsWith:fullName theStart:part checkBeginning:NO checkSpaces:NO equals:YES];
+            return [self.class cstartsWithNormalized:fullName theStart:part checkBeginning:NO checkSpaces:NO equals:YES];
     }
     return false;
 }
@@ -156,11 +153,22 @@ static NSCharacterSet * _APOSTROPHES;
  */
 + (BOOL) cstartsWith:(NSString *)fullTextP theStart:(NSString *)theStart checkBeginning:(BOOL)checkBeginning checkSpaces:(BOOL)checkSpaces equals:(BOOL)equals
 {
-    // FUTURE: This is not effective code, it runs on each comparision
-    // It would be more efficient to normalize all strings in file and normalize search string before collator
     theStart = [self alignChars:theStart];
-    theStart = [self replaceHyphen:theStart replacement:@(" ")];
     NSString *searchIn = [self lowercaseAndAlignChars:fullTextP];
+    return [self cstartsWithNormalized:searchIn
+                             theStart:theStart
+                       checkBeginning:checkBeginning
+                          checkSpaces:checkSpaces
+                               equals:equals];
+}
+
++ (BOOL) cstartsWithNormalized:(NSString *)searchIn
+                      theStart:(NSString *)theStart
+                checkBeginning:(BOOL)checkBeginning
+                   checkSpaces:(BOOL)checkSpaces
+                        equals:(BOOL)equals
+{
+    theStart = [self replaceHyphen:theStart replacement:@(" ")];
     searchIn = [self replaceHyphen:searchIn replacement:@(" ")];
     NSInteger searchInLength = searchIn.length;
     
@@ -260,6 +268,10 @@ static NSCharacterSet * _APOSTROPHES;
 
 + (NSString *) replaceHyphen:(NSString *)text replacement:(NSString *)replacement
 {
+    if ([text rangeOfString:@"-"].location == NSNotFound)
+    {
+        return text;
+    }
     return [text stringByReplacingOccurrencesOfString:@"-" withString:replacement];
 }
 

--- a/Sources/Common/OASearchAlgorithms.m
+++ b/Sources/Common/OASearchAlgorithms.m
@@ -17,40 +17,22 @@
         return s;
     }
 
-    static const unichar apostrophes[] = {
-        0x0027, // '
-        0x2019, // ’
-        0x02BC, // ʼ
-        0x00B4, // ´
-        0x0060, // `
-        0x2032, // ′
-        0x2035, // ‵
-        0x02B9  // ʹ
-    };
-    const int count = sizeof(apostrophes) / sizeof(unichar);
-
-    NSMutableString *result = [NSMutableString stringWithCapacity:s.length];
-
-    for (NSUInteger i = 0; i < s.length; i++)
+    static NSCharacterSet *apostrophes;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        apostrophes = [NSCharacterSet characterSetWithCharactersInString:@"'’ʼ´`′‵ʹ"];
+    });
+    if ([s rangeOfCharacterFromSet:apostrophes].location == NSNotFound)
     {
-        unichar c = [s characterAtIndex:i];
-        BOOL isApostroph = NO;
-
-        for (int j = 0; j < count; j++)
-        {
-            if (c == apostrophes[j])
-            {
-                isApostroph = YES;
-                break;
-            }
-        }
-
-        if (!isApostroph)
-        {
-            [result appendFormat:@"%C", c];
-        }
+        return s;
     }
 
+    NSMutableString *result = [s mutableCopy];
+    for (NSUInteger i = result.length; i > 0; i--)
+    {
+        if ([apostrophes characterIsMember:[result characterAtIndex:i - 1]])
+            [result deleteCharactersInRange:NSMakeRange(i - 1, 1)];
+    }
     return [result copy];
 }
 
@@ -59,6 +41,10 @@
     if (!fullText)
     {
         return nil;
+    }
+    if ([fullText rangeOfString:@"ß"].location == NSNotFound)
+    {
+        return fullText;
     }
     return [fullText stringByReplacingOccurrencesOfString:@"ß" withString:@"ss"];
 }

--- a/Sources/Search/OASearchPhrase.mm
+++ b/Sources/Search/OASearchPhrase.mm
@@ -258,13 +258,18 @@ static NSCache<NSString*, NSNumber*> *sCommonWordWeightCache = nil;
         _otherUnknownWords = [NSMutableArray new];
         _mainUnknownWordToSearch = nil;
         _unknownWordsMatcher = [NSMutableArray new];
-        if (settings != nil)
-        {
-            _regionPriorityProvider = [[OARegionPriorityProvider alloc] initWithPhrase:self];
-        }
         _acceptPrivate = NO;
     }
     return self;
+}
+
+- (OARegionPriorityProvider *) regionPriorityProviderIfNeeded
+{
+    if (_regionPriorityProvider == nil && self.settings != nil)
+    {
+        _regionPriorityProvider = [[OARegionPriorityProvider alloc] initWithPhrase:self];
+    }
+    return _regionPriorityProvider;
 }
 
 - (OASearchPhrase *) generateNewPhrase:(NSString *)text settings:(OASearchSettings *)settings
@@ -600,9 +605,10 @@ static NSCache<NSString*, NSNumber*> *sCommonWordWeightCache = nil;
 - (NSArray<NSString *> *) getRadiusOfflineIndexes:(int)minMeters maxMeters:(int)maxMeters dataType:(EOASearchPhraseDataType)dataType
 {
     NSArray<NSString *> *list;
-    if (_regionPriorityProvider)
+    OARegionPriorityProvider *regionPriorityProvider = [self regionPriorityProviderIfNeeded];
+    if (regionPriorityProvider)
     {
-        list = [_regionPriorityProvider getOfflineIndexesWithMinRadius:minMeters maxRadius:maxMeters];
+        list = [regionPriorityProvider getOfflineIndexesWithMinRadius:minMeters maxRadius:maxMeters];
     }
     else
     {
@@ -616,9 +622,10 @@ static NSCache<NSString*, NSNumber*> *sCommonWordWeightCache = nil;
 - (NSArray<NSString *> *)getOfflineIndexesWithRect:(QuadRect *)rect dataType:(EOASearchPhraseDataType)dataType
 {
     NSArray<NSString *> *list;
-    if (_regionPriorityProvider)
+    OARegionPriorityProvider *regionPriorityProvider = [self regionPriorityProviderIfNeeded];
+    if (regionPriorityProvider)
     {
-        list = [_regionPriorityProvider getOfflineIndexes];
+        list = [regionPriorityProvider getOfflineIndexes];
     }
     else
     {
@@ -1184,9 +1191,10 @@ static NSCache<NSString*, NSNumber*> *sCommonWordWeightCache = nil;
 
 - (NSNumber *) getRegionPriority:(NSString *) resId
 {
-    if (_regionPriorityProvider != nil)
+    OARegionPriorityProvider *regionPriorityProvider = [self regionPriorityProviderIfNeeded];
+    if (regionPriorityProvider != nil)
     {
-        return @([_regionPriorityProvider getRegionWeight:resId]);
+        return @([regionPriorityProvider getRegionWeight:resId]);
     }
     return 0;
 }


### PR DESCRIPTION
[related CORE request](https://github.com/osmandapp/OsmAnd-core/pull/1088)

----



Profiller results on current master branch:

[XCode_profiler_file__short_verstion.txt](https://github.com/user-attachments/files/30579208/XCode_profiler_file__short_verstion.txt)

[XCode_profiler_file__full.zip](https://github.com/user-attachments/files/30579210/XCode_profiler_file__full.zip)


<details><summary>Spoiler</summary>

<img width="1465" height="826" alt="Screenshot 2026-07-31 at 13 57 30" src="https://github.com/user-attachments/assets/abbed492-af53-4d2b-85d8-fec034874fbc" />
<img width="1467" height="802" alt="Screenshot 2026-07-31 at 13 57 53" src="https://github.com/user-attachments/assets/d82c3874-3c03-4500-b892-9147609d51d6" />
<img width="1468" height="791" alt="Screenshot 2026-07-31 at 13 58 18" src="https://github.com/user-attachments/assets/755b25d4-1afb-4ea4-bf19-fdd61503ec0b" />
<img width="1466" height="336" alt="Screenshot 2026-07-31 at 13 58 33" src="https://github.com/user-attachments/assets/8ecb9bae-b7d0-47c1-96bf-987c11af1d8d" />

</details>


---

This pr is a AI-written perfomance optimisations. We need to double check / rewrite it.

And here is a file with Ai-written description of this commit. And analysis of next possible optimisations.

[search_performance_optimization_report.pdf](https://github.com/user-attachments/files/30580961/search_performance_optimization_report.pdf)

---

Profiler results after this commits:

[time_profiler_search_004.txt](https://github.com/user-attachments/files/30581559/time_profiler_search_004.txt)

[time_profiler_search_004.trace.zip](https://github.com/user-attachments/files/30581555/time_profiler_search_004.trace.zip)

---

video tests before / after:

map center location:
52.51739 13.39513

search phrase:
Dosse 1A hauptstr

<details><summary>Spoiler</summary>

Before - 12 sec:

https://github.com/user-attachments/assets/771dc9ee-3fce-480b-822d-27769b171fe1

After commit 1 - 7 sec:

https://github.com/user-attachments/assets/bf2010f7-b360-415b-a6cb-1f9443636343

After commit 2 - 5 sec:

https://github.com/user-attachments/assets/b7d9c2ad-7433-4318-9458-7e124fa97893

</details>