### PR TITLE
Fix Plan Route undo/redo for empty segments and route profiles

### DIFF
--- a/Sources/Controllers/PlanRoute/OAPlanRouteEditingBridge.h
+++ b/Sources/Controllers/PlanRoute/OAPlanRouteEditingBridge.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, EOAPlanRoutePointEditMode) {
 @property (nonatomic, weak, nullable) UIViewController *presenterViewController;
 
 @property (nonatomic, readonly) BOOL hasPoints;
+@property (nonatomic, readonly) BOOL hasTrailingGap;
 @property (nonatomic, readonly, nullable) OASGpxFile *currentGpxFile;
 @property (nonatomic, readonly, nullable) OASGpxFile *exportedGpxFile;
 @property (nonatomic, readonly) BOOL isAddNewSegmentAllowed;
@@ -105,6 +106,7 @@ typedef NS_ENUM(NSInteger, EOAPlanRoutePointEditMode) {
 - (void)deleteSegmentWithPointIndexes:(NSArray<NSNumber *> *)indexes;
 - (void)startNewSegment;
 - (void)applyMode:(OAApplicationMode *)mode pointIndex:(NSInteger)pointIndex wholeRoute:(BOOL)wholeRoute;
+- (void)applyMode:(OAApplicationMode *)mode pointIndexes:(NSArray<NSNumber *> *)pointIndexes;
 - (void)refreshRouteForMode:(OAApplicationMode *)mode;
 - (void)sortSegmentDoorToDoorWithPointIndexes:(NSArray<NSNumber *> *)indexes;
 - (void)selectPointAtIndex:(NSInteger)index;

--- a/Sources/Controllers/PlanRoute/OAPlanRouteEditingBridge.mm
+++ b/Sources/Controllers/PlanRoute/OAPlanRouteEditingBridge.mm
@@ -173,6 +173,11 @@ static const NSTimeInterval kRouteInfoRefreshInterval = 0.25;
     return [self editingContext].getPoints.count > 0;
 }
 
+- (BOOL)hasTrailingGap
+{
+    return [self editingContext].getPoints.lastObject.isGap;
+}
+
 - (OASGpxFile *)currentGpxFile
 {
     return [self editingContext].gpxData.gpxFile;
@@ -1096,9 +1101,34 @@ static const NSTimeInterval kRouteInfoRefreshInterval = 0.25;
                                              mode:mode
                                        pointIndex:pointIndex
                                        wholeRoute:wholeRoute];
-    ctx.appMode = mode;
     EOAChangeRouteType type = wholeRoute ? EOAChangeRouteWhole : EOAChangeRouteNextSegment;
-    [ctx.commandManager execute:[[OAChangeRouteModeCommand alloc] initWithLayer:layer appMode:mode changeRouteType:type pointIndex:pointIndex]];
+    [ctx.commandManager execute:[[OAChangeRouteModeCommand alloc] initWithLayer:layer
+                                                                          appMode:mode
+                                                                   changeRouteType:type
+                                                                        pointIndex:pointIndex]];
+    [layer updateLayer];
+    if (self.onChange)
+        self.onChange();
+}
+
+- (void)applyMode:(OAApplicationMode *)mode pointIndexes:(NSArray<NSNumber *> *)pointIndexes
+{
+    OAMeasurementToolLayer *layer = [self layer];
+    OAMeasurementEditingContext *ctx = [self editingContext];
+    if (ctx == nil || pointIndexes.count == 0)
+        return;
+    [self invalidateTerrainElevationGpx];
+    for (NSNumber *indexNumber in pointIndexes)
+    {
+        if ([self beginRouteCalculationIfNeededForContext:ctx
+                                                     mode:mode
+                                               pointIndex:indexNumber.integerValue
+                                               wholeRoute:NO])
+            break;
+    }
+    [ctx.commandManager execute:[[OAChangeRouteModeCommand alloc] initWithLayer:layer
+                                                                          appMode:mode
+                                                                     pointIndexes:pointIndexes]];
     [layer updateLayer];
     if (self.onChange)
         self.onChange();

--- a/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
@@ -167,6 +167,7 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
     private var hasCachedAnalysisData = false
     private var analysisGeneration = 0
     private var pendingAnalysisGeneration: Int?
+    private var pendingSegmentHistoryState: (wasPending: Bool, hadTrailingGap: Bool)?
     private var initialApplicationMode: OAApplicationMode {
         var supportedModes = bridge.availableModes()
         if let directLineMode = OAApplicationMode.default() {
@@ -271,12 +272,15 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
     }
 
     func undo() {
-        pendingEmptySegmentIndex = nil
+        pendingSegmentHistoryState = (pendingEmptySegmentIndex != nil, bridge.hasTrailingGap)
         bridge.undo()
+        pendingSegmentHistoryState = nil
     }
 
     func redo() {
+        pendingSegmentHistoryState = (pendingEmptySegmentIndex != nil, bridge.hasTrailingGap)
         bridge.redo()
+        pendingSegmentHistoryState = nil
     }
 
     func reverseRoute() {
@@ -331,20 +335,20 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
         bridge.apply(mode, pointIndex: pointIndex, wholeRoute: wholeRoute)
     }
 
+    func applyMode(_ mode: OAApplicationMode, pointIndexes: [Int]) {
+        bridge.apply(mode, pointIndexes: pointIndexes.map { NSNumber(value: $0) })
+    }
+
     func applyModeToContext(_ mode: OAApplicationMode?, context: SegmentRouteContext) {
         guard let effectiveMode = mode ?? OAApplicationMode.default() else { return }
         if case let .profileGroup(_, segment) = context, segment.isPendingEmpty {
             guard let pointIndex = routeSegments.last?.pointIndexes.last else { return }
             bridge.apply(effectiveMode, pointIndex: pointIndex, wholeRoute: false)
         } else if case let .profileGroup(group, _) = context {
-            for point in group.points {
-                bridge.apply(effectiveMode, pointIndex: point.index, wholeRoute: false)
-            }
+            applyMode(effectiveMode, pointIndexes: group.points.map(\.index))
         } else if case let .wholeSegment(segment) = context {
-            let allPoints = segment.groups.flatMap { $0.points }
-            for point in allPoints {
-                bridge.apply(effectiveMode, pointIndex: point.index, wholeRoute: false)
-            }
+            let pointIndexes = segment.groups.flatMap { $0.points.map(\.index) }
+            applyMode(effectiveMode, pointIndexes: pointIndexes)
         } else {
             bridge.apply(effectiveMode, pointIndex: context.applyPointIndex, wholeRoute: context.applyWholeRoute)
         }
@@ -482,13 +486,15 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
     }
 
     private func updatePendingEmptySegment() {
-        guard let pendingEmptySegmentIndex else { return }
-        let segmentCount = bridgeSegments().count
-        if segmentCount == 0 || segmentCount >= pendingEmptySegmentIndex {
-            self.pendingEmptySegmentIndex = nil
+        let hasTrailingGap = bridge.hasTrailingGap
+        let shouldShowPendingSegment: Bool
+        if let pendingSegmentHistoryState {
+            shouldShowPendingSegment = hasTrailingGap
+                && (pendingSegmentHistoryState.wasPending || !pendingSegmentHistoryState.hadTrailingGap)
         } else {
-            self.pendingEmptySegmentIndex = segmentCount + 1
+            shouldShowPendingSegment = pendingEmptySegmentIndex != nil && hasTrailingGap
         }
+        pendingEmptySegmentIndex = shouldShowPendingSegment ? bridgeSegments().count + 1 : nil
     }
 
     private func mapSegment(_ segment: PlanRouteSegmentData) -> PlanRouteSegment {

--- a/Sources/Controllers/PlanRoute/PlanRouteModels.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteModels.swift
@@ -312,6 +312,7 @@ protocol PlanRoutePointsDataSource: AnyObject {
     func deleteSegment(pointIndexes: [Int])
     func startNewSegment()
     func applyMode(_ mode: OAApplicationMode, pointIndex: Int, wholeRoute: Bool)
+    func applyMode(_ mode: OAApplicationMode, pointIndexes: [Int])
     func applyModeToContext(_ mode: OAApplicationMode?, context: SegmentRouteContext)
     func sortDoorToDoor(pointIndexes: [Int])
     func saveSegment(pointIndexes: [Int], fileName: String, showOnMap: Bool, onComplete: @escaping (Bool, String?) -> Void)

--- a/Sources/Controllers/PlanRoute/SegmentRouteSettingsViewController.swift
+++ b/Sources/Controllers/PlanRoute/SegmentRouteSettingsViewController.swift
@@ -202,14 +202,12 @@ final class SegmentRouteSettingsViewController: UIViewController {
     @objc private func onConfirmTapped() {
         if let fromIndex = applyFromPointIndex, case let .profileGroup(group, _) = context {
             guard let mode = selectedMode ?? OAApplicationMode.default() else { return }
-            for point in group.points where point.index >= fromIndex {
-                dataSource?.applyMode(mode, pointIndex: point.index, wholeRoute: false)
-            }
+            let pointIndexes = group.points.filter { $0.index >= fromIndex }.map(\.index)
+            dataSource?.applyMode(mode, pointIndexes: pointIndexes)
         } else if let upToIndex = applyUpToPointIndex, case let .profileGroup(group, _) = context {
             guard let mode = selectedMode ?? OAApplicationMode.default() else { return }
-            for point in group.points where point.index <= upToIndex {
-                dataSource?.applyMode(mode, pointIndex: point.index, wholeRoute: false)
-            }
+            let pointIndexes = group.points.filter { $0.index <= upToIndex }.map(\.index)
+            dataSource?.applyMode(mode, pointIndexes: pointIndexes)
         } else {
             dataSource?.applyModeToContext(selectedMode, context: context)
         }

--- a/Sources/Controllers/RoutePlanning/Commands/OAChangeRouteModeCommand.h
+++ b/Sources/Controllers/RoutePlanning/Commands/OAChangeRouteModeCommand.h
@@ -23,5 +23,8 @@ typedef NS_ENUM(NSInteger, EOAChangeRouteType)
 @interface OAChangeRouteModeCommand : OAMeasurementModeCommand
 
 - (instancetype)initWithLayer:(OAMeasurementToolLayer *)measurementLayer appMode:(OAApplicationMode *)appMode changeRouteType:(EOAChangeRouteType)changeRouteType pointIndex:(NSInteger)pointIndex;
+- (instancetype)initWithLayer:(OAMeasurementToolLayer *)measurementLayer
+                      appMode:(OAApplicationMode *)appMode
+                 pointIndexes:(NSArray<NSNumber *> *)pointIndexes;
 
 @end

--- a/Sources/Controllers/RoutePlanning/Commands/OAChangeRouteModeCommand.mm
+++ b/Sources/Controllers/RoutePlanning/Commands/OAChangeRouteModeCommand.mm
@@ -14,16 +14,26 @@
 #import "OAMeasurementToolLayer.h"
 #import "OsmAndSharedWrapper.h"
 
+@interface OAChangeRouteModeCommand ()
+
+- (NSArray *)profileTypesForPoints:(NSArray<OASWptPt *> *)points;
+- (void)applyProfileTypes:(NSArray *)profileTypes toPoints:(NSArray<OASWptPt *> *)points;
+
+@end
+
 @implementation OAChangeRouteModeCommand
 {
     NSMutableArray<OASWptPt *> *_oldPoints;
     NSMutableArray<OASWptPt *> *_newPoints;
     NSMutableDictionary<NSArray<OASWptPt *> *, OARoadSegmentData *> *_oldRoadSegmentData;
     NSMutableDictionary<NSArray<OASWptPt *> *, OARoadSegmentData *> *_newRoadSegmentData;
+    NSArray *_oldProfileTypes;
+    NSArray *_newProfileTypes;
     OAApplicationMode *_oldMode;
     OAApplicationMode *_newMode;
     EOAChangeRouteType _changeRouteType;
     NSInteger _pointIndex;
+    NSArray<NSNumber *> *_pointIndexes;
 }
 
 - (instancetype)initWithLayer:(OAMeasurementToolLayer *)measurementLayer appMode:(OAApplicationMode *)appMode changeRouteType:(EOAChangeRouteType)changeRouteType pointIndex:(NSInteger)pointIndex
@@ -39,73 +49,104 @@
     return self;
 }
 
+- (instancetype)initWithLayer:(OAMeasurementToolLayer *)measurementLayer
+                      appMode:(OAApplicationMode *)appMode
+                 pointIndexes:(NSArray<NSNumber *> *)pointIndexes
+{
+    self = [super initWithLayer:measurementLayer];
+    if (self)
+    {
+        _newMode = appMode;
+        _pointIndexes = [pointIndexes copy];
+        _oldMode = self.getEditingCtx.appMode;
+    }
+    return self;
+}
+
 - (BOOL)execute
 {
     OAMeasurementEditingContext *editingCtx = self.getEditingCtx;
     _oldPoints = [NSMutableArray arrayWithArray:editingCtx.getPoints];
+    _oldProfileTypes = [self profileTypesForPoints:_oldPoints];
     _oldRoadSegmentData = [NSMutableDictionary dictionaryWithDictionary:editingCtx.roadSegmentData];
     _newPoints = [NSMutableArray arrayWithCapacity:_oldPoints.count];
     _newRoadSegmentData = [NSMutableDictionary dictionaryWithDictionary:_oldRoadSegmentData];
     if (_oldPoints.count > 0)
     {
         [_newPoints addObjectsFromArray:_oldPoints];
-        switch (_changeRouteType)
+        if (_pointIndexes != nil)
         {
-            case EOAChangeRouteLastSegment:
+            for (NSNumber *indexNumber in _pointIndexes)
             {
-                [self updateProfileType:_newPoints[_newPoints.count - 1]];
-                editingCtx.lastCalculationMode = NEXT_SEGMENT;
-                _newRoadSegmentData = nil;
-                break;
-            }
-            case EOAChangeRouteWhole:
-            {
-                for (OASWptPt *pt in _newPoints)
+                NSInteger index = indexNumber.integerValue;
+                if (index >= 0 && index < _newPoints.count)
                 {
-                    [self updateProfileType:pt];
+                    [self updateProfileType:_newPoints[index]];
+                    [_newRoadSegmentData removeObjectForKey:[self getPairAt:index]];
                 }
-                editingCtx.lastCalculationMode = WHOLE_TRACK;
-                [_newRoadSegmentData removeAllObjects];
-                break;
             }
-            case EOAChangeRouteNextSegment:
+        }
+        else
+        {
+            switch (_changeRouteType)
             {
-                if (_pointIndex >= 0 && _pointIndex < _newPoints.count)
+                case EOAChangeRouteLastSegment:
                 {
-                    [self updateProfileType:_newPoints[_pointIndex]];
+                    [self updateProfileType:_newPoints[_newPoints.count - 1]];
+                    editingCtx.lastCalculationMode = NEXT_SEGMENT;
+                    _newRoadSegmentData = nil;
+                    break;
                 }
-                [_newRoadSegmentData removeObjectForKey:[self getPairAt:_pointIndex]];
-                break;
-            }
-            case EOAChangeRouteAllNextSegments:
-            {
-                for (NSInteger i = _pointIndex; i >= 0 && i < _newPoints.count; i++)
+                case EOAChangeRouteWhole:
                 {
-                    [self updateProfileType:_newPoints[i]];
-                    [_newRoadSegmentData removeObjectForKey:[self getPairAt:i]];
+                    for (OASWptPt *pt in _newPoints)
+                    {
+                        [self updateProfileType:pt];
+                    }
+                    editingCtx.lastCalculationMode = WHOLE_TRACK;
+                    [_newRoadSegmentData removeAllObjects];
+                    break;
                 }
-                break;
-            }
-            case EOAChangeRoutePrevSegment:
-            {
-                if (_pointIndex > 0 && _pointIndex < _newPoints.count)
+                case EOAChangeRouteNextSegment:
                 {
-                    [self updateProfileType:_newPoints[_pointIndex - 1]];
-                    [_newRoadSegmentData removeObjectForKey:[self getPairAt:_pointIndex - 1]];
+                    if (_pointIndex >= 0 && _pointIndex < _newPoints.count)
+                    {
+                        [self updateProfileType:_newPoints[_pointIndex]];
+                    }
+                    [_newRoadSegmentData removeObjectForKey:[self getPairAt:_pointIndex]];
+                    break;
                 }
-                break;
-            }
-            case EOAChangeRouteAllPrevSegments:
-            {
-                for (NSInteger i = 0; i < _pointIndex && i < _newPoints.count; i++)
+                case EOAChangeRouteAllNextSegments:
                 {
-                    [self updateProfileType:_newPoints[i]];
-                    [_newRoadSegmentData removeObjectForKey:[self getPairAt:i]];
+                    for (NSInteger i = _pointIndex; i >= 0 && i < _newPoints.count; i++)
+                    {
+                        [self updateProfileType:_newPoints[i]];
+                        [_newRoadSegmentData removeObjectForKey:[self getPairAt:i]];
+                    }
+                    break;
                 }
-                break;
+                case EOAChangeRoutePrevSegment:
+                {
+                    if (_pointIndex > 0 && _pointIndex < _newPoints.count)
+                    {
+                        [self updateProfileType:_newPoints[_pointIndex - 1]];
+                        [_newRoadSegmentData removeObjectForKey:[self getPairAt:_pointIndex - 1]];
+                    }
+                    break;
+                }
+                case EOAChangeRouteAllPrevSegments:
+                {
+                    for (NSInteger i = 0; i < _pointIndex && i < _newPoints.count; i++)
+                    {
+                        [self updateProfileType:_newPoints[i]];
+                        [_newRoadSegmentData removeObjectForKey:[self getPairAt:i]];
+                    }
+                    break;
+                }
             }
         }
     }
+    _newProfileTypes = [self profileTypesForPoints:_newPoints];
     [self executeCommand];
     return true;
 }
@@ -113,10 +154,11 @@
 - (void)undo
 {
     OAMeasurementEditingContext *editingCtx = [self getEditingCtx];
+    [self applyProfileTypes:_oldProfileTypes toPoints:_oldPoints];
     [editingCtx clearPoints];
     [editingCtx addPoints:_oldPoints];
     editingCtx.appMode = _oldMode;
-    editingCtx.roadSegmentData = _oldRoadSegmentData;
+    editingCtx.roadSegmentData = [_oldRoadSegmentData mutableCopy];
     [editingCtx updateSegmentsForSnap];
     [self refreshMap];
 }
@@ -147,6 +189,7 @@
 - (void) executeCommand
 {
     OAMeasurementEditingContext *editingCtx = [self getEditingCtx];
+    [self applyProfileTypes:_newProfileTypes toPoints:_newPoints];
     [editingCtx clearPoints];
     [editingCtx addPoints:_newPoints];
     if (_newPoints.count == 0)
@@ -162,7 +205,7 @@
             editingCtx.appMode = [OAApplicationMode valueOfStringKey:lastPoint.getProfileType def:OAApplicationMode.DEFAULT];
     }
     if (_newRoadSegmentData != nil)
-        editingCtx.roadSegmentData = _newRoadSegmentData;
+        editingCtx.roadSegmentData = [_newRoadSegmentData mutableCopy];
     [editingCtx updateSegmentsForSnap];
     [self refreshMap];
 }
@@ -175,6 +218,27 @@
             [pt setProfileTypeProfileType:_newMode.stringKey];
         else
             [pt removeProfileType];
+    }
+}
+
+- (NSArray *)profileTypesForPoints:(NSArray<OASWptPt *> *)points
+{
+    NSMutableArray *profileTypes = [NSMutableArray arrayWithCapacity:points.count];
+    for (OASWptPt *point in points)
+        [profileTypes addObject:point.getProfileType ?: NSNull.null];
+    return [profileTypes copy];
+}
+
+- (void)applyProfileTypes:(NSArray *)profileTypes toPoints:(NSArray<OASWptPt *> *)points
+{
+    NSInteger count = MIN(profileTypes.count, points.count);
+    for (NSInteger index = 0; index < count; index++)
+    {
+        id profileType = profileTypes[index];
+        if ([profileType isKindOfClass:NSString.class])
+            [points[index] setProfileTypeProfileType:profileType];
+        else
+            [points[index] removeProfileType];
     }
 }
 

--- a/Sources/Controllers/RoutePlanning/Commands/OAChangeRouteModeCommand.mm
+++ b/Sources/Controllers/RoutePlanning/Commands/OAChangeRouteModeCommand.mm
@@ -154,6 +154,7 @@
 - (void)undo
 {
     OAMeasurementEditingContext *editingCtx = [self getEditingCtx];
+    [editingCtx cancelSnapToRoad];
     [self applyProfileTypes:_oldProfileTypes toPoints:_oldPoints];
     [editingCtx clearPoints];
     [editingCtx addPoints:_oldPoints];
@@ -165,6 +166,7 @@
 
 - (void)redo
 {
+    [[self getEditingCtx] cancelSnapToRoad];
     [self executeCommand];
 }
 

--- a/Sources/Controllers/RoutePlanning/Commands/OASplitPointsCommand.mm
+++ b/Sources/Controllers/RoutePlanning/Commands/OASplitPointsCommand.mm
@@ -17,6 +17,8 @@
     NSArray<OASWptPt *> *_points;
     NSMutableDictionary<NSArray<OASWptPt *> *, OARoadSegmentData *> *_roadSegmentData;
     NSInteger _pointPosition;
+    NSInteger _splitPointPosition;
+    NSString *_pointProfileType;
 }
 
 - (instancetype) initWithLayer:(OAMeasurementToolLayer *)measurementLayer after:(BOOL)after
@@ -32,6 +34,7 @@
             _after = YES;
             _pointPosition = (NSInteger) [editingCtx getPoints].count - 1;
         }
+        _splitPointPosition = _after ? _pointPosition : _pointPosition - 1;
     }
     return self;
 }
@@ -45,8 +48,12 @@
 - (void) executeCommand
 {
     OAMeasurementEditingContext *editingCtx = [self getEditingCtx];
-    _points = [NSArray arrayWithArray:editingCtx.getPoints];
-    _roadSegmentData = editingCtx.roadSegmentData;
+    _points = [editingCtx.getPoints copy];
+    _roadSegmentData = [editingCtx.roadSegmentData mutableCopy];
+    _splitPointPosition = _after ? _pointPosition : _pointPosition - 1;
+    _pointProfileType = _splitPointPosition >= 0 && _splitPointPosition < (NSInteger)_points.count
+        ? [_points[_splitPointPosition].getProfileType copy]
+        : nil;
     [editingCtx splitPoints:_pointPosition after:_after];
     [self refreshMap];
 }
@@ -55,7 +62,15 @@
 {
     OAMeasurementEditingContext *editingCtx = [self getEditingCtx];
     [editingCtx clearSegments];
-    [editingCtx setRoadSegmentData:_roadSegmentData];
+    if (_splitPointPosition >= 0 && _splitPointPosition < (NSInteger)_points.count)
+    {
+        OASWptPt *splitPoint = _points[_splitPointPosition];
+        if (_pointProfileType != nil)
+            [splitPoint setProfileTypeProfileType:_pointProfileType];
+        else
+            [splitPoint removeProfileType];
+    }
+    [editingCtx setRoadSegmentData:[_roadSegmentData mutableCopy]];
     [editingCtx addPoints:_points];
     [self refreshMap];
 }

--- a/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
+++ b/Sources/Controllers/RoutePlanning/OAMeasurementEditingContext.mm
@@ -799,7 +799,9 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
         return;
     OARoutingHelper *routingHelper = OARoutingHelper.sharedInstance;
     id<OASnapToRoadProgressDelegate> progressDelegate = self.progressDelegate;
-    if (progressDelegate != nil && !routingHelper.isRouteBeingCalculated)
+    BOOL canStartCalculation = !routingHelper.isRouteBeingCalculated
+        || (_calculationProgress != nullptr && _calculationProgress->isCancelled());
+    if (progressDelegate != nil && canStartCalculation)
     {
         OARouteCalculationParams *params = [self getParams:YES];
         if (params != nil)
@@ -1480,9 +1482,17 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 
 #pragma mark OARouteCalculationProgressCallback
 
-- (void)finish {
+- (void)finish
+{
     _calculatedPairs = 0;
     _pointsToCalculateSize = 0;
+    NSArray<OASWptPt *> *pair = _currentPair;
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf != nil && pair != nil && strongSelf->_currentPair == pair)
+            [strongSelf cancelSnapToRoad];
+    });
 }
 
 - (void)requestPrivateAccessRouting
@@ -1551,7 +1561,15 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
 {
     NSArray<OASWptPt *> *pair = _currentPair;
     if (![self isCurrentRouteCalculationForPair:pair route:route start:start end:end])
+    {
+        __weak __typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (strongSelf != nil && pair != nil && strongSelf->_currentPair == pair)
+                [strongSelf cancelSnapToRoad];
+        });
         return;
+    }
 
     NSArray<CLLocation *> *locations = route.getRouteLocations;
     NSMutableArray<OASWptPt *> *pts = [NSMutableArray arrayWithCapacity:locations.count];
@@ -1580,7 +1598,11 @@ static int MIN_METERS_BETWEEN_INTERMEDIATES = 100;
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong __typeof(weakSelf) strongSelf = weakSelf;
         if (![strongSelf isCurrentRouteCalculationForPair:pair route:route start:start end:end])
+        {
+            if (strongSelf != nil && pair != nil && strongSelf->_currentPair == pair)
+                [strongSelf cancelSnapToRoad];
             return;
+        }
 
         strongSelf->_calculatedPairs++;
         [strongSelf updateProgress:0];


### PR DESCRIPTION
## Summary

Fixes Undo/Redo state restoration for empty segments and route profiles in Plan Route.

## Changes

- Synchronize the pending empty segment with the actual trailing GPX gap after Undo/Redo.
- Restore the empty segment cell after redoing the `Start new segment` action.
- Remove the empty segment cell after undoing the split.
- Preserve and restore the original point profile when undoing a segment split.
- Preserve both old and new route profiles inside the route mode command.
- Apply profile changes to multiple points as a single command.
- Make grouped profile changes atomic: one Undo reverts the entire user action, and one Redo reapplies it.
- Restore the application mode and route profile after Undo/Redo.
- Update the selected profile and its icon in `Route between points` after history operations.
- Keep road segment data snapshots independent between Undo and Redo.