### PR TITLE
Fix Plan Route save behavior and track naming

### DIFF
--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -67,6 +67,13 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         }
     }
 
+    private var suggestedFilePath: String? {
+        guard case .editTrack(let fileName) = dataProvider.mode,
+              let gpxFileName = (fileName as NSString).appendingPathExtension("gpx") else { return nil }
+        guard let folder = dataProvider.editTrackFolder, !folder.isEmpty else { return gpxFileName }
+        return (folder as NSString).appendingPathComponent(gpxFileName)
+    }
+
     private var currentScreenHeight: CGFloat {
         guard isViewLoaded, view.bounds.height > 0 else { return OAUtilities.calculateScreenHeight() }
         return view.bounds.height
@@ -892,23 +899,18 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
 
     private func handleSave() {
         guard ensurePointsForSaving() else { return }
+        let fileName: String
+        let folder: String?
         switch dataProvider.mode {
         case .newRoute:
-            presentSaveDialog(duplicate: false)
-        case .editTrack(let fileName):
-            dataProvider.saveAs(fileName: fileName, folder: dataProvider.editTrackFolder, showOnMap: true) { [weak self] success, _ in
-                guard let self else { return }
-                if success {
-                    let message = String(format: localizedString("gpx_saved_successfully"), fileName)
-                    let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: localizedString("shared_string_ok"), style: .default))
-                    hide(true, duration: Self.sheetAnimationDuration) {
-                        OARootViewController.instance().present(alert, animated: true)
-                    }
-                } else {
-                    showSaveError()
-                }
-            }
+            fileName = suggestedFileName
+            folder = nil
+        case .editTrack(let existingFileName):
+            fileName = existingFileName
+            folder = dataProvider.editTrackFolder
+        }
+        dataProvider.saveAs(fileName: fileName, folder: folder, showOnMap: true) { [weak self] success, filePath in
+            self?.handleSaveResult(success: success, filePath: filePath, fallbackFileName: fileName)
         }
     }
 
@@ -931,11 +933,10 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
     private func handleMenuAction(_ action: PlanRouteMenuAction) {
         switch action {
         case .saveAs:
-            guard ensurePointsForSaving() else { return }
-            presentSaveDialog(duplicate: false)
+            handleSave()
         case .saveAsCopy:
             guard ensurePointsForSaving() else { return }
-            presentSaveDialog(duplicate: true)
+            presentSaveAsCopyDialog()
         case .appendToExistingTrack:
             presentAppendToTrack()
         case .changeSegmentOrder:
@@ -963,10 +964,10 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         return true
     }
 
-    private func presentSaveDialog(duplicate: Bool) {
-        isPendingSaveAsCopy = duplicate
+    private func presentSaveAsCopyDialog() {
+        isPendingSaveAsCopy = true
         pendingSegmentPointIndexes = nil
-        guard let vc = OASaveTrackViewController(fileName: suggestedFileName, filePath: nil, showOnMap: true, simplifiedTrack: false, duplicate: duplicate) else { return }
+        guard let vc = OASaveTrackViewController(fileName: suggestedFileName, filePath: suggestedFilePath, showOnMap: true, simplifiedTrack: false, duplicate: false) else { return }
         vc.delegate = self
         present(UINavigationController(rootViewController: vc), animated: true)
     }
@@ -1010,6 +1011,18 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         })
         alert.addAction(UIAlertAction(title: localizedString("shared_string_cancel"), style: .cancel))
         present(alert, animated: true)
+    }
+
+    private func handleSaveResult(success: Bool, filePath: String?, fallbackFileName: String) {
+        guard success else {
+            showSaveError()
+            return
+        }
+        let path = filePath ?? fallbackFileName
+        hide(true, duration: Self.sheetAnimationDuration) {
+            let bottomSheet = OASaveTrackBottomSheetViewController(fileName: path)
+            bottomSheet?.present(in: OARootViewController.instance())
+        }
     }
 
     private func showSaveError() {
@@ -1118,16 +1131,7 @@ extension PlanRouteScrollableViewController: OAInfoBottomViewDelegate {
 extension PlanRouteScrollableViewController: OASaveTrackViewControllerDelegate {
     func onSave(asNewTrack fileName: String, showOnMap: Bool, simplifiedTrack: Bool, openTrack: Bool) {
         let onComplete: (Bool, String?) -> Void = { [weak self] success, filePath in
-            guard let self else { return }
-            if success {
-                let path = filePath ?? fileName
-                hide(true, duration: Self.sheetAnimationDuration) {
-                    let bottomSheet = OASaveTrackBottomSheetViewController(fileName: path)
-                    bottomSheet?.present(in: OARootViewController.instance())
-                }
-            } else {
-                showSaveError()
-            }
+            self?.handleSaveResult(success: success, filePath: filePath, fallbackFileName: fileName)
         }
         if let pointIndexes = pendingSegmentPointIndexes {
             pendingSegmentPointIndexes = nil

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -62,7 +62,7 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
 
     private var suggestedFileName: String {
         switch dataProvider.mode {
-        case .newRoute: OAUtilities.generateCurrentDateFilename()
+        case .newRoute: uniqueFileName(for: OAUtilities.generateCurrentDateFilename())
         case .editTrack(let fileName): fileName
         }
     }
@@ -969,6 +969,22 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         guard let vc = OASaveTrackViewController(fileName: suggestedFileName, filePath: nil, showOnMap: true, simplifiedTrack: false, duplicate: duplicate) else { return }
         vc.delegate = self
         present(UINavigationController(rootViewController: vc), animated: true)
+    }
+
+    private func uniqueFileName(for fileName: String) -> String {
+        let gpxDirectory = URL(fileURLWithPath: OsmAndApp.swiftInstance().gpxPath)
+        let fileManager = FileManager.default
+        let initialFile = gpxDirectory.appendingPathComponent(fileName).appendingPathExtension("gpx")
+        guard fileManager.fileExists(atPath: initialFile.path) else { return fileName }
+
+        for index in 2..<100_000 {
+            let candidate = "\(fileName)_(\(index))"
+            let candidateFile = gpxDirectory.appendingPathComponent(candidate).appendingPathExtension("gpx")
+            if !fileManager.fileExists(atPath: candidateFile.path) {
+                return candidate
+            }
+        }
+        return fileName
     }
 
     private func presentSegmentSaveDialog(pointIndexes: [Int]) {

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -933,10 +933,11 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
     private func handleMenuAction(_ action: PlanRouteMenuAction) {
         switch action {
         case .saveAs:
-            handleSave()
+            guard ensurePointsForSaving() else { return }
+            presentSaveDialog(saveAsCopy: false)
         case .saveAsCopy:
             guard ensurePointsForSaving() else { return }
-            presentSaveAsCopyDialog()
+            presentSaveDialog(saveAsCopy: true)
         case .appendToExistingTrack:
             presentAppendToTrack()
         case .changeSegmentOrder:
@@ -964,12 +965,43 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         return true
     }
 
-    private func presentSaveAsCopyDialog() {
-        isPendingSaveAsCopy = true
+    private func presentSaveDialog(saveAsCopy: Bool) {
+        isPendingSaveAsCopy = saveAsCopy
         pendingSegmentPointIndexes = nil
-        guard let vc = OASaveTrackViewController(fileName: suggestedFileName, filePath: suggestedFilePath, showOnMap: true, simplifiedTrack: false, duplicate: false) else { return }
+        let fileName = saveAsCopy ? uniqueCopyFileName(for: suggestedFileName) : suggestedFileName
+        guard let vc = OASaveTrackViewController(fileName: fileName, filePath: suggestedFilePath, showOnMap: true, simplifiedTrack: false, duplicate: false) else { return }
         vc.delegate = self
         present(UINavigationController(rootViewController: vc), animated: true)
+    }
+
+    private func uniqueCopyFileName(for fileName: String) -> String {
+        let suffixPattern = #"_\((\d+)\)$"#
+        var baseName = fileName
+        var index = 2
+        if let suffixRange = fileName.range(of: suffixPattern, options: .regularExpression) {
+            let suffix = fileName[suffixRange]
+            let number = suffix.dropFirst(2).dropLast()
+            if let suffixNumber = Int(number), suffixNumber < Int.max {
+                baseName = String(fileName[..<suffixRange.lowerBound])
+                index = max(index, suffixNumber + 1)
+            }
+        }
+
+        var gpxDirectory = URL(fileURLWithPath: OsmAndApp.swiftInstance().gpxPath)
+        if let folder = dataProvider.editTrackFolder, !folder.isEmpty {
+            gpxDirectory.appendPathComponent(folder, isDirectory: true)
+        }
+        let fileManager = FileManager.default
+        for _ in 0..<100_000 {
+            let candidate = "\(baseName)_(\(index))"
+            let candidateFile = gpxDirectory.appendingPathComponent(candidate).appendingPathExtension("gpx")
+            if !fileManager.fileExists(atPath: candidateFile.path) {
+                return candidate
+            }
+            guard index < Int.max else { break }
+            index += 1
+        }
+        return "\(baseName)_\(UUID().uuidString)"
     }
 
     private func uniqueFileName(for fileName: String) -> String {


### PR DESCRIPTION
### Summary

- Restored the legacy unique naming logic for new routes:
  - `date`
  - `date_(2)`
  - `date_(3)`
- Prevented routes created on the same day from overwriting each other.
- Updated the Navbar Save action to skip the save dialog and show the saved-track bottom sheet.
- Restored the previous `Save as copy` behavior:
  - opens the save dialog;
  - uses the original track name without automatically adding `_copy`;
  - preserves the original track folder.