### PR TITLE
Fixed Dynamic Text for Gap cell

### DIFF
--- a/Sources/Controllers/PlanRoute/Cells/PlanRoutePointCell.swift
+++ b/Sources/Controllers/PlanRoute/Cells/PlanRoutePointCell.swift
@@ -10,6 +10,8 @@ import UIKit
 final class PlanRoutePointCell: UITableViewCell {
 
     private static let horizontalInset: CGFloat = 16
+    private static let minimumHeight: CGFloat = 68
+    private static let verticalInset: CGFloat = 12
     private static let circleSize: CGFloat = 28
     private static let deleteButtonSize: CGFloat = 30
     private static let deleteNumberSpacing: CGFloat = 26
@@ -65,6 +67,7 @@ final class PlanRoutePointCell: UITableViewCell {
         numberLabel.font = .scaledSystemFont(ofSize: 13, weight: .semibold)
         numberLabel.textColor = .white
         numberLabel.textAlignment = .center
+        numberLabel.adjustsFontForContentSizeCategory = true
         numberLabel.adjustsFontSizeToFitWidth = true
         numberLabel.minimumScaleFactor = 0.5
         numberLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -72,17 +75,29 @@ final class PlanRoutePointCell: UITableViewCell {
 
         titleLabel.font = .scaledSystemFont(ofSize: 17)
         titleLabel.textColor = .textColorPrimary
-        subtitleLabel.font = .scaledSystemFont(ofSize: 13)
+        titleLabel.numberOfLines = 0
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.lineBreakMode = .byWordWrapping
+        titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        subtitleLabel.font = .scaledSystemFont(ofSize: 15)
         subtitleLabel.textColor = .textColorSecondary
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.adjustsFontForContentSizeCategory = true
+        subtitleLabel.lineBreakMode = .byWordWrapping
+        subtitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         let textStack = UIStackView(arrangedSubviews: [subtitleLabel, titleLabel])
         textStack.axis = .vertical
+        textStack.distribution = .fillProportionally
         textStack.spacing = 2
 
         [deleteButton, numberContainer, textStack].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview($0)
         }
+
+        let textTopConstraint = textStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Self.verticalInset)
+        let textBottomConstraint = textStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Self.verticalInset)
 
         NSLayoutConstraint.activate([
             deleteButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.horizontalInset),
@@ -101,8 +116,9 @@ final class PlanRoutePointCell: UITableViewCell {
 
             textStack.leadingAnchor.constraint(equalTo: numberContainer.trailingAnchor, constant: Self.numberTextSpacing),
             textStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.horizontalInset),
-            textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            textStack.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 8)
+            textTopConstraint,
+            textBottomConstraint,
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: Self.minimumHeight)
         ])
     }
 

--- a/Sources/Controllers/PlanRoute/Cells/PlanRouteProfileGroupCell.swift
+++ b/Sources/Controllers/PlanRoute/Cells/PlanRouteProfileGroupCell.swift
@@ -10,6 +10,7 @@ import UIKit
 final class PlanRouteProfileGroupCell: UITableViewCell {
 
     private static let horizontalInset: CGFloat = 16
+    private static let minimumHeight: CGFloat = 53
     private static let verticalInset: CGFloat = 11
     private static let iconSize: CGFloat = 30
     private static let iconTitleSpacing: CGFloat = 26
@@ -20,6 +21,7 @@ final class PlanRouteProfileGroupCell: UITableViewCell {
     private let titleLabel = UILabel()
     private let distanceLabel = UILabel()
     private let optionsButton = UIButton(type: .system)
+    private let labelsStackView = UIStackView()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -28,6 +30,12 @@ final class PlanRouteProfileGroupCell: UITableViewCell {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory else { return }
+        updateLabelsLayout()
     }
 
     func configure(title: String, distanceText: String, icon: UIImage?, tintColor: UIColor, menu: UIMenu) {
@@ -52,10 +60,25 @@ final class PlanRouteProfileGroupCell: UITableViewCell {
 
         titleLabel.font = .scaledSystemFont(ofSize: 17)
         titleLabel.textColor = .textColorPrimary
+        titleLabel.numberOfLines = 0
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.lineBreakMode = .byWordWrapping
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         distanceLabel.font = .scaledSystemFont(ofSize: 17)
         distanceLabel.textColor = .textColorSecondary
+        distanceLabel.numberOfLines = 0
+        distanceLabel.adjustsFontForContentSizeCategory = true
+        distanceLabel.lineBreakMode = .byWordWrapping
         distanceLabel.setContentHuggingPriority(.required, for: .horizontal)
+        distanceLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        distanceLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        labelsStackView.spacing = 8
+        labelsStackView.addArrangedSubview(titleLabel)
+        labelsStackView.addArrangedSubview(distanceLabel)
+        updateLabelsLayout()
 
         var configuration = UIButton.Configuration.plain()
         configuration.image = .icCustomOverflowMenuStroke
@@ -65,9 +88,10 @@ final class PlanRouteProfileGroupCell: UITableViewCell {
         optionsButton.configuration = configuration
         optionsButton.showsMenuAsPrimaryAction = true
         optionsButton.accessibilityLabel = localizedString("shared_string_options")
+        optionsButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         iconView.isAccessibilityElement = false
 
-        [iconView, titleLabel, distanceLabel, optionsButton].forEach {
+        [iconView, labelsStackView, optionsButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview($0)
         }
@@ -80,18 +104,24 @@ final class PlanRouteProfileGroupCell: UITableViewCell {
             iconView.widthAnchor.constraint(equalToConstant: Self.iconSize),
             iconView.heightAnchor.constraint(equalToConstant: Self.iconSize),
 
-            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: Self.iconTitleSpacing),
-            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            titleLabel.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 10),
+            labelsStackView.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: Self.iconTitleSpacing),
+            labelsStackView.trailingAnchor.constraint(equalTo: optionsButton.leadingAnchor, constant: -12),
+            labelsStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            labelsStackView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 10),
+            labelsStackView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -10),
 
-            distanceLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: 8),
-            distanceLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-
-            optionsButton.leadingAnchor.constraint(equalTo: distanceLabel.trailingAnchor, constant: 12),
             optionsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.horizontalInset),
             optionsButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             optionsButton.widthAnchor.constraint(equalToConstant: Self.optionsButtonSize),
-            optionsButton.heightAnchor.constraint(equalToConstant: Self.optionsButtonSize)
+            optionsButton.heightAnchor.constraint(equalToConstant: Self.optionsButtonSize),
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: Self.minimumHeight)
         ])
+    }
+
+    private func updateLabelsLayout() {
+        let usesVerticalLayout = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        labelsStackView.axis = usesVerticalLayout ? .vertical : .horizontal
+        labelsStackView.alignment = usesVerticalLayout ? .fill : .firstBaseline
+        labelsStackView.distribution = usesVerticalLayout ? .fillProportionally : .fill
     }
 }

--- a/Sources/Controllers/PlanRoute/Cells/PlanRouteSegmentGapCell.swift
+++ b/Sources/Controllers/PlanRoute/Cells/PlanRouteSegmentGapCell.swift
@@ -12,9 +12,10 @@ final class PlanRouteSegmentGapCell: UITableViewCell {
     private enum Constants {
         static let horizontalInset: CGFloat = 16
         static let topInset: CGFloat = 10
+        static let verticalPadding: CGFloat = 15
+        static let minimumCapsuleHeight: CGFloat = 52
         static let iconSize: CGFloat = 30
         static let iconTitleSpacing: CGFloat = 16
-        static let cornerRadius: CGFloat = 26
     }
 
     private let borderView = UIView()
@@ -30,6 +31,11 @@ final class PlanRouteSegmentGapCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        borderView.layer.cornerRadius = borderView.bounds.height / 2
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateBorderColor()
@@ -43,9 +49,10 @@ final class PlanRouteSegmentGapCell: UITableViewCell {
     private func setupCell() {
         let horizontalInset = Constants.horizontalInset
         let topInset = Constants.topInset
+        let verticalPadding = Constants.verticalPadding
+        let minimumCapsuleHeight = Constants.minimumCapsuleHeight
         let iconSize = Constants.iconSize
         let iconTitleSpacing = Constants.iconTitleSpacing
-        let cornerRadius = Constants.cornerRadius
 
         backgroundColor = .clear
         contentView.backgroundColor = .clear
@@ -54,7 +61,6 @@ final class PlanRouteSegmentGapCell: UITableViewCell {
         isAccessibilityElement = true
 
         borderView.layer.borderWidth = 1
-        borderView.layer.cornerRadius = cornerRadius
         updateBorderColor()
 
         iconView.image = .icCustomSegmentsGap
@@ -65,6 +71,8 @@ final class PlanRouteSegmentGapCell: UITableViewCell {
         titleLabel.font = .scaledSystemFont(ofSize: 17)
         titleLabel.textColor = .textColorSecondary
         titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 0
+        titleLabel.lineBreakMode = .byWordWrapping
 
         borderView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(borderView)
@@ -78,6 +86,7 @@ final class PlanRouteSegmentGapCell: UITableViewCell {
             borderView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             borderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             borderView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            borderView.heightAnchor.constraint(greaterThanOrEqualToConstant: minimumCapsuleHeight),
 
             iconView.leadingAnchor.constraint(equalTo: borderView.leadingAnchor, constant: horizontalInset),
             iconView.centerYAnchor.constraint(equalTo: borderView.centerYAnchor),
@@ -85,8 +94,10 @@ final class PlanRouteSegmentGapCell: UITableViewCell {
             iconView.heightAnchor.constraint(equalToConstant: iconSize),
 
             titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: iconTitleSpacing),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: borderView.trailingAnchor, constant: -horizontalInset),
-            titleLabel.centerYAnchor.constraint(equalTo: borderView.centerYAnchor)
+            titleLabel.trailingAnchor.constraint(equalTo: borderView.trailingAnchor, constant: -horizontalInset),
+            titleLabel.centerYAnchor.constraint(equalTo: borderView.centerYAnchor),
+            titleLabel.topAnchor.constraint(greaterThanOrEqualTo: borderView.topAnchor, constant: verticalPadding),
+            titleLabel.bottomAnchor.constraint(lessThanOrEqualTo: borderView.bottomAnchor, constant: -verticalPadding)
         ])
     }
 

--- a/Sources/Controllers/PlanRoute/Cells/PlanRouteSegmentHeaderView.swift
+++ b/Sources/Controllers/PlanRoute/Cells/PlanRouteSegmentHeaderView.swift
@@ -10,6 +10,7 @@ import UIKit
 final class PlanRouteSegmentHeaderView: UITableViewHeaderFooterView {
 
     private static let horizontalInset: CGFloat = 16
+    private static let minimumHeight: CGFloat = 44
     private static let optionsButtonSize: CGFloat = 44
 
     private let titleLabel = UILabel()
@@ -39,15 +40,23 @@ final class PlanRouteSegmentHeaderView: UITableViewHeaderFooterView {
     private func setupView() {
         titleLabel.font = .scaledSystemFont(ofSize: 20, weight: .semibold)
         titleLabel.textColor = .textColorPrimary
-        titleLabel.numberOfLines = 1
+        titleLabel.numberOfLines = 0
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.lineBreakMode = .byWordWrapping
+        titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         subtitleLabel.font = .scaledSystemFont(ofSize: 15)
         subtitleLabel.textColor = .textColorSecondary
-        subtitleLabel.numberOfLines = 1
+        subtitleLabel.numberOfLines = 0
+        subtitleLabel.adjustsFontForContentSizeCategory = true
+        subtitleLabel.lineBreakMode = .byWordWrapping
+        subtitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
         textStack.axis = .vertical
+        textStack.distribution = .fillProportionally
         textStack.spacing = 2
+        textStack.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular)
         var configuration = UIButton.Configuration.plain()
@@ -58,24 +67,26 @@ final class PlanRouteSegmentHeaderView: UITableViewHeaderFooterView {
         optionsButton.configuration = configuration
         optionsButton.showsMenuAsPrimaryAction = true
         optionsButton.accessibilityLabel = localizedString("shared_string_options")
+        optionsButton.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         [textStack, optionsButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview($0)
         }
 
-        let textConstraints = [
+        let constraints = [
             textStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Self.horizontalInset),
             textStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
             textStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
-            optionsButton.leadingAnchor.constraint(greaterThanOrEqualTo: textStack.trailingAnchor, constant: 12)
-        ]
-        textConstraints.forEach { $0.priority = UILayoutPriority(999) }
-        NSLayoutConstraint.activate(textConstraints + [
+            optionsButton.leadingAnchor.constraint(greaterThanOrEqualTo: textStack.trailingAnchor, constant: 12),
             optionsButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Self.horizontalInset),
             optionsButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             optionsButton.widthAnchor.constraint(equalToConstant: Self.optionsButtonSize),
             optionsButton.heightAnchor.constraint(equalToConstant: Self.optionsButtonSize)
+        ]
+        constraints.forEach { $0.priority = UILayoutPriority(999) }
+        NSLayoutConstraint.activate(constraints + [
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: Self.minimumHeight)
         ])
     }
 }

--- a/Sources/Controllers/PlanRoute/Cells/PlanRouteStartSegmentCell.swift
+++ b/Sources/Controllers/PlanRoute/Cells/PlanRouteStartSegmentCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class PlanRouteStartSegmentCell: UITableViewCell {
 
+    private static let minimumHeight: CGFloat = 50
+
     private let titleLabel = UILabel()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -30,6 +32,9 @@ final class PlanRouteStartSegmentCell: UITableViewCell {
         accessibilityTraits = .button
         titleLabel.font = .scaledSystemFont(ofSize: 17)
         titleLabel.textColor = .iconColorActive
+        titleLabel.numberOfLines = 0
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.lineBreakMode = .byWordWrapping
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(titleLabel)
 
@@ -37,7 +42,8 @@ final class PlanRouteStartSegmentCell: UITableViewCell {
             titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 14),
-            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -14)
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -14),
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: Self.minimumHeight)
         ])
     }
 }

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteRouteViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteRouteViewController.swift
@@ -27,8 +27,8 @@ final class PlanRouteRouteViewController: UIViewController, PlanRouteTabContent 
     private static let sectionHorizontalInset: CGFloat = 16
     private static let separatorLeftInset: CGFloat = 76
     private static let bottomContentInset: CGFloat = 72
-    private static let pointRowHeight: CGFloat = 68
-    private static let profileGroupRowHeight: CGFloat = 53
+    private static let estimatedRowHeight: CGFloat = 68
+    private static let estimatedSectionHeaderHeight: CGFloat = 60
 
     let planRouteTab: PlanRouteTab = .route
     var onPointSelected: ((PlanRoutePoint, PlanRouteProfileGroup, PlanRouteSegment) -> Void)?
@@ -80,12 +80,16 @@ final class PlanRouteRouteViewController: UIViewController, PlanRouteTabContent 
         tableView.isEditing = true
         tableView.allowsSelectionDuringEditing = true
         tableView.alwaysBounceVertical = true
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = Self.estimatedRowHeight
         tableView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0,
                                                                      leading: horizontalInset,
                                                                      bottom: 0,
                                                                      trailing: horizontalInset)
         tableView.separatorInset = UIEdgeInsets(top: 0, left: Self.separatorLeftInset, bottom: 0, right: 0)
         tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: Self.bottomContentInset, right: 0)
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.estimatedSectionHeaderHeight = Self.estimatedSectionHeaderHeight
         tableView.sectionHeaderTopPadding = 0
         tableView.register(PlanRoutePointCell.self, forCellReuseIdentifier: PlanRoutePointCell.reuseIdentifier)
         tableView.register(PlanRouteProfileGroupCell.self, forCellReuseIdentifier: PlanRouteProfileGroupCell.reuseIdentifier)
@@ -395,24 +399,8 @@ extension PlanRouteRouteViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 extension PlanRouteRouteViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        let section = sections[indexPath.section]
-        guard !section.isStartNewSegment else { return UITableView.automaticDimension }
-        switch section.rows[indexPath.row] {
-        case .profileGroup:
-            return Self.profileGroupRowHeight
-        case .point:
-            return Self.pointRowHeight
-        case .gap:
-            return UITableView.automaticDimension
-        case .empty:
-            return UITableView.automaticDimension
-        }
-    }
-
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard sections[section].headerTitle != nil else { return 0 }
-        return sections[section].headerSubtitle != nil ? 60 : 44
+        sections[section].headerTitle == nil ? .leastNormalMagnitude : UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteRouteViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteRouteViewController.swift
@@ -57,6 +57,15 @@ final class PlanRouteRouteViewController: UIViewController, PlanRouteTabContent 
         reloadData()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard isViewLoaded,
+              previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.tableView.performBatchUpdates(nil)
+        }
+    }
+
     func reloadData() {
         guard isViewLoaded else { return }
         let segments = dataSource?.routeSegments ?? []

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteRouteViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteRouteViewController.swift
@@ -29,7 +29,6 @@ final class PlanRouteRouteViewController: UIViewController, PlanRouteTabContent 
     private static let bottomContentInset: CGFloat = 72
     private static let pointRowHeight: CGFloat = 68
     private static let profileGroupRowHeight: CGFloat = 53
-    private static let gapRowHeight: CGFloat = 62
 
     let planRouteTab: PlanRouteTab = .route
     var onPointSelected: ((PlanRoutePoint, PlanRouteProfileGroup, PlanRouteSegment) -> Void)?
@@ -405,7 +404,7 @@ extension PlanRouteRouteViewController: UITableViewDelegate {
         case .point:
             return Self.pointRowHeight
         case .gap:
-            return Self.gapRowHeight
+            return UITableView.automaticDimension
         case .empty:
             return UITableView.automaticDimension
         }


### PR DESCRIPTION
Fixed Dynamic Type support for the Plan Route screen.

Changes:
- Replaced fixed row heights with UITableView.automaticDimension.
- Added self-sizing constraints for point, profile group, segment header, gap, and “Start new segment” cells.
- Added minimum heights to preserve the Figma layout at the default text size:
  - Gap capsule: 52 pt
  - “Start new segment”: 50 pt
- Allowed labels to wrap and grow vertically at Accessibility text sizes.
- Updated Plan Route text styles according to Figma:
  - Body: 17 pt
  - Subheadline: 15 pt
  - Segment title: scalable 20 pt semibold
- Made capsule and header layouts expand with their content instead of clipping it.

The default layout remains aligned with Figma, while larger Dynamic Type sizes no longer clip the segment title or other text.