### PR TITLE
Related multypolygon context menu ui fix 

### DIFF
--- a/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
+++ b/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
@@ -716,7 +716,8 @@ static inline BOOL OARowsContainKey(NSArray<OAAmenityInfoRow *> *rows, NSString 
             {
                 NSString *title = OALocalizedString(@"route_members");
                 OAAmenityInfoRow *row = [self buildRouteRow:rows amenities:amenities key:ROUTE_MEMBERS_ROW_KEY title:title];
-                [self appendInfoRow:row];
+                [rows addObject:row];
+                [self updateInfoRows];
             }
         }];
     }
@@ -728,7 +729,8 @@ static inline BOOL OARowsContainKey(NSArray<OAAmenityInfoRow *> *rows, NSString 
             {
                 NSString *title = OALocalizedString(@"route_part_of");
                 OAAmenityInfoRow *row = [self buildRouteRow:rows amenities:amenities key:ROUTE_PART_OF_ROW_KEY title:title];
-                [self appendInfoRow:row];
+                [rows addObject:row];
+                [self updateInfoRows];
             }
         }];
         
@@ -737,7 +739,8 @@ static inline BOOL OARowsContainKey(NSArray<OAAmenityInfoRow *> *rows, NSString 
             {
                 NSString *title = OALocalizedString(@"multipoligon_related");
                 OAAmenityInfoRow *row = [self buildRouteRow:rows amenities:amenities key:ROUTE_RELATED_ROUTES_ROW_KEY title:title];
-                [self appendInfoRow:row];
+                [rows addObject:row];
+                [self updateInfoRows];
             }
         }];
     }

--- a/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
+++ b/Sources/Controllers/TargetMenu/OATargetInfoViewController.mm
@@ -777,7 +777,9 @@ static inline BOOL OARowsContainKey(NSArray<OAAmenityInfoRow *> *rows, NSString 
     
     OACollapsablePoiView *collapsableView = [[OACollapsablePoiView alloc] init];
     [collapsableView setDataWithTitles:titles amenities:amenities];
+    collapsableView.collapsed = YES;
     row.collapsableView = collapsableView;
+    row.collapsed = YES;
 
     return row;
 }


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4499#issuecomment-5003467119)

- [x] - Related section is closed by default.
- [x] - Fixed bug with doubling cells. (Because of async menu loading)

before / after / android:

<table style="width:100%">
  <tr>
       <th> before </th>
       <th> after</th>
       <th>android </th>
  </tr>
  <tr>
       <th><img src="https://github.com/user-attachments/assets/27e27ca4-8a3b-40b2-8b13-b1101a8c8857"  width="200" height="auto"/> </th>
        <th><img src="https://github.com/user-attachments/assets/b0e7dc02-2af0-4bc1-b814-948087e64da9"  width="200" height="auto"/> </th>
         <th><img src="https://github.com/user-attachments/assets/d046894a-00d5-4bd3-972c-567b0bb91fc0"  width="200" height="auto"/> </th>
  </tr>
</table>
