### PR TITLE
Fixed incorrect profile state

### DIFF
--- a/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
@@ -169,6 +169,14 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
     private var cachedRouteSegments: [PlanRouteSegment]?
     private var cachedAnalysisData: PlanRouteAnalysisData?
     private var hasCachedAnalysisData = false
+    private var initialApplicationMode: OAApplicationMode {
+        var supportedModes = bridge.availableModes()
+        if let directLineMode = OAApplicationMode.default() {
+            supportedModes.append(directLineMode)
+        }
+        let currentMode = OAAppSettings.sharedManager().applicationMode.get()
+        return supportedModes.first(where: { $0.stringKey == currentMode.stringKey }) ?? .default()
+    }
 
     init(mode: PlanRouteMode = .newRoute, filePath: String? = nil, initialPoint: CLLocationCoordinate2D? = nil, applicationMode: OAApplicationMode? = nil) {
         self.mode = mode
@@ -184,11 +192,7 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
         if mode.isEditTrack, let filePath {
             bridge.openTrack(withFilePath: filePath)
         } else {
-            if let applicationMode {
-                bridge.prepareNewRoute(with: applicationMode)
-            } else {
-                bridge.prepareNewRoute()
-            }
+            bridge.prepareNewRoute(with: applicationMode ?? initialApplicationMode)
             if let initialPoint {
                 bridge.addPoint(at: initialPoint)
             }

--- a/Sources/Controllers/RoutePlanning/InitialRoutePlanningBottomSheetViewController.mm
+++ b/Sources/Controllers/RoutePlanning/InitialRoutePlanningBottomSheetViewController.mm
@@ -253,11 +253,8 @@
     NSString *key = item[@"key"];
     if ([key isEqualToString:@"create_new_route"])
     {
-        OAApplicationMode *routeMode = [[OAAppSettings sharedManager].applicationMode get];
-        if ([routeMode isDerivedRoutingFrom:OAApplicationMode.PUBLIC_TRANSPORT])
-            routeMode = OAApplicationMode.DEFAULT;
         [self hide:YES completion:^{
-            [PlanRouteScrollableViewController showNewRouteWithApplicationMode:routeMode];
+            [PlanRouteScrollableViewController showNewRoute];
         }];
         return;
     }


### PR DESCRIPTION
Updated Plan Route initialization to use the current global application profile for all entry points, including Main Menu and Map Context Menu. Unsupported profiles, such as Public Transport, fall back to Direct Line. Profile changes made inside Plan Route apply only to the current editing session