### PR TITLE
Context menu fixes

### DIFF
--- a/Sources/Helpers/OAAmenitySearcher.mm
+++ b/Sources/Helpers/OAAmenitySearcher.mm
@@ -40,6 +40,7 @@
 
 #include <OsmAndCore/CommonTypes.h>
 #include <OsmAndCore/Data/DataCommonTypes.h>
+#include <OsmAndCore/Data/ObfInfo.h>
 #include <OsmAndCore/Data/ObfMapSectionInfo.h>
 #include <OsmAndCore/Data/ObfPoiSectionInfo.h>
 #include <OsmAndCore/Data/Road.h>
@@ -745,17 +746,6 @@ static std::shared_ptr<const OsmAnd::Amenity> OAGetAmenityFromSearchResult(const
     result.append(baseMaps);
     result.append(travelMaps);
     return result;
-}
-
-+ (NSArray<NSString *> *) getAmenityRepositoriesNames:(BOOL)includeTravel
-{
-    NSMutableArray<NSString *> *filePaths = [NSMutableArray new];
-    const auto files = [self getAmenityRepositories:includeTravel];
-    for (const auto file : files)
-    {
-        [filePaths addObject:file->filePath.toNSString()];
-    }
-    return filePaths;
 }
 
 + (BOOL) isWorldMap:(NSString *)obfFilePath
@@ -1612,10 +1602,11 @@ static std::shared_ptr<const OsmAnd::Amenity> OAGetAmenityFromSearchResult(const
     
     const std::shared_ptr<OsmAnd::AmenitiesInAreaSearch::Criteria>& searchCriteria = std::shared_ptr<OsmAnd::AmenitiesInAreaSearch::Criteria>(new OsmAnd::AmenitiesInAreaSearch::Criteria);
     const auto& obfsCollection = [OsmAndApp instance].resourcesManager->obfsCollection;
-    NSArray<NSString *> *repos = [self getAmenityRepositoriesNames:includeTravel];
+    const auto repositories = [self getAmenityRepositories:includeTravel];
     const auto search = std::shared_ptr<const OsmAnd::AmenitiesInAreaSearch>(new OsmAnd::AmenitiesInAreaSearch(obfsCollection));
     
-    if (bbox31.width() != 0 && bbox31.height() != 0)
+    const BOOL shouldFilterRepositories = bbox31.width() != 0 && bbox31.height() != 0;
+    if (shouldFilterRepositories)
     {
         searchCriteria->bbox31 = bbox31;
     }
@@ -1629,16 +1620,18 @@ static std::shared_ptr<const OsmAnd::Amenity> OAGetAmenityFromSearchResult(const
     if (!isEmpty || additionalFilter)
     {
         NSMutableSet<NSNumber *> *allIds = [NSMutableSet set]; // live updates filter
-        for (NSString *repoName in repos)
+        for (const auto& repository : repositories)
         {
             if (matcher && matcher.isCancelled)
             {
                 break;
             }
+            if (shouldFilterRepositories && repository->obfInfo && !repository->obfInfo->containsPOIFor(bbox31))
+                continue;
             
             NSMutableArray<OAPOI *> *foundAmenities = [NSMutableArray array];
 
-            search->performTravelGuidesSearch(QString::fromNSString(repoName), *searchCriteria,
+            search->performTravelGuidesSearch(repository->filePath, *searchCriteria,
                                               [&filter, &foundAmenities, &currentLocation, &deduplicateTypeIdSet, &publish, &done](const OsmAnd::ISearch::Criteria& criteria, const OsmAnd::ISearch::IResultEntry& resultEntry)
                                   {
                                         const auto am = OAGetAmenityFromSearchResult(resultEntry);


### PR DESCRIPTION
## Problem

Loading detailed POI data after opening the context menu could take several seconds when many OBF files were installed.

The amenity search iterated through every available OBF repository, including files that did not cover the selected location. On the affected device, 921 OBF files caused the nearby POI scan to take about 8.8 seconds.

## Solution

- Filter amenity repositories using the POI section bounding box before starting the search.
- Skip repositories whose POI data does not intersect the requested area.
- Keep repositories without loaded metadata as a fallback.
- Pass the selected OBF file path directly to the existing search.
- Remove the redundant conversion of repository objects into a separate array of paths.

The existing repository order, Travel Guides handling, Live Updates deduplication, search radius, and matching logic remain unchanged.