### PR TITLE
Fix Plan Route map controls and elevation graph navigation

### DIFF
--- a/Sources/Controllers/Map/OAMapHudViewController.mm
+++ b/Sources/Controllers/Map/OAMapHudViewController.mm
@@ -1861,7 +1861,12 @@ static const NSTimeInterval kWidgetsUpdateFrameInterval = 1.0 / 30.0;
     BOOL isScrollableHudAllowed = _mapPanelViewController.activeTargetType == OATargetMapModeParametersSettings;
     BOOL isTargetMultiMenuViewVisible = [_mapPanelViewController isTargetMultiMenuViewVisible];
     BOOL isBottomPanelVisible = _mapInfoController.bottomPanelController && [_mapInfoController.bottomPanelController hasWidgets];
-    BOOL isAllHidden = _mapPanelViewController.activeTargetType == OATargetRouteLineAppearance || _mapPanelViewController.activeTargetType == OATargetProfileAppearanceIconSizeSettings;
+    BOOL isPlanRouteFullscreen = _mapPanelViewController.activeTargetType == OATargetRoutePlanning
+        && _mapPanelViewController.scrollableHudViewController
+        && _mapPanelViewController.scrollableHudViewController.currentState == EOADraggableMenuStateFullScreen;
+    BOOL isAllHidden = _mapPanelViewController.activeTargetType == OATargetRouteLineAppearance
+        || _mapPanelViewController.activeTargetType == OATargetProfileAppearanceIconSizeSettings
+        || isPlanRouteFullscreen;
     BOOL isTargetToHideVisible = _mapPanelViewController.activeTargetType == OATargetChangePosition
         || _mapPanelViewController.activeTargetType == OATargetRouteLineAppearance;
     BOOL isToolbarAllowed = !self.contextMenuMode && !isDashboardVisible & !isTargetMultiMenuViewVisible && !isWeatherToolbarVisible;

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -789,6 +789,7 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
 
     private func setState(_ state: EOADraggableMenuState, animated: Bool) {
         sheetState = state
+        routeTypeButton.isHidden = state == .fullScreen
         let height = height(for: state)
         sheetHeightConstraint?.constant = height
         crosshairCenterYConstraint?.constant = crosshairCenterY(sheetHeight: height)

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -502,7 +502,7 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         let bottom = routeTypeButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -routeTypeButtonBottomInset(for: sheetState))
         routeTypeButtonBottomConstraint = bottom
         NSLayoutConstraint.activate([
-            routeTypeButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            routeTypeButton.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 16),
             bottom
         ])
         routeTypeButton.accessibilityLabel = localizedString("route_between_points")

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -80,6 +80,13 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         return view.bounds.height
     }
 
+    var mapViewportBounds: CGRect {
+        let bounds = view.bounds
+        let minY = bounds.minY + getNavbarHeight()
+        let maxY = max(minY, bounds.maxY - getViewHeight())
+        return CGRect(x: bounds.minX, y: minY, width: bounds.width, height: maxY - minY)
+    }
+
     init(dataProvider: PlanRouteDataProvider) {
         self.dataProvider = dataProvider
         sheetState = dataProvider.mode.isNewRoute ? .initial : .expanded

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -83,7 +83,8 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
     var mapViewportBounds: CGRect {
         let bounds = view.bounds
         let minY = bounds.minY + getNavbarHeight()
-        let maxY = max(minY, bounds.maxY - getViewHeight())
+        let sheetHeight = height(for: sheetState)
+        let maxY = max(minY, bounds.maxY - sheetHeight)
         return CGRect(x: bounds.minX, y: minY, width: bounds.width, height: maxY - minY)
     }
 

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
@@ -132,6 +132,10 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         return []
     }
 
+    private var mapViewportBounds: CGRect? {
+        (parent as? PlanRouteScrollableViewController)?.mapViewportBounds
+    }
+
     init(dataSource: PlanRouteAnalyzeDataSource?) {
         self.dataSource = dataSource
         super.init(nibName: nil, bundle: nil)
@@ -259,8 +263,12 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
             return
         }
         let helper = trackChartHelper(for: gpxFile)
+        let viewportBounds = mapViewportBounds
+        if let viewportBounds {
+            helper.screenBBox = viewportBounds
+        }
         helper.refreshChart(chart,
-                            fitTrack: false,
+                            fitTrack: viewportBounds != nil,
                             forceFit: false,
                             recalculateXAxis: false,
                             analysis: analysis,

--- a/Sources/Controllers/QuickAction/OAFloatingButtonsHudViewController/OAFloatingButtonsHudViewController.mm
+++ b/Sources/Controllers/QuickAction/OAFloatingButtonsHudViewController/OAFloatingButtonsHudViewController.mm
@@ -582,10 +582,13 @@ static NSInteger const kQuickActionSlashBackgroundTag = -2;
     Map3DModeVisibility map3DMode = [_map3DButtonState getVisibility];
     BOOL contextMenuHidesButton = [mapPanel isContextMenuVisible]
         && ![self isPlanRouteVisibleOnMapPanel:mapPanel];
+    BOOL isPlanRouteFullscreen = [self isPlanRouteVisibleOnMapPanel:mapPanel]
+        && mapPanel.scrollableHudViewController.currentState == EOADraggableMenuStateFullScreen;
     BOOL hideButton = map3DMode == Map3DModeVisibilityHidden
         || (map3DMode == Map3DModeVisibilityVisibleIn3DMode
             && ![OAMapViewTrackingUtilities.instance is3DMode])
         || contextMenuHidesButton
+        || isPlanRouteFullscreen
         || [mapPanel isDashboardVisible]
         || [mapPanel gpxModeActive]
         || [mapPanel isRouteInfoVisible]


### PR DESCRIPTION
## Summary

Fixes several Plan Route map UI issues related to RTL layout, full-screen mode, and elevation graph interaction.

## Changes

- Keep the route type button anchored to the physical left side in RTL layouts to prevent overlap with the zoom controls.
- Hide the route type, map HUD, and 3D buttons when the Plan Route bottom sheet is opened in full-screen mode.
- Recenter the map when a point selected on the elevation graph is outside the visible map viewport.