### PR TITLE
Use async address lookup for unknown locations

### DIFF
--- a/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
@@ -18,7 +18,6 @@
 #import "OAContextMenuProvider.h"
 #import "OARootViewController.h"
 #import "OAMapPanelViewController.h"
-#import "OAReverseGeocoder.h"
 #import "Localization.h"
 #import "OAPOILocationType.h"
 #import "OAMapObject+cpp.h"
@@ -422,28 +421,7 @@
 
 - (OATargetPoint *) getUnknownTargetPoint:(double)latitude longitude:(double)longitude
 {
-    NSString *addressString = nil;
-    BOOL isAddressFound = NO;
-    NSString *formattedTargetName = nil;
-    NSString *roadTitle = [[OAReverseGeocoder instance] lookupAddressAtLat:latitude lon:longitude];
-    if (!roadTitle || roadTitle.length == 0)
-    {
-        addressString = OALocalizedString(@"map_no_address");
-    }
-    else
-    {
-        addressString = roadTitle;
-        isAddressFound = YES;
-    }
-    
-    if (isAddressFound || addressString)
-    {
-        formattedTargetName = addressString;
-    }
-    else
-    {
-        formattedTargetName = [OAPointDescription getLocationName:latitude lon:longitude sh:NO];
-    }
+    NSString *formattedTargetName = OALocalizedString(@"shared_string_location");
     
     OAPOIType *poiType = [[OAPOILocationType alloc] init];
     
@@ -465,9 +443,10 @@
     targetPoint.location = CLLocationCoordinate2DMake(latitude, longitude);
     targetPoint.title = formattedTargetName;
     targetPoint.icon = [poiType icon];
-    targetPoint.titleAddress = roadTitle;
+    targetPoint.titleAddress = nil;
     targetPoint.type = OATargetPOI;
     targetPoint.targetObj = poi;
+    targetPoint.shouldFetchAddress = YES;
 
     return targetPoint;
 }

--- a/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
+++ b/Sources/Controllers/Map/Layers/OAContextMenuLayer.mm
@@ -421,7 +421,7 @@
 
 - (OATargetPoint *) getUnknownTargetPoint:(double)latitude longitude:(double)longitude
 {
-    NSString *formattedTargetName = OALocalizedString(@"shared_string_location");
+    NSString *formattedTargetName = OALocalizedString(@"map_no_address");
     
     OAPOIType *poiType = [[OAPOILocationType alloc] init];
     

--- a/Sources/Views/OATargetPointView.mm
+++ b/Sources/Views/OATargetPointView.mm
@@ -2834,7 +2834,15 @@ static const NSInteger _buttonsCount = 4;
     if (self.targetPoint.titleAddress.length == 0)
         self.targetPoint.titleAddress = OALocalizedString(@"map_no_address");
 
-    [self addressLabelUpdated];
+    if (self.targetPoint.addressFound && [self.targetPoint.title isEqualToString:OALocalizedString(@"map_no_address")])
+    {
+        self.targetPoint.title = self.targetPoint.titleAddress;
+        [self applyTargetPoint];
+    }
+    else
+    {
+        [self addressLabelUpdated];
+    }
 }
 
 @end


### PR DESCRIPTION
### Summary

- Removed synchronous reverse geocoding when creating an unknown map target.
- Enabled the existing `shouldFetchAddress` flow.