### PR TITLE
Fix GPS battery drain after CarPlay disconnect

### DIFF
--- a/Sources/AppHost/CarPlayDelegate/CarPlayService.swift
+++ b/Sources/AppHost/CarPlayDelegate/CarPlayService.swift
@@ -47,7 +47,13 @@ final class CarPlayService: NSObject {
         restoreOriginalMapAppearanceModeIfNeeded()
         appMapAppearanceMode = nil
         carPlayMapAppearanceMode = nil
-        OARoutingHelper.sharedInstance().onCarPlayConnectionStateChanged()
+        // Evaluate on the next runloop turn so connectedScenes reflects the
+        // just-disconnected scene's removal (resolves the connect/disconnect race
+        // and the dual app + dashboard scene case).
+        DispatchQueue.main.async {
+            let hasRemainingCarPlayScene = UIApplication.shared.isCarPlayConnected
+            OARoutingHelper.sharedInstance().onCarPlayDisconnected(withRemainingScene: hasRemainingCarPlayScene)
+        }
         navigationModeProvider.restoreOnDisconnect()
         if case .app = sceneType, isSearchUICorePrepared, UIApplication.shared.mainScene != nil {
             OAQuickSearchHelper.instance().setResourcesForSearchUICore()

--- a/Sources/Router/OARoutingHelper.h
+++ b/Sources/Router/OARoutingHelper.h
@@ -120,7 +120,7 @@ struct RouteSegmentResult;
 - (void) startRouteCalculationThread:(OARouteCalculationParams *)params paramsChanged:(BOOL)paramsChanged updateProgress:(BOOL)updateProgress;
 - (void)stopRouteCalculation;
 - (void)resumeNavigationAfterCarPlayReconnect;
-- (void)onCarPlayConnectionStateChanged;
+- (void)onCarPlayDisconnectedWithRemainingScene:(BOOL)hasRemainingCarPlayScene;
 
 - (OARoutingEnvironment *) getRoutingEnvironment:(OAApplicationMode *)mode start:(CLLocation *)start end:(CLLocation *)end;
 

--- a/Sources/Router/OARoutingHelper.mm
+++ b/Sources/Router/OARoutingHelper.mm
@@ -186,29 +186,40 @@ static BOOL _isDeviatedFromRoute = false;
         _isPausedDueToCarPlayDisconnect = NO;
         [self resumeNavigation];
     }
+    // Resume GPS if it was suspended after a prior CarPlay disconnect, otherwise
+    // navigation would run with a frozen (last-known) position.
+    [_app.locationServices updateBackgroundState];
 }
 
-- (void)onCarPlayConnectionStateChanged
+- (void)onCarPlayDisconnectedWithRemainingScene:(BOOL)hasRemainingCarPlayScene
 {
-    if (UIApplication.sharedApplication.isCarPlayConnected)
+    // Act only when the LAST CarPlay scene disconnects. If another CarPlay
+    // scene (app or dashboard) is still connected, keep navigating.
+    if (hasRemainingCarPlayScene)
+        return;
+
+    if ([self isFollowingMode])
     {
-        if ([self isFollowingMode])
+        if ([self getLeftDistance] < kCarDisconnectStopNavigationDistanceMeters)
         {
-            if ([self getLeftDistance] < kCarDisconnectStopNavigationDistanceMeters)
+            [_app stopNavigation];
+        }
+        else
+        {
+            CLLocation *currentLocation = _app.locationServices.lastKnownLocation;
+            if (currentLocation && currentLocation.speed >= 0 && currentLocation.speed < kCarDisconnectPauseSpeedMetersPerSecond)
             {
-                [_app stopNavigation];
-            }
-            else
-            {
-                CLLocation *currentLocation = _app.locationServices.lastKnownLocation;
-                if (currentLocation && currentLocation.speed >= 0 && currentLocation.speed < kCarDisconnectPauseSpeedMetersPerSecond)
-                {
-                    [self pauseNavigation];
-                    _isPausedDueToCarPlayDisconnect = YES;
-                }
+                [self pauseNavigation];
+                _isPausedDueToCarPlayDisconnect = YES;
             }
         }
     }
+
+    // CarPlay kept GPS alive (shouldBeRunningInBackground / isInBackground both
+    // depend on isCarPlayConnected). Now the last CarPlay scene is gone, so
+    // re-evaluate: suspend GPS if the device is backgrounded and no longer needs
+    // it. Nothing else re-triggers this when the screen is already locked.
+    [_app.locationServices updateBackgroundState];
 }
 
 - (void) resumeNavigation

--- a/Sources/Services/OALocationServices.h
+++ b/Sources/Services/OALocationServices.h
@@ -60,5 +60,6 @@ typedef NS_ENUM(NSUInteger, OALocationServicesStatus)
 
 - (void)resume;
 - (void)suspend;
+- (void)updateBackgroundState;
 
 @end

--- a/Sources/Services/OALocationServices.mm
+++ b/Sources/Services/OALocationServices.mm
@@ -341,6 +341,48 @@
     }
 }
 
+// Re-evaluates whether location services should be running, suspended, or
+// resumed. Unlike onApplicationDidEnterBackground (which fires on the system
+// background notification), this is meant to be called when the effective
+// background state may have changed without an app-level background transition
+// — e.g. when CarPlay disconnects/reconnects while the device screen is locked.
+- (void)updateBackgroundState
+{
+    OALocationServicesStatus status = self.status;
+    BOOL shouldRun = [self shouldBeRunningInBackground];
+
+    if (status == OALocationServicesStatusSuspended)
+    {
+        // Resume if back in foreground on device, or something needs background
+        // running again (CarPlay reconnected / nav resumed / track recording).
+        if (!_app.isInBackgroundOnDevice || shouldRun)
+            [self resume];
+        return;
+    }
+
+    BOOL isRunning = (status == OALocationServicesStatusActive || status == OALocationServicesStatusAuthorizing);
+    if (!isRunning)
+        return;
+
+    if (_app.isInBackgroundOnDevice)
+    {
+        if (!shouldRun)
+        {
+            OALog(@"Suspending location services (background state re-evaluated)");
+            [self suspend];
+        }
+        else
+        {
+            [self setupDistanceFilter:YES];
+        }
+    }
+    else
+    {
+        [self setupDistanceFilter:NO];
+        [self updateRequestedAccuracy];
+    }
+}
+
 - (CLLocation*) lastKnownLocation
 {
     //return [[CLLocation alloc] initWithLatitude:44.953197568579 longitude:34.097549412400];


### PR DESCRIPTION
The CarPlay disconnect handler was gated by an inverted, race-prone guard (if isCarPlayConnected) so its stop/pause-navigation logic was usually skipped, leaving navigation in following mode and GPS running at best-for-navigation in the background after the user left the car.

Even with navigation cleared, nothing actually suspended GPS: suspend was only reachable via the system background notification, which does not reliably re-fire when CarPlay disconnects while the phone is already locked.

Fixes:
- Rename onCarPlayConnectionStateChanged to onCarPlayDisconnectedWithRemainingScene: and drop the bad guard; act only when the last CarPlay scene disconnects (resolved via a one-runloop deferral in CarPlayService so connectedScenes has settled, which also handles the dual app + dashboard scene case).
- Add OALocationServices updateBackgroundState to deterministically suspend GPS when the device is backgrounded and no longer needs it, and resume it on CarPlay reconnect (avoids navigation running with a frozen position). Left onApplicationDidEnterBackground untouched to avoid regressing the phone-only background path.