### PR TITLE
Fix elevation sheet opening from status card

### DIFF
--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
@@ -1217,19 +1217,9 @@ extension PlanRouteAnalyzeViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
-        switch currentState {
-        case .noData:
-            showGetElevationSheet()
-        case .elevationCalculating, .routeCalculating:
-            break
-        case .hasData:
-            if !hasOverviewData, indexPath.section == 0 {
-                showGetElevationSheet()
-                return
-            }
-            guard indexPath.section >= roadAttributesSectionStart else { return }
-            toggleRoadAttribute(at: indexPath.section - roadAttributesSectionStart)
-        }
+        guard case .hasData = currentState,
+              indexPath.section >= roadAttributesSectionStart else { return }
+        toggleRoadAttribute(at: indexPath.section - roadAttributesSectionStart)
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {


### PR DESCRIPTION
## Summary

Fixed the **Get elevation data** sheet opening when tapping the title or description of the **No elevation data** card.

The sheet now opens only when tapping the **Get elevation data** action. Road attribute rows remain selectable and continue to expand normally.