### PR TITLE
Plan route fixes for analyze tab

### DIFF
--- a/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
@@ -458,6 +458,7 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
                 maxSpeed: analysis.maxSpeed > 0 ? Double(analysis.maxSpeed) : nil,
                 timeInMotion: analysis.timeMoving > 0 ? TimeInterval(analysis.timeMoving) / 1000 : nil,
                 hasElevationData: analysis.hasElevationData(),
+                hasSpeedData: analysis.isSpeedSpecified(),
                 gpxAnalysis: analysis,
                 gpxFile: gpxFile,
                 routeStatistics: stats

--- a/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
@@ -428,7 +428,7 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
     }
 
     private func scheduleAnalysisIfNeeded() {
-        guard isTrackReadyToCalculate,
+        guard bridge.hasPoints,
               !hasCachedAnalysisData,
               pendingAnalysisGeneration == nil,
               !bridge.isCalculatingRoute else { return }

--- a/Sources/Controllers/PlanRoute/PlanRouteModels.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteModels.swift
@@ -181,6 +181,7 @@ struct PlanRouteAnalysisData {
     let maxSpeed: Double?
     let timeInMotion: TimeInterval?
     let hasElevationData: Bool
+    let hasSpeedData: Bool
     let gpxAnalysis: GpxTrackAnalysis?
     let gpxFile: GpxFile?
     let routeStatistics: [OARouteStatistics]

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
@@ -74,6 +74,8 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
     private var hasCompletedElevationCalculation = false
     private var cachedState: AnalyzeState = .noData
     private var cachedHasOverviewData = false
+    private var cachedHasElevationData = false
+    private var cachedHasSpeedData = false
     private var cachedRoadAttributeStatistics: [OARouteStatistics] = []
     private var cachedSyntheticSteepness: OARouteStatistics?
     private var cachedSyntheticSteepnessSignature: Double = -1
@@ -105,6 +107,30 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         cachedState
     }
 
+    private var effectiveYAxisTypes: [NSNumber] {
+        let availableTypes = selectedYAxisTypes.filter { number in
+            guard let type = GPXDataSetType(rawValue: number.intValue) else { return false }
+            switch type {
+            case .altitude, .slope:
+                return cachedHasElevationData
+            case .speed:
+                return cachedHasSpeedData
+            default:
+                return true
+            }
+        }
+        if !availableTypes.isEmpty {
+            return availableTypes
+        }
+        if cachedHasSpeedData {
+            return [NSNumber(value: GPXDataSetType.speed.rawValue)]
+        }
+        if cachedHasElevationData {
+            return [NSNumber(value: GPXDataSetType.altitude.rawValue)]
+        }
+        return []
+    }
+
     init(dataSource: PlanRouteAnalyzeDataSource?) {
         self.dataSource = dataSource
         super.init(nibName: nil, bundle: nil)
@@ -134,7 +160,9 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         }
         wasCalculatingElevation = isElevationCalculating
         let analysisData = dataSource?.analysisData
-        cachedHasOverviewData = analysisData?.hasElevationData == true
+        cachedHasElevationData = analysisData?.hasElevationData == true
+        cachedHasSpeedData = analysisData?.hasSpeedData == true
+        cachedHasOverviewData = cachedHasElevationData || cachedHasSpeedData
         scheduleSteepnessComputationIfNeeded(analysisData: analysisData)
         cachedRoadAttributeStatistics = buildRoadAttributeStatistics(from: analysisData)
         expandedStatIndexes = Set(expandedStatIndexes.filter { $0 < cachedRoadAttributeStatistics.count })
@@ -190,7 +218,7 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
     private func showAxisPicker(startingOnYAxis: Bool) {
         guard let analysis = dataSource?.analysisData?.gpxAnalysis else { return }
         let sheet = StatisticsSelectionBottomSheetViewController(
-            types: selectedYAxisTypes,
+            types: effectiveYAxisTypes,
             selectedXAxisMode: selectedXAxisType,
             analysis: analysis,
             isYAxisMode: startingOnYAxis
@@ -332,9 +360,9 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
     }
 
     private func resolvedYAxisTypes() -> (GPXDataSetType, GPXDataSetType) {
-        let first = selectedYAxisTypes.first.flatMap { GPXDataSetType(rawValue: $0.intValue) } ?? .altitude
-        let second = selectedYAxisTypes.count > 1
-            ? (GPXDataSetType(rawValue: selectedYAxisTypes[1].intValue) ?? .none)
+        let first = effectiveYAxisTypes.first.flatMap { GPXDataSetType(rawValue: $0.intValue) } ?? .none
+        let second = effectiveYAxisTypes.count > 1
+            ? (GPXDataSetType(rawValue: effectiveYAxisTypes[1].intValue) ?? .none)
             : .none
         return (first, second)
     }
@@ -345,14 +373,14 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
                               roadAttributeStatistics: [OARouteStatistics]) -> AnalyzeState {
         if isRouteCalculating { return .routeCalculating }
         if isElevationCalculating {
-            return !roadAttributeStatistics.isEmpty ? .hasData : .elevationCalculating
+            return hasOverviewData || !roadAttributeStatistics.isEmpty ? .hasData : .elevationCalculating
         }
         if hasOverviewData || !roadAttributeStatistics.isEmpty { return .hasData }
         return .noData
     }
 
     private func yAxisButtonTitle() -> String {
-        let titles = selectedYAxisTypes.compactMap { GPXDataSetType(rawValue: $0.intValue)?.getTitle() }
+        let titles = effectiveYAxisTypes.compactMap { GPXDataSetType(rawValue: $0.intValue)?.getTitle() }
         guard let firstTitle = titles.first else { return "" }
         guard titles.count > 1, let secondTitle = titles.last else { return firstTitle }
         return String(format: localizedString("ltr_or_rtl_combine_via_slash"), firstTitle, secondTitle)
@@ -400,7 +428,7 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
               let gpxFile = analysisData?.gpxFile else {
             return nil
         }
-        let yTypes = selectedYAxisTypes.map(\.stringValue).joined(separator: ",")
+        let yTypes = effectiveYAxisTypes.map(\.stringValue).joined(separator: ",")
         return [
             gpxFile.path,
             String(analysis.totalDistance),
@@ -414,6 +442,8 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
     private func statsSignature(for analysisData: PlanRouteAnalysisData?) -> String? {
         guard cachedHasOverviewData, let analysisData else { return nil }
         return [
+            String(analysisData.hasElevationData),
+            String(analysisData.hasSpeedData),
             String(analysisData.uphill),
             String(analysisData.downhill),
             String(analysisData.altMin ?? .nan),
@@ -634,6 +664,7 @@ extension PlanRouteAnalyzeViewController: UITableViewDataSource {
         recalcBtn.titleLabel?.font = .preferredFont(forTextStyle: .body)
         recalcBtn.contentHorizontalAlignment = .left
         recalcBtn.addTarget(self, action: #selector(onRecalculateTapped), for: .touchUpInside)
+        recalcBtn.isEnabled = dataSource?.isCalculatingElevation != true
         recalcBtn.translatesAutoresizingMaskIntoConstraints = false
 
         [buttonStack, chart, recalcSeparator, recalcBtn].forEach { card.addSubview($0) }
@@ -695,8 +726,12 @@ extension PlanRouteAnalyzeViewController: UITableViewDataSource {
               let cell = dequeueCardCell(tableView, indexPath) else { return UITableViewCell() }
         let card = cell.cardView
 
+        let uphill = data.hasElevationData ? data.uphill : nil
+        let downhill = data.hasElevationData ? data.downhill : nil
+        let altitudeMinimum = data.hasElevationData ? data.altMin : nil
+        let altitudeMaximum = data.hasElevationData ? data.altMax : nil
         let altRange: String
-        if let min = data.altMin, let max = data.altMax {
+        if let min = altitudeMinimum, let max = altitudeMaximum {
             let minStr = OAOsmAndFormatter.getFormattedAlt(min) ?? "–"
             let maxStr = OAOsmAndFormatter.getFormattedAlt(max) ?? "–"
             altRange = "\(minStr), \(maxStr)"
@@ -705,19 +740,19 @@ extension PlanRouteAnalyzeViewController: UITableViewDataSource {
         }
         let items = [
             AnalyzeStatItem(
-                value: fmtAlt(data.uphill),
+                value: fmtAlt(uphill),
                 label: localizedString("shared_string_uphill"),
-                accessibilityValue: accessibilityAltitude(data.uphill)
+                accessibilityValue: accessibilityAltitude(uphill)
             ),
             AnalyzeStatItem(
-                value: fmtAlt(data.downhill),
+                value: fmtAlt(downhill),
                 label: localizedString("shared_string_downhill"),
-                accessibilityValue: accessibilityAltitude(data.downhill)
+                accessibilityValue: accessibilityAltitude(downhill)
             ),
             AnalyzeStatItem(
                 value: altRange,
                 label: localizedString("altitude_range"),
-                accessibilityValue: accessibilityAltitudeRange(minimum: data.altMin, maximum: data.altMax)
+                accessibilityValue: accessibilityAltitudeRange(minimum: altitudeMinimum, maximum: altitudeMaximum)
             ),
             AnalyzeStatItem(
                 value: fmtSpeed(data.avgSpeed),
@@ -1052,8 +1087,9 @@ extension PlanRouteAnalyzeViewController: UITableViewDataSource {
 
     // MARK: - Formatters
 
-    private func fmtAlt(_ value: Double) -> String {
-        OAOsmAndFormatter.getFormattedAlt(value) ?? "–"
+    private func fmtAlt(_ value: Double?) -> String {
+        guard let value else { return "–" }
+        return OAOsmAndFormatter.getFormattedAlt(value) ?? "–"
     }
 
     private func fmtSpeed(_ value: Double?) -> String {

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
@@ -1270,6 +1270,7 @@ private extension PlanRouteAnalyzeViewController {
     private func scheduleSteepnessComputationIfNeeded(analysisData: PlanRouteAnalysisData?) {
         guard let analysisData,
               let gpxAnalysis = analysisData.gpxAnalysis,
+              isRoadAttributeDataAvailable(analysisData),
               !analysisData.routeStatistics.contains(where: { $0.name == Self.steepnessAttributeName }) else {
             return
         }
@@ -1300,6 +1301,7 @@ private extension PlanRouteAnalyzeViewController {
             guard let fallback = buildImmediateTerrainFallbackSteepnessStatistics() else { return [] }
             return Self.routeAttributeNames.compactMap { $0 == Self.steepnessAttributeName ? fallback : nil }
         }
+        guard isRoadAttributeDataAvailable(analysisData) else { return [] }
         let routeStatistics = analysisData.routeStatistics
         let groupedStatistics = Dictionary(grouping: routeStatistics) { $0.name }
         let syntheticSteepness: OARouteStatistics?
@@ -1319,6 +1321,10 @@ private extension PlanRouteAnalyzeViewController {
             }
             return groupedStatistics[attributeName]?.first
         }
+    }
+
+    private func isRoadAttributeDataAvailable(_ analysisData: PlanRouteAnalysisData) -> Bool {
+        hasCompletedElevationCalculation || allowsTerrainFallbackSteepness || !analysisData.routeStatistics.isEmpty
     }
 
     private func buildImmediateTerrainFallbackSteepnessStatistics() -> OARouteStatistics? {

--- a/Sources/Controllers/RoutePlanning/OAGpxApproximationHelper.mm
+++ b/Sources/Controllers/RoutePlanning/OAGpxApproximationHelper.mm
@@ -17,6 +17,96 @@
 #import "OAGPXDatabase.h"
 #import "OAGpxData.h"
 
+#include <gpxRouteApproximation.h>
+#include <routeSegment.h>
+#include <routeSegmentResult.h>
+
+static BOOL hasValidExternalTimestamps(NSArray<OASWptPt *> *points)
+{
+    if (points.count == 0)
+        return NO;
+
+    int64_t lastTimestamp = 0;
+    for (OASWptPt *point in points)
+    {
+        if (point.time == 0 || point.time < lastTimestamp)
+            return NO;
+        lastTimestamp = point.time;
+    }
+    return YES;
+}
+
+static float externalSpeed(const SHARED_PTR<GpxPoint> &gpxPoint,
+                           const SHARED_PTR<RouteSegmentResult> &segment,
+                           NSArray<OASWptPt *> *sourcePoints)
+{
+    NSInteger startIndex = gpxPoint->ind;
+    NSInteger endIndex = gpxPoint->targetInd;
+    if (endIndex == -1 && startIndex >= 0 && startIndex + 1 < sourcePoints.count)
+        endIndex = startIndex + 1;
+
+    if (startIndex < 0 || endIndex <= 0 || startIndex >= endIndex || endIndex >= sourcePoints.count)
+        return segment->segmentSpeed;
+
+    int64_t duration = sourcePoints[endIndex].time - sourcePoints[startIndex].time;
+    if (duration <= 0)
+        return segment->segmentSpeed;
+
+    double distance = 0;
+    for (NSInteger index = startIndex; index < endIndex; index++)
+    {
+        OASWptPt *firstPoint = sourcePoints[index];
+        OASWptPt *secondPoint = sourcePoints[index + 1];
+        distance += getDistance(firstPoint.getLatitude,
+                                firstPoint.getLongitude,
+                                secondPoint.getLatitude,
+                                secondPoint.getLongitude);
+    }
+    return distance > 0 ? distance / (duration / 1000.0) : segment->segmentSpeed;
+}
+
+static void recalculateTimeAndDistance(const vector<SHARED_PTR<RouteSegmentResult>> &segments)
+{
+    for (const auto &segment : segments)
+    {
+        float speed = segment->segmentSpeed;
+        if (speed == 0)
+            continue;
+
+        BOOL isForward = segment->getStartPointIndex() < segment->getEndPointIndex();
+        double distance = 0;
+        for (NSInteger index = segment->getStartPointIndex(); index != segment->getEndPointIndex();)
+        {
+            NSInteger nextIndex = isForward ? index + 1 : index - 1;
+            distance += measuredDist31(segment->object->getPoint31XTile((int)index),
+                                       segment->object->getPoint31YTile((int)index),
+                                       segment->object->getPoint31XTile((int)nextIndex),
+                                       segment->object->getPoint31YTile((int)nextIndex));
+            index = nextIndex;
+        }
+        segment->segmentTime = distance / speed;
+        segment->segmentSpeed = speed;
+        segment->distance = distance;
+    }
+}
+
+static void applyExternalTimestamps(OAGpxRouteApproximation *approximation,
+                                    OALocationsHolder *locationsHolder)
+{
+    NSArray<OASWptPt *> *sourcePoints = locationsHolder.getWptPtList;
+    if (approximation == nil || approximation.gpxApproximation == nullptr)
+        return;
+    if (!hasValidExternalTimestamps(sourcePoints))
+        return;
+
+    for (const auto &gpxPoint : approximation.gpxApproximation->finalPoints)
+    {
+        for (const auto &segment : gpxPoint->routeToTarget)
+            segment->segmentSpeed = externalSpeed(gpxPoint, segment, sourcePoints);
+        recalculateTimeAndDistance(gpxPoint->routeToTarget);
+    }
+}
+
 @interface OAGpxApproximationHelper () <OAGpxApproximationProgressDelegate>
 
 @end
@@ -105,13 +195,16 @@
         OAGpxApproximator *gpxApproximator = approximationsToDo.firstObject;
         [approximationsToDo removeObjectAtIndex:0];
         _currentApproximator = gpxApproximator;
+        __weak __typeof(self) weakSelf = self;
         [gpxApproximator calculateGpxApproximation:[[OAResultMatcher alloc] initWithPublishFunc:^BOOL(OAGpxRouteApproximation *__autoreleasing *approxPtr) {
             OAGpxRouteApproximation *strongApprox = (approxPtr && *approxPtr) ? *approxPtr : nil;
+            applyExternalTimestamps(strongApprox, gpxApproximator.locationsHolder);
             dispatch_async(dispatch_get_main_queue(), ^{
+                __strong __typeof(weakSelf) strongSelf = weakSelf;
                 if (!gpxApproximator.isCancelled)
                 {
                     approximateResult[gpxApproximator.locationsHolder] = strongApprox;
-                    [self approximateMultipleGpxAsync:approximationsToDo withResult:approximateResult];
+                    [strongSelf approximateMultipleGpxAsync:approximationsToDo withResult:approximateResult];
                 }
             });
             return YES;
@@ -151,7 +244,10 @@
         {
             [approximator calculateGpxApproximationSync:[[OAResultMatcher alloc] initWithPublishFunc:^BOOL(OAGpxRouteApproximation *__autoreleasing *approximation) {
                 if (approximation && *approximation)
+                {
+                    applyExternalTimestamps(*approximation, holder);
                     approximateResult[holder] = *approximation;
+                }
                 return YES;
             } cancelledFunc:^BOOL {
                 return NO;

--- a/Sources/Controllers/RoutePlanning/OAGpxApproximationHelper.mm
+++ b/Sources/Controllers/RoutePlanning/OAGpxApproximationHelper.mm
@@ -17,94 +17,9 @@
 #import "OAGPXDatabase.h"
 #import "OAGpxData.h"
 
-#include <gpxRouteApproximation.h>
-#include <routeSegment.h>
-#include <routeSegmentResult.h>
-
-static BOOL hasValidExternalTimestamps(NSArray<OASWptPt *> *points)
+static BOOL OAShouldUseExternalTimestamps(OALocationsHolder *locationsHolder)
 {
-    if (points.count == 0)
-        return NO;
-
-    int64_t lastTimestamp = 0;
-    for (OASWptPt *point in points)
-    {
-        if (point.time == 0 || point.time < lastTimestamp)
-            return NO;
-        lastTimestamp = point.time;
-    }
-    return YES;
-}
-
-static float externalSpeed(const SHARED_PTR<GpxPoint> &gpxPoint,
-                           const SHARED_PTR<RouteSegmentResult> &segment,
-                           NSArray<OASWptPt *> *sourcePoints)
-{
-    NSInteger startIndex = gpxPoint->ind;
-    NSInteger endIndex = gpxPoint->targetInd;
-    if (endIndex == -1 && startIndex >= 0 && startIndex + 1 < sourcePoints.count)
-        endIndex = startIndex + 1;
-
-    if (startIndex < 0 || endIndex <= 0 || startIndex >= endIndex || endIndex >= sourcePoints.count)
-        return segment->segmentSpeed;
-
-    int64_t duration = sourcePoints[endIndex].time - sourcePoints[startIndex].time;
-    if (duration <= 0)
-        return segment->segmentSpeed;
-
-    double distance = 0;
-    for (NSInteger index = startIndex; index < endIndex; index++)
-    {
-        OASWptPt *firstPoint = sourcePoints[index];
-        OASWptPt *secondPoint = sourcePoints[index + 1];
-        distance += getDistance(firstPoint.getLatitude,
-                                firstPoint.getLongitude,
-                                secondPoint.getLatitude,
-                                secondPoint.getLongitude);
-    }
-    return distance > 0 ? distance / (duration / 1000.0) : segment->segmentSpeed;
-}
-
-static void recalculateTimeAndDistance(const vector<SHARED_PTR<RouteSegmentResult>> &segments)
-{
-    for (const auto &segment : segments)
-    {
-        float speed = segment->segmentSpeed;
-        if (speed == 0)
-            continue;
-
-        BOOL isForward = segment->getStartPointIndex() < segment->getEndPointIndex();
-        double distance = 0;
-        for (NSInteger index = segment->getStartPointIndex(); index != segment->getEndPointIndex();)
-        {
-            NSInteger nextIndex = isForward ? index + 1 : index - 1;
-            distance += measuredDist31(segment->object->getPoint31XTile((int)index),
-                                       segment->object->getPoint31YTile((int)index),
-                                       segment->object->getPoint31XTile((int)nextIndex),
-                                       segment->object->getPoint31YTile((int)nextIndex));
-            index = nextIndex;
-        }
-        segment->segmentTime = distance / speed;
-        segment->segmentSpeed = speed;
-        segment->distance = distance;
-    }
-}
-
-static void applyExternalTimestamps(OAGpxRouteApproximation *approximation,
-                                    OALocationsHolder *locationsHolder)
-{
-    NSArray<OASWptPt *> *sourcePoints = locationsHolder.getWptPtList;
-    if (approximation == nil || approximation.gpxApproximation == nullptr)
-        return;
-    if (!hasValidExternalTimestamps(sourcePoints))
-        return;
-
-    for (const auto &gpxPoint : approximation.gpxApproximation->finalPoints)
-    {
-        for (const auto &segment : gpxPoint->routeToTarget)
-            segment->segmentSpeed = externalSpeed(gpxPoint, segment, sourcePoints);
-        recalculateTimeAndDistance(gpxPoint->routeToTarget);
-    }
+    return locationsHolder.size > 0 && [locationsHolder timeAtIndex:0] > 0;
 }
 
 @interface OAGpxApproximationHelper () <OAGpxApproximationProgressDelegate>
@@ -196,9 +111,8 @@ static void applyExternalTimestamps(OAGpxRouteApproximation *approximation,
         [approximationsToDo removeObjectAtIndex:0];
         _currentApproximator = gpxApproximator;
         __weak __typeof(self) weakSelf = self;
-        [gpxApproximator calculateGpxApproximation:[[OAResultMatcher alloc] initWithPublishFunc:^BOOL(OAGpxRouteApproximation *__autoreleasing *approxPtr) {
+        OAResultMatcher<OAGpxRouteApproximation *> *resultMatcher = [[OAResultMatcher alloc] initWithPublishFunc:^BOOL(OAGpxRouteApproximation *__autoreleasing *approxPtr) {
             OAGpxRouteApproximation *strongApprox = (approxPtr && *approxPtr) ? *approxPtr : nil;
-            applyExternalTimestamps(strongApprox, gpxApproximator.locationsHolder);
             dispatch_async(dispatch_get_main_queue(), ^{
                 __strong __typeof(weakSelf) strongSelf = weakSelf;
                 if (!gpxApproximator.isCancelled)
@@ -210,7 +124,9 @@ static void applyExternalTimestamps(OAGpxRouteApproximation *approximation,
             return YES;
         } cancelledFunc:^BOOL {
             return NO;
-        }]];
+        }];
+        [gpxApproximator calculateGpxApproximation:resultMatcher
+                             useExternalTimestamps:OAShouldUseExternalTimestamps(gpxApproximator.locationsHolder)];
     } else {
         NSArray *pair = [self processApproximationResults:approximateResult];
         if (self.delegate)
@@ -242,16 +158,15 @@ static void applyExternalTimestamps(OAGpxRouteApproximation *approximation,
         OAGpxApproximator *approximator = [self getNewGpxApproximator:holder];
         if (approximator)
         {
-            [approximator calculateGpxApproximationSync:[[OAResultMatcher alloc] initWithPublishFunc:^BOOL(OAGpxRouteApproximation *__autoreleasing *approximation) {
+            OAResultMatcher<OAGpxRouteApproximation *> *resultMatcher = [[OAResultMatcher alloc] initWithPublishFunc:^BOOL(OAGpxRouteApproximation *__autoreleasing *approximation) {
                 if (approximation && *approximation)
-                {
-                    applyExternalTimestamps(*approximation, holder);
                     approximateResult[holder] = *approximation;
-                }
                 return YES;
             } cancelledFunc:^BOOL {
                 return NO;
-            }]];
+            }];
+            [approximator calculateGpxApproximationSync:resultMatcher
+                                  useExternalTimestamps:OAShouldUseExternalTimestamps(holder)];
         }
     }
     

--- a/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
+++ b/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
@@ -1429,7 +1429,6 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 {
     std::vector<std::shared_ptr<RouteSegmentResult>> route;
     NSMutableArray<CLLocation *> *locations = [NSMutableArray new];
-    NSMutableArray<OASWptPt *> *sourcePoints = [NSMutableArray new];
     std::vector<int> routePointIndexes;
     routePointIndexes.push_back(0);
     for (NSInteger i = startPointIndex; i < endPointIndex; i++)
@@ -1444,10 +1443,15 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
         {
             for (OASWptPt *pt in dataPoints)
             {
-                CLLocation *l = [[CLLocation alloc] initWithCoordinate:CLLocationCoordinate2DMake(pt.getLatitude, pt.getLongitude) altitude:pt.ele horizontalAccuracy:0 verticalAccuracy:0 timestamp:NSDate.date];
-                
-                [locations addObject:l];
-                [sourcePoints addObject:pt];
+                NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:pt.time / 1000.0];
+                CLLocation *location = [[CLLocation alloc] initWithCoordinate:CLLocationCoordinate2DMake(pt.getLatitude, pt.getLongitude)
+                                                                     altitude:pt.ele
+                                                           horizontalAccuracy:0
+                                                             verticalAccuracy:0
+                                                                       course:0
+                                                                        speed:pt.speed
+                                                                    timestamp:timestamp];
+                [locations addObject:location];
             }
             [pair.lastObject setTrkPtIndexIndex:(int)(i + 1 < _before.points.count - 1 ? locations.count : locations.count - 1)];
             route.insert(route.end(), dataSegments.begin(), dataSegments.end());
@@ -1462,16 +1466,7 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
                                                                     locations:locations
                                                             routePointIndexes:routePointIndexes
                                                                        points:nil];
-        OASTrkSegment *routeSegment = [routeExporter generateRouteSegment];
-        NSInteger pointsCount = MIN(routeSegment.points.count, sourcePoints.count);
-        for (NSInteger index = 0; index < pointsCount; index++)
-        {
-            OASWptPt *sourcePoint = sourcePoints[index];
-            OASWptPt *routePoint = routeSegment.points[index];
-            routePoint.time = sourcePoint.time;
-            routePoint.speed = sourcePoint.speed;
-        }
-        return routeSegment;
+        return [routeExporter generateRouteSegment];
     }
     else if (endPointIndex - startPointIndex >= 0)
     {

--- a/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
+++ b/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
@@ -32,6 +32,120 @@
 static OAApplicationMode *DEFAULT_APP_MODE;
 static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 
+@interface OAGpxTimeCalculator : NSObject
+
+- (instancetype)initWithInitialTimestamp:(int64_t)initialTimestamp;
+- (void)fillPointsArray:(NSMutableArray<OASWptPt *> *)points
+                segment:(const SHARED_PTR<RouteSegmentResult> &)segment
+        includeEndPoint:(BOOL)includeEndPoint;
+- (void)addPointToArray:(NSMutableArray<OASWptPt *> *)points
+                segment:(const SHARED_PTR<RouteSegmentResult> &)segment
+                  index:(NSInteger)index
+            heightArray:(const std::vector<double> &)heightArray;
+- (int64_t)durationForSegment:(const SHARED_PTR<RouteSegmentResult> &)segment
+                 fromLocation:(const LatLon &)fromLocation
+                   toLocation:(const LatLon &)toLocation;
+- (int64_t)durationForSegment:(const SHARED_PTR<RouteSegmentResult> &)segment
+                 fromLatitude:(double)latitude
+                    longitude:(double)longitude
+                   toLocation:(const LatLon &)toLocation;
+
+@end
+
+@implementation OAGpxTimeCalculator
+{
+    int64_t _timestamp;
+    double _previousLatitude;
+    double _previousLongitude;
+    BOOL _hasPreviousPoint;
+}
+
+- (instancetype)initWithInitialTimestamp:(int64_t)initialTimestamp
+{
+    self = [super init];
+    if (self)
+        _timestamp = initialTimestamp;
+    return self;
+}
+
+- (void)fillPointsArray:(NSMutableArray<OASWptPt *> *)points
+                segment:(const SHARED_PTR<RouteSegmentResult> &)segment
+        includeEndPoint:(BOOL)includeEndPoint
+{
+    NSInteger index = segment->getStartPointIndex();
+    BOOL isForward = segment->isForwardDirection();
+    const auto &heightArray = segment->object->calculateHeightArray();
+    while (index != segment->getEndPointIndex())
+    {
+        [self addPointToArray:points segment:segment index:index heightArray:heightArray];
+        index = isForward ? index + 1 : index - 1;
+    }
+    if (includeEndPoint)
+        [self addPointToArray:points segment:segment index:index heightArray:heightArray];
+}
+
+- (void)addPointToArray:(NSMutableArray<OASWptPt *> *)points
+                segment:(const SHARED_PTR<RouteSegmentResult> &)segment
+                  index:(NSInteger)index
+            heightArray:(const std::vector<double> &)heightArray
+{
+    LatLon location = segment->getPoint((int)index);
+    OASWptPt *point = [[OASWptPt alloc] init];
+    point.lat = location.lat;
+    point.lon = location.lon;
+    if (heightArray.size() > index * 2 + 1)
+        point.ele = heightArray[index * 2 + 1];
+
+    if (_timestamp > 0 && index == segment->getStartPointIndex() && _hasPreviousPoint)
+        _timestamp += [self durationForSegment:segment
+                                  fromLatitude:_previousLatitude
+                                     longitude:_previousLongitude
+                                    toLocation:location];
+
+    if (_timestamp > 0)
+    {
+        point.time = _timestamp;
+        point.speed = segment->segmentSpeed;
+    }
+
+    if (_timestamp > 0 && index != segment->getEndPointIndex())
+    {
+        NSInteger nextIndex = index + (segment->isForwardDirection() ? 1 : -1);
+        LatLon nextLocation = segment->getPoint((int)nextIndex);
+        _timestamp += [self durationForSegment:segment fromLocation:location toLocation:nextLocation];
+        _previousLatitude = nextLocation.lat;
+        _previousLongitude = nextLocation.lon;
+        _hasPreviousPoint = YES;
+    }
+
+    [points addObject:point];
+}
+
+- (int64_t)durationForSegment:(const SHARED_PTR<RouteSegmentResult> &)segment
+                 fromLocation:(const LatLon &)fromLocation
+                   toLocation:(const LatLon &)toLocation
+{
+    return [self durationForSegment:segment
+                       fromLatitude:fromLocation.lat
+                          longitude:fromLocation.lon
+                         toLocation:toLocation];
+}
+
+- (int64_t)durationForSegment:(const SHARED_PTR<RouteSegmentResult> &)segment
+                 fromLatitude:(double)latitude
+                    longitude:(double)longitude
+                   toLocation:(const LatLon &)toLocation
+{
+    float speed = segment->segmentSpeed;
+    double distance = [OAMapUtils getDistance:latitude
+                                         lon1:longitude
+                                         lat2:toLocation.lat
+                                         lon2:toLocation.lon];
+    return distance > 0 && speed > 0 ? (int64_t)(distance / speed * 1000.0) : 0;
+}
+
+@end
+
 @interface OAMeasurementEditingContext() <OARouteCalculationProgressCallback, OARouteCalculationResultListener>
 @property (nonatomic, assign) BOOL checkApproximation;
 - (NSArray<NSArray<OASWptPt *> *> *)getOrderedRoadSegmentDataKeys;
@@ -959,6 +1073,9 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 		return nil;
 	
 	NSMutableArray<OASWptPt *> *routePoints = [NSMutableArray array];
+	int64_t initialTimestamp = originalPoints.count == 0 ? 0 : originalPoints.firstObject.time;
+	OAGpxTimeCalculator *timeCalculator = [[OAGpxTimeCalculator alloc]
+		initWithInitialTimestamp:initialTimestamp];
 	const auto gpxPoints = gpxApproximation.gpxApproximation->finalPoints;
 	for (NSInteger i = 0; i < gpxPoints.size(); i++)
 	{
@@ -979,7 +1096,7 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 		{
 			const auto& seg = segments[k];
 			BOOL includeEndPoint = (duplicatePoint || lastGpxPoint) && k == segments.size() - 1;
-			[self fillPointsArray:points seg:seg includeEndPoint:includeEndPoint];
+			[timeCalculator fillPointsArray:points segment:seg includeEndPoint:includeEndPoint];
 		}
 		if (points.count > 0)
 		{
@@ -1085,36 +1202,6 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 		}
 	}
 	return YES;
-}
-
-- (void) fillPointsArray:(NSMutableArray<OASWptPt *> *)points
-					 seg:(const SHARED_PTR<RouteSegmentResult> &)seg
-		 includeEndPoint:(BOOL)includeEndPoint
-{
-	NSInteger ind = seg->getStartPointIndex();
-	BOOL plus = seg->isForwardDirection();
-	const auto& heightArray = seg->object->calculateHeightArray();
-	while (ind != seg->getEndPointIndex())
-	{
-		[self addPointToArray:points seg:seg index:ind heightArray:heightArray];
-		ind = plus ? ind + 1 : ind - 1;
-	}
-	if (includeEndPoint)
-		[self addPointToArray:points seg:seg index:ind heightArray:heightArray];
-}
-
-- (void) addPointToArray:(NSMutableArray<OASWptPt *> *)points
-					 seg:(const SHARED_PTR<RouteSegmentResult> &)seg
-				   index:(NSInteger)index
-			 heightArray:(const std::vector<double>&)heightArray
-{
-	LatLon l = seg->getPoint((int)index);
-	OASWptPt *pt = [[OASWptPt alloc] init];
-	if (heightArray.size() > index * 2 + 1)
-		pt.ele = heightArray[index * 2 + 1];
-    pt.lat = l.lat;
-    pt.lon = l.lon;
-	[points addObject:pt];
 }
 
 - (BOOL) canSplit:(BOOL)after
@@ -1342,6 +1429,7 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 {
     std::vector<std::shared_ptr<RouteSegmentResult>> route;
     NSMutableArray<CLLocation *> *locations = [NSMutableArray new];
+    NSMutableArray<OASWptPt *> *sourcePoints = [NSMutableArray new];
     std::vector<int> routePointIndexes;
     routePointIndexes.push_back(0);
     for (NSInteger i = startPointIndex; i < endPointIndex; i++)
@@ -1359,6 +1447,7 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
                 CLLocation *l = [[CLLocation alloc] initWithCoordinate:CLLocationCoordinate2DMake(pt.getLatitude, pt.getLongitude) altitude:pt.ele horizontalAccuracy:0 verticalAccuracy:0 timestamp:NSDate.date];
                 
                 [locations addObject:l];
+                [sourcePoints addObject:pt];
             }
             [pair.lastObject setTrkPtIndexIndex:(int)(i + 1 < _before.points.count - 1 ? locations.count : locations.count - 1)];
             route.insert(route.end(), dataSegments.begin(), dataSegments.end());
@@ -1368,7 +1457,21 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
     if (locations.count > 0 && route.size() > 0)
     {
         [_before.points[startPointIndex] setTrkPtIndexIndex:0];
-        return [[[OARouteExporter alloc] initWithName:@"" route:route locations:locations routePointIndexes:routePointIndexes points:nil] generateRouteSegment];
+        OARouteExporter *routeExporter = [[OARouteExporter alloc] initWithName:@""
+                                                                        route:route
+                                                                    locations:locations
+                                                            routePointIndexes:routePointIndexes
+                                                                       points:nil];
+        OASTrkSegment *routeSegment = [routeExporter generateRouteSegment];
+        NSInteger pointsCount = MIN(routeSegment.points.count, sourcePoints.count);
+        for (NSInteger index = 0; index < pointsCount; index++)
+        {
+            OASWptPt *sourcePoint = sourcePoints[index];
+            OASWptPt *routePoint = routeSegment.points[index];
+            routePoint.time = sourcePoint.time;
+            routePoint.speed = sourcePoint.speed;
+        }
+        return routeSegment;
     }
     else if (endPointIndex - startPointIndex >= 0)
     {

--- a/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
+++ b/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
@@ -1465,7 +1465,8 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
                                                                         route:route
                                                                     locations:locations
                                                             routePointIndexes:routePointIndexes
-                                                                       points:nil];
+                                                                       points:nil
+                                                           preserveTimestamps:YES];
         return [routeExporter generateRouteSegment];
     }
     else if (endPointIndex - startPointIndex >= 0)

--- a/Sources/Controllers/RoutePlanning/OARouteExporter.h
+++ b/Sources/Controllers/RoutePlanning/OARouteExporter.h
@@ -23,7 +23,8 @@ struct RouteSegmentResult;
                        route:(std::vector<std::shared_ptr<RouteSegmentResult>> &)route
                    locations:(NSArray<CLLocation *> *)locations
            routePointIndexes:(std::vector<int>)routePointIndexes
-                      points:(NSArray<OASWptPt *> *)points;
+                      points:(NSArray<OASWptPt *> *)points
+          preserveTimestamps:(BOOL)preserveTimestamps;
 - (OASGpxFile *)exportRoute;
 - (OASTrkSegment *)generateRouteSegment;
 

--- a/Sources/Controllers/RoutePlanning/OARouteExporter.mm
+++ b/Sources/Controllers/RoutePlanning/OARouteExporter.mm
@@ -170,6 +170,10 @@
         OASWptPt *pt = [[OASWptPt alloc] initWithLat:loc.coordinate.latitude lon:loc.coordinate.longitude];
         if (loc.speed > 0)
             pt.speed = loc.speed;
+
+        NSTimeInterval timestamp = loc.timestamp.timeIntervalSince1970;
+        if (timestamp > 0)
+            pt.time = (int64_t)(timestamp * 1000.0);
         
         if (loc.altitude > 0)
             pt.ele = loc.altitude;

--- a/Sources/Controllers/RoutePlanning/OARouteExporter.mm
+++ b/Sources/Controllers/RoutePlanning/OARouteExporter.mm
@@ -23,6 +23,7 @@
     NSArray<CLLocation *> *_locations;
     std::vector<int> _routePointIndexes;
     NSArray<OASWptPt *> *_points;
+    BOOL _preserveTimestamps;
 }
 
 - (instancetype)initWithName:(NSString *)name
@@ -30,6 +31,7 @@
                     locations:(NSArray<CLLocation *> *)locations
             routePointIndexes:(std::vector<int>)routePointIndexes
                        points:(NSArray<OASWptPt *> *)points
+           preserveTimestamps:(BOOL)preserveTimestamps
 {
     self = [super init];
     if (self) {
@@ -38,6 +40,7 @@
         _routePointIndexes = routePointIndexes;
         _locations = locations;
         _points = points;
+        _preserveTimestamps = preserveTimestamps;
     }
     return self;
 }
@@ -171,9 +174,12 @@
         if (loc.speed > 0)
             pt.speed = loc.speed;
 
-        NSTimeInterval timestamp = loc.timestamp.timeIntervalSince1970;
-        if (timestamp > 0)
-            pt.time = (int64_t)(timestamp * 1000.0);
+        if (_preserveTimestamps)
+        {
+            NSTimeInterval timestamp = loc.timestamp.timeIntervalSince1970;
+            if (timestamp > 0)
+                pt.time = (int64_t)(timestamp * 1000.0);
+        }
         
         if (loc.altitude > 0)
             pt.ele = loc.altitude;

--- a/Sources/Router/OAGpxApproximator.h
+++ b/Sources/Router/OAGpxApproximator.h
@@ -34,8 +34,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype) initWithLocationsHolder:(OALocationsHolder *)locationsHolder;
 - (instancetype) initWithApplicationMode:(OAApplicationMode *)mode pointApproximation:(double)pointApproximation locationsHolder:(OALocationsHolder *)locationsHolder;
 
-- (void) calculateGpxApproximation:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher;
-- (void) calculateGpxApproximationSync:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher;
+- (void)calculateGpxApproximation:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+            useExternalTimestamps:(BOOL)useExternalTimestamps;
+- (void)calculateGpxApproximationSync:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+                useExternalTimestamps:(BOOL)useExternalTimestamps;
 - (BOOL) isCancelled;
 - (void) cancelApproximation;
 

--- a/Sources/Router/OAGpxApproximator.mm
+++ b/Sources/Router/OAGpxApproximator.mm
@@ -42,6 +42,8 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
 								 env:(OARoutingEnvironment *)env
 								gctx:(SHARED_PTR<GpxRouteApproximation> &)gctx
 							  points:(const std::vector<SHARED_PTR<GpxPoint>> &)points
+					 locationsHolder:(OALocationsHolder *)locationsHolder
+				useExternalTimestamps:(BOOL)useExternalTimestamps
 					   resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher;
 
 @end
@@ -52,6 +54,8 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
 	OARoutingEnvironment *_env;
 	SHARED_PTR<GpxRouteApproximation> _gctx;
 	std::vector<SHARED_PTR<GpxPoint>> _points;
+	OALocationsHolder *_locationsHolder;
+	BOOL _useExternalTimestamps;
 	OAResultMatcher<OAGpxRouteApproximation *> *_resultMatcher;
 }
 
@@ -59,6 +63,8 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
 								 env:(OARoutingEnvironment *)env
 								gctx:(SHARED_PTR<GpxRouteApproximation> &)gctx
 							  points:(const std::vector<SHARED_PTR<GpxPoint>> &)points
+					 locationsHolder:(OALocationsHolder *)locationsHolder
+				useExternalTimestamps:(BOOL)useExternalTimestamps
 					   resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
 {
 	self = [super init];
@@ -69,6 +75,8 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
 		_env = env;
 		_gctx = gctx;
 		_points = points;
+		_locationsHolder = locationsHolder;
+		_useExternalTimestamps = useExternalTimestamps;
 		_resultMatcher = resultMatcher;
 	}
 	return self;
@@ -101,7 +109,12 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
 		}
 		return;
 	}
-	[OARoutingHelper.sharedInstance calculateGpxApproximation:_env gctx:_gctx points:_points resultMatcher:_resultMatcher];
+	[OARoutingHelper.sharedInstance calculateGpxApproximation:_env
+												gctx:_gctx
+											  points:_points
+									 locationsHolder:_locationsHolder
+								useExternalTimestamps:_useExternalTimestamps
+									   resultMatcher:_resultMatcher];
 	@synchronized (_approximator)
 	{
 		_approximator.approximationTask = nil;
@@ -214,7 +227,8 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
 		_gctx->ctx->progress->cancelled = true;
 }
 
-- (void) calculateGpxApproximation:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+- (void)calculateGpxApproximation:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+            useExternalTimestamps:(BOOL)useExternalTimestamps
 {
 	if (OAHasValidProgress(_gctx))
 		_gctx->ctx->progress->cancelled = true;
@@ -237,12 +251,19 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
 	_gctx = gctx;
 	[self startProgress];
 	[self updateProgress:gctx];
-	OAApproximationTask *task = [[OAApproximationTask alloc] initWithApproximator:self env:_env gctx:_gctx points:points resultMatcher:resultMatcher];
+	OAApproximationTask *task = [[OAApproximationTask alloc] initWithApproximator:self
+														 env:_env
+														gctx:_gctx
+													  points:points
+												 locationsHolder:_locationsHolder
+											useExternalTimestamps:useExternalTimestamps
+												   resultMatcher:resultMatcher];
 	task.previousTask = _approximationTask;
 	[task start];
 }
 
-- (void) calculateGpxApproximationSync:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+- (void)calculateGpxApproximationSync:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+                useExternalTimestamps:(BOOL)useExternalTimestamps
 {
     @try {
         auto gctx = [self getNewGpxApproximationContext];
@@ -259,7 +280,12 @@ static BOOL OAHasValidProgress(const SHARED_PTR<GpxRouteApproximation>& gctx)
             return;
         }
 
-        [_routingHelper calculateGpxApproximation:_env gctx:gctx points:points resultMatcher:resultMatcher];
+        [_routingHelper calculateGpxApproximation:_env
+                                             gctx:gctx
+                                           points:points
+                                  locationsHolder:_locationsHolder
+                             useExternalTimestamps:useExternalTimestamps
+                                    resultMatcher:resultMatcher];
     } @catch (NSException *exception) {
         [resultMatcher publish:nil];
         NSLog(@"Error: %@", exception.reason);

--- a/Sources/Router/OALocationsHolder.h
+++ b/Sources/Router/OALocationsHolder.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (double) getLatitude:(NSInteger)index;
 - (double) getLongitude:(NSInteger)index;
+- (int64_t)timeAtIndex:(NSInteger)index;
 
 - (std::vector<std::pair<double, double>>) getLatLonList;
 - (NSArray<OASWptPt *> *)getWptPtList;

--- a/Sources/Router/OALocationsHolder.mm
+++ b/Sources/Router/OALocationsHolder.mm
@@ -110,6 +110,27 @@
 	return 0;
 }
 
+- (int64_t)timeAtIndex:(NSInteger)index
+{
+	switch (_locationType)
+	{
+		case LOCATION_TYPE_LOCATION:
+		{
+			if (index >= 0 && index < _locationList.count)
+				return (int64_t)(_locationList[index].timestamp.timeIntervalSince1970 * 1000.0);
+			break;
+		}
+		case LOCATION_TYPE_WPTPT:
+		{
+			if (index >= 0 && index < _wptPtList.count)
+				return _wptPtList[index].time;
+		}
+		default:
+			return 0;
+	}
+	return 0;
+}
+
 - (NSArray *) getList:(NSInteger)locationType
 {
 	NSMutableArray *res = [NSMutableArray array];

--- a/Sources/Router/OALocationsHolder.mm
+++ b/Sources/Router/OALocationsHolder.mm
@@ -112,22 +112,8 @@
 
 - (int64_t)timeAtIndex:(NSInteger)index
 {
-	switch (_locationType)
-	{
-		case LOCATION_TYPE_LOCATION:
-		{
-			if (index >= 0 && index < _locationList.count)
-				return (int64_t)(_locationList[index].timestamp.timeIntervalSince1970 * 1000.0);
-			break;
-		}
-		case LOCATION_TYPE_WPTPT:
-		{
-			if (index >= 0 && index < _wptPtList.count)
-				return _wptPtList[index].time;
-		}
-		default:
-			return 0;
-	}
+	if (_locationType == LOCATION_TYPE_WPTPT && index >= 0 && index < _wptPtList.count)
+		return _wptPtList[index].time;
 	return 0;
 }
 

--- a/Sources/Router/OARouteProvider.h
+++ b/Sources/Router/OARouteProvider.h
@@ -123,10 +123,12 @@ struct RouteSegmentResult;
 - (OARoutingEnvironment *) getRoutingEnvironment:(OAApplicationMode *)mode start:(CLLocation *)start end:(CLLocation *)end;
 - (std::vector<std::shared_ptr<GpxPoint>>) generateGpxPoints:(OARoutingEnvironment *)env gctx:(std::shared_ptr<GpxRouteApproximation>)gctx locationsHolder:(OALocationsHolder *)locationsHolder;
 
-- (std::shared_ptr<GpxRouteApproximation>) calculateGpxApproximation:(OARoutingEnvironment *)env
-														   gctx:(std::shared_ptr<GpxRouteApproximation>)gctx
-														 points:(std::vector<std::shared_ptr<GpxPoint>> &)points
-												  resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher;
+- (std::shared_ptr<GpxRouteApproximation>)calculateGpxApproximation:(OARoutingEnvironment *)env
+                                                              gctx:(std::shared_ptr<GpxRouteApproximation>)gctx
+                                                            points:(std::vector<std::shared_ptr<GpxPoint>> &)points
+                                                   locationsHolder:(OALocationsHolder *)locationsHolder
+                                              useExternalTimestamps:(BOOL)useExternalTimestamps
+                                                     resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher;
 
 + (std::vector<std::shared_ptr<RouteSegmentResult>>) parseOsmAndGPXRoute:(NSMutableArray<CLLocation *> *)points
                                                                  gpxFile:(OASGpxFile *)gpxFile

--- a/Sources/Router/OARouteProvider.mm
+++ b/Sources/Router/OARouteProvider.mm
@@ -56,6 +56,88 @@
 static NSString * const kRouteCalculationOutOfMemoryError = @"Not enough memory to calculate route.";
 static NSString * const kRouteCalculationFailedError = @"Route calculation failed.";
 
+static BOOL OAHasValidExternalTimestamps(OALocationsHolder *locationsHolder)
+{
+    if (locationsHolder.size == 0)
+        return NO;
+
+    int64_t lastTimestamp = 0;
+    for (NSInteger index = 0; index < locationsHolder.size; index++)
+    {
+        int64_t timestamp = [locationsHolder timeAtIndex:index];
+        if (timestamp == 0 || timestamp < lastTimestamp)
+            return NO;
+        lastTimestamp = timestamp;
+    }
+    return YES;
+}
+
+static float OACalculateExternalSpeed(const SHARED_PTR<GpxPoint> &gpxPoint,
+                                      const SHARED_PTR<RouteSegmentResult> &segment,
+                                      OALocationsHolder *locationsHolder)
+{
+    NSInteger startIndex = gpxPoint->ind;
+    NSInteger endIndex = gpxPoint->targetInd;
+    if (endIndex == -1 && startIndex >= 0 && startIndex + 1 < locationsHolder.size)
+        endIndex = startIndex + 1;
+
+    if (startIndex < 0 || endIndex <= 0 || startIndex >= endIndex || endIndex >= locationsHolder.size)
+        return segment->segmentSpeed;
+
+    int64_t duration = [locationsHolder timeAtIndex:endIndex] - [locationsHolder timeAtIndex:startIndex];
+    if (duration <= 0)
+        return segment->segmentSpeed;
+
+    double distance = 0;
+    for (NSInteger index = startIndex; index < endIndex; index++)
+    {
+        distance += getDistance([locationsHolder getLatitude:index],
+                                [locationsHolder getLongitude:index],
+                                [locationsHolder getLatitude:index + 1],
+                                [locationsHolder getLongitude:index + 1]);
+    }
+    return distance > 0 ? (float)(distance / (duration / 1000.0)) : segment->segmentSpeed;
+}
+
+static void OARecalculateTimeAndDistance(const vector<SHARED_PTR<RouteSegmentResult>> &segments)
+{
+    for (const auto &segment : segments)
+    {
+        float speed = segment->segmentSpeed;
+        if (speed == 0)
+            continue;
+
+        BOOL isForward = segment->getStartPointIndex() < segment->getEndPointIndex();
+        double distance = 0;
+        for (NSInteger index = segment->getStartPointIndex(); index != segment->getEndPointIndex();)
+        {
+            NSInteger nextIndex = isForward ? index + 1 : index - 1;
+            distance += measuredDist31(segment->object->getPoint31XTile((int)index),
+                                       segment->object->getPoint31YTile((int)index),
+                                       segment->object->getPoint31XTile((int)nextIndex),
+                                       segment->object->getPoint31YTile((int)nextIndex));
+            index = nextIndex;
+        }
+        segment->segmentTime = (float)(distance / speed);
+        segment->segmentSpeed = speed;
+        segment->distance = (float)distance;
+    }
+}
+
+static void OAApplyExternalTimestamps(const SHARED_PTR<GpxRouteApproximation> &approximation,
+                                      OALocationsHolder *locationsHolder)
+{
+    if (approximation == nullptr || !OAHasValidExternalTimestamps(locationsHolder))
+        return;
+
+    for (const auto &gpxPoint : approximation->finalPoints)
+    {
+        for (const auto &segment : gpxPoint->routeToTarget)
+            segment->segmentSpeed = OACalculateExternalSpeed(gpxPoint, segment, locationsHolder);
+        OARecalculateTimeAndDistance(gpxPoint->routeToTarget);
+    }
+}
+
 static NSString *RouteCalculationErrorMessage(const std::exception &exception)
 {
     const char *what = exception.what();
@@ -1075,10 +1157,12 @@ static NSString *RouteCalculationErrorMessage(const std::exception &exception)
     return env.router->generateGpxPoints(gctx, locationsHolder.getLatLonList);
 }
 
-- (SHARED_PTR<GpxRouteApproximation>) calculateGpxApproximation:(OARoutingEnvironment *)env
-                                                           gctx:(SHARED_PTR<GpxRouteApproximation>)gctx
-                                                         points:(std::vector<SHARED_PTR<GpxPoint>> &)points
-                                                  resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+- (SHARED_PTR<GpxRouteApproximation>)calculateGpxApproximation:(OARoutingEnvironment *)env
+                                                         gctx:(SHARED_PTR<GpxRouteApproximation>)gctx
+                                                       points:(std::vector<SHARED_PTR<GpxPoint>> &)points
+                                              locationsHolder:(OALocationsHolder *)locationsHolder
+                                         useExternalTimestamps:(BOOL)useExternalTimestamps
+                                                resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
 {
     if (!env || !env.router || gctx == nullptr || gctx->ctx == nullptr || gctx->ctx->config == nullptr || gctx->ctx->progress == nullptr || points.empty())
     {
@@ -1088,7 +1172,7 @@ static NSString *RouteCalculationErrorMessage(const std::exception &exception)
 
     @synchronized (_nativeRoutingLock) {
         const auto resultAcceptor =
-        [resultMatcher]
+        [resultMatcher, locationsHolder, useExternalTimestamps]
         (SHARED_PTR<GpxRouteApproximation> approximation) -> bool
         {
             if (approximation == nullptr)
@@ -1097,6 +1181,8 @@ static NSString *RouteCalculationErrorMessage(const std::exception &exception)
                 return true;
             }
 
+            if (useExternalTimestamps)
+                OAApplyExternalTimestamps(approximation, locationsHolder);
             OAGpxRouteApproximation *approx = [[OAGpxRouteApproximation alloc] initWithApproximation:approximation];
             [resultMatcher publish:approx];
             return true;

--- a/Sources/Router/OARoutingHelper+cpp.h
+++ b/Sources/Router/OARoutingHelper+cpp.h
@@ -19,10 +19,12 @@
 
 - (std::vector<std::shared_ptr<RouteSegmentResult>>) getUpcomingTunnel:(float)distToStart;
 - (std::vector<std::shared_ptr<GpxPoint>>) generateGpxPoints:(OARoutingEnvironment *)env gctx:(std::shared_ptr<GpxRouteApproximation>)gctx locationsHolder:(OALocationsHolder *)locationsHolder;
-- (std::shared_ptr<GpxRouteApproximation>) calculateGpxApproximation:(OARoutingEnvironment *)env
-                                                           gctx:(std::shared_ptr<GpxRouteApproximation>)gctx
-                                                         points:(std::vector<std::shared_ptr<GpxPoint>> &)points
-                                                  resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher;
+- (std::shared_ptr<GpxRouteApproximation>)calculateGpxApproximation:(OARoutingEnvironment *)env
+                                                              gctx:(std::shared_ptr<GpxRouteApproximation>)gctx
+                                                            points:(std::vector<std::shared_ptr<GpxPoint>> &)points
+                                                   locationsHolder:(OALocationsHolder *)locationsHolder
+                                              useExternalTimestamps:(BOOL)useExternalTimestamps
+                                                     resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher;
 
 - (std::shared_ptr<RouteSegmentResult>) getCurrentSegmentResult;
 - (std::shared_ptr<RouteSegmentResult>) getNextStreetSegmentResult;

--- a/Sources/Router/OARoutingHelper.mm
+++ b/Sources/Router/OARoutingHelper.mm
@@ -1182,7 +1182,12 @@ static BOOL _isDeviatedFromRoute = false;
     
     NSArray<CLLocation *> *locations = route.getImmutableAllLocations;
     auto originalRoute = route.getOriginalRoute;
-    OARouteExporter *exporter = [[OARouteExporter alloc] initWithName:name route:originalRoute locations:locations routePointIndexes:{} points:points];
+    OARouteExporter *exporter = [[OARouteExporter alloc] initWithName:name
+                                                               route:originalRoute
+                                                           locations:locations
+                                                   routePointIndexes:{}
+                                                              points:points
+                                                  preserveTimestamps:NO];
     return [exporter exportRoute];
 }
 

--- a/Sources/Router/OARoutingHelper.mm
+++ b/Sources/Router/OARoutingHelper.mm
@@ -1045,12 +1045,19 @@ static BOOL _isDeviatedFromRoute = false;
 	return [_provider generateGpxPoints:env gctx:gctx locationsHolder:locationsHolder];
 }
 
-- (SHARED_PTR<GpxRouteApproximation>) calculateGpxApproximation:(OARoutingEnvironment *)env
-														   gctx:(SHARED_PTR<GpxRouteApproximation>)gctx
-														 points:(std::vector<SHARED_PTR<GpxPoint>> &)points
-												  resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
+- (SHARED_PTR<GpxRouteApproximation>)calculateGpxApproximation:(OARoutingEnvironment *)env
+                                                         gctx:(SHARED_PTR<GpxRouteApproximation>)gctx
+                                                       points:(std::vector<SHARED_PTR<GpxPoint>> &)points
+                                              locationsHolder:(OALocationsHolder *)locationsHolder
+                                         useExternalTimestamps:(BOOL)useExternalTimestamps
+                                                resultMatcher:(OAResultMatcher<OAGpxRouteApproximation *> *)resultMatcher
 {
-	return [_provider calculateGpxApproximation:env gctx:gctx points:points resultMatcher:resultMatcher];
+	return [_provider calculateGpxApproximation:env
+											 gctx:gctx
+										   points:points
+								  locationsHolder:locationsHolder
+							 useExternalTimestamps:useExternalTimestamps
+									resultMatcher:resultMatcher];
 }
 
 - (nullable CLLocation *) getLastProjection


### PR DESCRIPTION
## Summary

Aligned the iOS Plan Route Analyze flow with Android.

## Problem

On iOS, the altitude/speed graph was empty when opening a GPX track, even when the track already contained the required data. Average speed, maximum speed, and time in motion were also unavailable before elevation recalculation.

After recalculation, the iOS speed statistics differed significantly from Android because iOS used routing-profile speeds instead of the original GPX timestamps.

## Changes

- Display the altitude/speed graph immediately when the GPX contains the required data.
- Display average speed, maximum speed, and time in motion before elevation recalculation.
- Make **Recalculate elevation** trigger the complete elevation and route-data calculation flow.
- Display Road type, Surface, Smoothness, and Steepness after the enriched data becomes available.
- Preserve the original GPX timestamps during route approximation.
- Recalculate segment speed, time, and distance using the original timestamps instead of routing-profile speeds.
- Propagate the recalculated timestamps and speeds to the exported track and iOS UI state.

## Result

The initial graph and available track statistics are now displayed before recalculation. After elevation recalculation, the speed statistics are much closer to the Android results.