### PR TITLE
Show distance from segment start for Plan Route points

### DIFF
--- a/Sources/Controllers/PlanRoute/Cells/PlanRoutePointCell.swift
+++ b/Sources/Controllers/PlanRoute/Cells/PlanRoutePointCell.swift
@@ -110,7 +110,7 @@ final class PlanRoutePointCell: UITableViewCell {
         if point.isStart {
             return localizedString("start_point")
         }
-        let distance = OAOsmAndFormatter.getFormattedDistance(Float(point.distanceFromPrevious)) ?? ""
+        let distance = OAOsmAndFormatter.getFormattedDistance(Float(point.distanceFromStart)) ?? ""
         if point.isDestination {
             return "\(distance) • \(localizedString("route_descr_destination"))"
         }

--- a/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteEditingContextDataProvider.swift
@@ -501,8 +501,13 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
         let gapAfter = segment.hasGapAfter
             ? PlanRouteSegmentGap(distance: segment.gapDistance, bearing: segment.gapBearing)
             : nil
+        var distanceFromStart = 0.0
+        var groups: [PlanRouteProfileGroup] = []
+        for group in segment.groups {
+            groups.append(mapGroup(group, distanceFromStart: &distanceFromStart))
+        }
         return PlanRouteSegment(index: segment.index,
-                                groups: segment.groups.map { mapGroup($0) },
+                                groups: groups,
                                 routed: segment.routed,
                                 multiMode: segment.multiMode,
                                 singleMode: segment.singleMode,
@@ -524,18 +529,24 @@ final class PlanRouteEditingContextDataProvider: PlanRouteDataProvider {
                                  item: item)
     }
 
-    private func mapGroup(_ group: PlanRouteGroupData) -> PlanRouteProfileGroup {
-        PlanRouteProfileGroup(appMode: group.appMode,
-                              distance: group.distance,
-                              lastPointIndex: group.lastGlobalIndex,
-                              points: group.points.map { mapPoint($0) })
+    private func mapGroup(_ group: PlanRouteGroupData, distanceFromStart: inout Double) -> PlanRouteProfileGroup {
+        var points: [PlanRoutePoint] = []
+        for point in group.points {
+            distanceFromStart += point.distanceFromPrevious
+            points.append(mapPoint(point, distanceFromStart: distanceFromStart))
+        }
+        return PlanRouteProfileGroup(appMode: group.appMode,
+                                     distance: group.distance,
+                                     lastPointIndex: group.lastGlobalIndex,
+                                     points: points)
     }
 
-    private func mapPoint(_ point: PlanRoutePointData) -> PlanRoutePoint {
+    private func mapPoint(_ point: PlanRoutePointData, distanceFromStart: Double) -> PlanRoutePoint {
         PlanRoutePoint(index: point.globalIndex,
                        indexInSegment: point.indexInSegment,
                        name: point.name,
                        distanceFromPrevious: point.distanceFromPrevious,
+                       distanceFromStart: distanceFromStart,
                        bearing: point.bearing,
                        isStart: point.isStart,
                        isDestination: point.isDestination)

--- a/Sources/Controllers/PlanRoute/PlanRouteModels.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteModels.swift
@@ -136,6 +136,7 @@ struct PlanRoutePoint {
     let indexInSegment: Int
     let name: String
     let distanceFromPrevious: Double
+    let distanceFromStart: Double
     let bearing: Double
     let isStart: Bool
     let isDestination: Bool


### PR DESCRIPTION
## Summary

Fixed the distance displayed for points in Plan Route.

Previously, each point showed only the distance from the previous point. It now shows the cumulative distance from the start of the current segment.

## Changes

- Added a cumulative distance value to the point presentation model.
- Accumulated routed distances across all points within a segment.
- Reset the accumulated distance for each new segment.
- Kept gaps between segments excluded from the accumulated distance.
- Preserved the distance from the previous point for existing point-editing actions.