### PR TITLE
polygon highlighting fixes

### DIFF
--- a/Sources/Controllers/Map/Helpers/BaseDetailsObject.swift
+++ b/Sources/Controllers/Map/Helpers/BaseDetailsObject.swift
@@ -541,11 +541,11 @@ final class BaseDetailsObject: NSObject {
     }
 
     func setX(_ x: [Int]) {
-        syntheticAmenity.x = x as? NSMutableArray ?? []
+        syntheticAmenity.x = NSMutableArray(array: x)
     }
 
     func setY(_ y: [Int]) {
-        syntheticAmenity.y = y as? NSMutableArray ?? []
+        syntheticAmenity.y = NSMutableArray(array: y)
     }
 
     func addX(_ x: NSNumber) {

--- a/Sources/Controllers/Map/Layers/OAContextMenuLayer.h
+++ b/Sources/Controllers/Map/Layers/OAContextMenuLayer.h
@@ -39,6 +39,7 @@
 - (OATargetPoint *) getTargetPointCpp:(const void *)obj;
 
 - (void) hideRegionHighlight;
+- (void)setSelectedObject:(nullable id)selectedObject;
 
 - (NSArray<OARenderedObject *> *) retrievePolygonsAroundMapObject:(double)lat lon:(double)lon mapObject:(OAMapObject *)mapObject;
 

--- a/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
@@ -665,6 +665,9 @@
 - (void) hideRegionHighlight
 {
     _highlightedPolygonPoints.clear();
+    if (_outlineCollection == nullptr)
+        return;
+
     [self.mapViewController runWithRenderSync:^{
         [self.mapView removeKeyedSymbolsProvider:_outlineCollection];
         _outlineCollection = nullptr;

--- a/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
@@ -62,6 +62,7 @@
     std::shared_ptr<OsmAnd::MapMarker> _contextPinMarker;
     
     std::shared_ptr<OsmAnd::VectorLinesCollection> _outlineCollection;
+    QVector<OsmAnd::PointI> _highlightedPolygonPoints;
     
     UIImageView *_animatedPin;
     BOOL _animationDone;
@@ -79,6 +80,8 @@
     CGPoint _cachedTargetPoint;
     
     OAMapSelectionHelper *_mapSelectionHelper;
+
+    id _selectedObject;
 }
 
 - (NSString *) layerId
@@ -637,9 +640,13 @@
 
 - (void) highlightPolygon:(QVector<OsmAnd::PointI>)points;
 {
+    if (_outlineCollection != nullptr && points == _highlightedPolygonPoints)
+        return;
+
     if (_outlineCollection != nullptr)
         [self hideRegionHighlight];
 
+    _highlightedPolygonPoints = points;
     [self.mapViewController runWithRenderSync:^{
         _outlineCollection = std::make_shared<OsmAnd::VectorLinesCollection>();
         OsmAnd::VectorLineBuilder builder;
@@ -657,10 +664,45 @@
 
 - (void) hideRegionHighlight
 {
+    _highlightedPolygonPoints.clear();
     [self.mapViewController runWithRenderSync:^{
         [self.mapView removeKeyedSymbolsProvider:_outlineCollection];
         _outlineCollection = nullptr;
     }];
+}
+
+- (QVector<OsmAnd::PointI>)polygonPointsForObject:(id)object
+{
+    QVector<OsmAnd::PointI> points;
+
+    OAMapObject *mapObject = nil;
+    if ([object isKindOfClass:OAMapObject.class])
+        mapObject = object;
+    else if ([object isKindOfClass:BaseDetailsObject.class])
+        mapObject = (OAMapObject *) [(BaseDetailsObject *) object syntheticAmenity];
+
+    if (mapObject && mapObject.x && mapObject.y
+        && mapObject.x.count == mapObject.y.count && mapObject.x.count > 2)
+    {
+        for (NSUInteger i = 0; i < mapObject.x.count; i++)
+            points.push_back(OsmAnd::PointI(mapObject.x[i].intValue, mapObject.y[i].intValue));
+    }
+    return points;
+}
+
+- (void)updateSelectedObjectHighlight
+{
+    QVector<OsmAnd::PointI> points = [self polygonPointsForObject:_selectedObject];
+    if (points.size() > 2)
+        [self highlightPolygon:points];
+    else
+        [self hideRegionHighlight];
+}
+
+- (void)setSelectedObject:(id)selectedObject
+{
+    _selectedObject = selectedObject;
+    [self updateSelectedObjectHighlight];
 }
 
 - (NSArray<OARenderedObject *> *) retrievePolygonsAroundMapObject:(double)lat lon:(double)lon mapObject:(OAMapObject *)mapObject
@@ -817,6 +859,7 @@
 
 - (void)contextMenuDidHide
 {
+    [self setSelectedObject:nil];
     [self hideAnimatedPin];
     [self hideContextPinMarker];
 }

--- a/Sources/Controllers/Panels/OAMapPanelViewController.h
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.h
@@ -66,6 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) showContextMenu:(OATargetPoint *)targetPoint saveState:(BOOL)saveState preferredZoom:(float)preferredZoom;
 - (void) showContextMenu:(OATargetPoint *)targetPoint;
 - (void) updateContextMenu:(OATargetPoint *)targetPoint;
+- (BOOL)updateContextMenuSelectedObject:(nullable id)selectedObject forTargetPoint:(OATargetPoint *)targetPoint;
 - (void) reopenContextMenu;
 - (void) hideContextMenu;
 - (BOOL) isContextMenuVisible;

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -1562,28 +1562,16 @@ typedef enum
 
 - (void)setSelectedObject:(OATargetPoint *)targetPoint
 {
+    [_mapViewController.mapLayers.contextMenuLayer setSelectedObject:targetPoint.targetObj];
+}
 
-    OAMapObject *obj = nil;
-    if ([targetPoint.targetObj isKindOfClass:OAMapObject.class])
-    {
-        obj = targetPoint.targetObj;
+- (BOOL)updateContextMenuSelectedObject:(id)selectedObject forTargetPoint:(OATargetPoint *)targetPoint
+{
+    if (![self isContextMenuVisible] || [_targetMenuView isHiding] || _targetMenuView.targetPoint != targetPoint)
+        return NO;
 
-    }
-    else if([targetPoint.targetObj isKindOfClass:BaseDetailsObject.class])
-    {
-        BaseDetailsObject *baseDetails = (BaseDetailsObject *) targetPoint.targetObj;
-        obj = (OAMapObject *) [baseDetails syntheticAmenity];
-    }
-    if (obj != nil)
-    {
-        QVector<OsmAnd::PointI> points;
-        if (obj.x && obj.x.count > 0)
-        {
-            for (int i = 0; i < obj.x.count; i++)
-                points.push_back(OsmAnd::PointI(obj.x[i].intValue, obj.y[i].intValue));
-        }
-        [_mapViewController.mapLayers.contextMenuLayer highlightPolygon:points];
-    }
+    [_mapViewController.mapLayers.contextMenuLayer setSelectedObject:selectedObject];
+    return YES;
 }
 
 - (void) setupNetworkGpxProgress

--- a/Sources/Controllers/TargetMenu/POI/PlaceDetailsViewController.swift
+++ b/Sources/Controllers/TargetMenu/POI/PlaceDetailsViewController.swift
@@ -14,6 +14,7 @@ final class PlaceDetailsViewController: OAPOIViewController {
     private var detailsObject: BaseDetailsObject?
     private var renderedObject: OARenderedObject?
     private var provider: RenderedObjectAmenityProvider!
+    private var cityFetchStarted = false
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -39,12 +40,15 @@ final class PlaceDetailsViewController: OAPOIViewController {
     }
 
     override func viewDidLoad() {
+        applyPolygonAddressIfNeeded()
         if detailsObject != nil {
             updateMenuWithDetailedObject()
         }
         super.viewDidLoad()
         if detailsObject == nil {
             resolveDetailedObjectInBackground()
+        } else {
+            resolveGeometryInBackground()
         }
     }
     
@@ -231,8 +235,22 @@ final class PlaceDetailsViewController: OAPOIViewController {
         updateTargetPoint(with: amenity)
     }
 
+    private func resolveGeometryInBackground() {
+        guard let poi = detailsObject?.syntheticAmenity ?? self.poi,
+              let targetPoint = OARootViewController.instance()?.mapPanel?.getCurrentTargetPoint()
+        else { return }
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let geoObject = OAAmenitySearcher.sharedInstance().resolveGeometryOnly(poi) else { return }
+            DispatchQueue.main.async {
+                _ = OARootViewController.instance()?.mapPanel?.updateContextMenuSelectedObject(geoObject, for: targetPoint)
+            }
+        }
+    }
+
     private func resolveDetailedObjectInBackground() {
-        guard let renderedObject else { return }
+        guard let renderedObject,
+              let targetPoint = OARootViewController.instance()?.mapPanel?.getCurrentTargetPoint()
+        else { return }
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let details = OAAmenitySearcher.sharedInstance().searchDetailedObject(renderedObject)
             DispatchQueue.main.async {
@@ -240,8 +258,7 @@ final class PlaceDetailsViewController: OAPOIViewController {
                       let details,
                       let tableView = self.tableView,
                       let mapPanel = OARootViewController.instance()?.mapPanel,
-                      let targetPoint = mapPanel.getCurrentTargetPoint(),
-                      (targetPoint.targetObj as AnyObject) === renderedObject
+                      mapPanel.updateContextMenuSelectedObject(details, for: targetPoint)
                 else { return }
                 self.detailsObject = details
                 self.provider.detailsObject = details
@@ -262,6 +279,75 @@ final class PlaceDetailsViewController: OAPOIViewController {
         targetPoint.title = amenity.nameLocalized ?? amenity.name
         targetPoint.icon = amenity.type?.icon()
 
+        applyPolygonAddressIfNeeded()
         mapPanel.update(targetPoint)
+    }
+
+    private func applyPolygonAddressIfNeeded() {
+        guard let mapPanel = OARootViewController.instance()?.mapPanel,
+              let targetPoint = mapPanel.getCurrentTargetPoint() else { return }
+
+        let amenity: OAPOI? = detailsObject?.syntheticAmenity ?? poi
+        let polygonPoints = max(Int(renderedObject?.x.count ?? 0), Int(amenity?.x.count ?? 0))
+        guard polygonPoints > 2 else { return }
+
+        targetPoint.shouldFetchAddress = false
+        if let address = polygonAddressString(amenity), !address.isEmpty {
+            targetPoint.titleAddress = address
+            targetPoint.addressFound = true
+        }
+        fetchCityInBackground(for: targetPoint)
+    }
+
+    private func fetchCityInBackground(for targetPoint: OATargetPoint) {
+        guard !cityFetchStarted else { return }
+        cityFetchStarted = true
+
+        let lat = targetPoint.location.latitude
+        let lon = targetPoint.location.longitude
+        let objectId = targetPoint.obfId
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let fullAddress = OAReverseGeocoder.instance().lookupAddress(atLat: lat, lon: lon, objectId: objectId)
+            let trimmed = fullAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+            DispatchQueue.main.async {
+                guard let self, !trimmed.isEmpty,
+                      let mapPanel = OARootViewController.instance()?.mapPanel,
+                      let currentTarget = mapPanel.getCurrentTargetPoint(),
+                      currentTarget === targetPoint else { return }
+                currentTarget.titleAddress = trimmed
+                currentTarget.addressFound = true
+                self.delegate?.refreshTargetPointHeader?()
+            }
+        }
+    }
+
+    private func polygonAddressString(_ amenity: OAPOI?) -> String? {
+        guard let amenity else { return nil }
+        let street = amenity.getAdditionalInfo("addr:street") ?? amenity.getAdditionalInfo("addr_street")
+        let house = amenity.getAdditionalInfo("addr:housenumber") ?? amenity.getAdditionalInfo("addr_housenumber")
+        let cityCandidates: [String?] = [
+            amenity.cityName,
+            amenity.getAdditionalInfo("addr:city"),
+            amenity.getAdditionalInfo("addr_city"),
+            amenity.getAdditionalInfo("addr:place"),
+            amenity.getAdditionalInfo("addr_place"),
+            amenity.getAdditionalInfo("is_in:city"),
+            amenity.getAdditionalInfo("is_in")
+        ]
+        let city = cityCandidates.compactMap { $0 }.first { !$0.isEmpty }
+        var line = ""
+        if let street, !street.isEmpty {
+            if let house, !house.isEmpty {
+                line = "\(street) \(house)"
+            } else {
+                line = street
+            }
+        }
+        var parts: [String] = []
+        if !line.isEmpty { parts.append(line) }
+        if let city, !city.isEmpty { parts.append(city) }
+        let result = parts.joined(separator: ", ")
+        return result.isEmpty ? nil : result
     }
 }

--- a/Sources/Helpers/OAAmenitySearcher.h
+++ b/Sources/Helpers/OAAmenitySearcher.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable BaseDetailsObject *)searchDetailedObject:(id)object;
 - (nullable BaseDetailsObject *)searchDetailedObjectWithRequest:(OAAmenitySearcherRequest *)request;
+- (nullable BaseDetailsObject *)resolveGeometryOnly:(OAPOI *)poi;
 
 - (NSArray<NSString *> *) getAmenityRepositories:(BOOL)includeTravel;
 

--- a/Sources/Helpers/OAAmenitySearcher.mm
+++ b/Sources/Helpers/OAAmenitySearcher.mm
@@ -284,6 +284,15 @@ static std::shared_ptr<const OsmAnd::Amenity> OAGetAmenityFromSearchResult(const
     return detailsObject;
 }
 
+- (nullable BaseDetailsObject *)resolveGeometryOnly:(OAPOI *)poi
+{
+    if (!poi)
+        return nil;
+    BaseDetailsObject *detailsObject = [[BaseDetailsObject alloc] initWithMapObjects:@[poi] lang:[[OAAppSettings sharedManager].settingPrefMapLanguage get]];
+    [self completeGeometry:detailsObject object:poi];
+    return detailsObject;
+}
+
 - (NSMutableArray<OAPOI *> *)filterAmenities:(NSArray<OAPOI *> *)amenities request:(OAAmenitySearcherRequest*) request
 {
     int64_t osmId = request.osmId;

--- a/Sources/OsmAnd Maps-Bridging-Header.h
+++ b/Sources/OsmAnd Maps-Bridging-Header.h
@@ -78,6 +78,7 @@
 #import "OrderedDictionary.h"
 #import "OAMapActions.h"
 #import "OAPOIHelper.h"
+#import "OAReverseGeocoder.h"
 #import "OARenderedObject.h"
 #import "OAPOIType.h"
 #import "OAPOIFiltersHelper.h"

--- a/Sources/Views/OATargetPointView.h
+++ b/Sources/Views/OATargetPointView.h
@@ -59,6 +59,7 @@
 - (void) show:(BOOL)animated onComplete:(void (^)(void))onComplete;
 - (void) hide:(BOOL)animated duration:(NSTimeInterval)duration onComplete:(void (^)(void))onComplete;
 - (BOOL) preHide;
+- (BOOL)isHiding;
 
 - (void) hideByMapGesture;
 - (BOOL) forceHideIfSupported;

--- a/Sources/Views/OATargetPointView.mm
+++ b/Sources/Views/OATargetPointView.mm
@@ -923,6 +923,11 @@ static const NSInteger _buttonsCount = 4;
         [self.customController onMenuShown];
 }
 
+- (BOOL)isHiding
+{
+    return _hiding;
+}
+
 - (void) hide:(BOOL)animated duration:(NSTimeInterval)duration onComplete:(void (^)(void))onComplete
 {
     _hiding = YES;


### PR DESCRIPTION
Moves polygon highlighting state to OAContextMenuLayer, following the Android implementation. Async geometry results are applied only when the original context-menu target is still active, preventing stale polygons from being drawn over a newly selected object. Polygon highlighting is also cleared when the context menu closes.