### PR TITLE
Use empty-trash endpoint for cloud Trash deletion

### DIFF
--- a/Sources/Backup/OABackupHelper.h
+++ b/Sources/Backup/OABackupHelper.h
@@ -57,6 +57,7 @@ static inline BOOL backupDebugLogs()
 + (NSString *) LIST_FILES_URL;
 + (NSString *) DELETE_FILE_VERSION_URL;
 + (NSString *) DELETE_FILE_URL;
++ (NSString *) EMPTY_TRASH_URL;
 + (NSString *) ACCOUNT_DELETE_URL;
 + (NSString *) SEND_CODE_URL;
 + (NSString *) CHECK_CODE_URL;
@@ -108,6 +109,7 @@ static inline BOOL backupDebugLogs()
 - (void) updateBackupUploadTime;
 
 - (void) deleteFilesSync:(NSArray<OARemoteFile *> *)remoteFiles byVersion:(BOOL)byVersion listener:(id<OAOnDeleteFilesListener>)listener;
+- (void) emptyTrash:(NSArray<OARemoteFile *> *)deletedFiles listener:(id<OAOnDeleteFilesListener>)listener;
 
 - (BOOL) prepareBackup;
 - (void) addPrepareBackupListener:(id<OAOnPrepareBackupListener>)listener;

--- a/Sources/Backup/OABackupHelper.mm
+++ b/Sources/Backup/OABackupHelper.mm
@@ -56,6 +56,7 @@ static NSString *ACCOUNT_DELETE_URL = [SERVER_URL stringByAppendingString:@"/use
 static NSString *SEND_CODE_URL = [SERVER_URL stringByAppendingString:@"/userdata/send-code"];
 static NSString *CHECK_CODE_URL = [SERVER_URL stringByAppendingString:@"/userdata/auth/confirm-code"];
 static NSCharacterSet* URL_PATH_CHARACTER_SET;
+static const NSUInteger EMPTY_TRASH_CHUNK_SIZE = 50;
 
 
 @interface OABackupHelper () <OAOnPrepareBackupListener, NSURLSessionDelegate>
@@ -678,6 +679,163 @@ static NSCharacterSet* URL_PATH_CHARACTER_SET;
     }
 }
 
+- (NSDictionary<OARemoteFile *, NSString *> *) emptyTrashChunk:(NSArray<OARemoteFile *> *)files
+{
+    NSMutableDictionary<OARemoteFile *, NSString *> *errors = [NSMutableDictionary dictionary];
+    NSMutableArray<OARemoteFile *> *requestFiles = [NSMutableArray array];
+    NSMutableArray<NSDictionary *> *filesJson = [NSMutableArray array];
+    for (OARemoteFile *file in files)
+    {
+        if (file.name.length == 0 || file.type.length == 0)
+        {
+            errors[file] = @"Invalid Trash item: missing name or type";
+            continue;
+        }
+        [requestFiles addObject:file];
+        [filesJson addObject:@{
+            @"name": file.name,
+            @"type": file.type,
+            @"updatetime": @(file.updatetimems)
+        }];
+    }
+
+    if (requestFiles.count == 0)
+        return errors;
+
+    NSError *jsonError = nil;
+    NSData *bodyData = [NSJSONSerialization dataWithJSONObject:filesJson options:0 error:&jsonError];
+    NSString *body = bodyData ? [[NSString alloc] initWithData:bodyData encoding:NSUTF8StringEncoding] : nil;
+    if (jsonError || !body)
+    {
+        for (OARemoteFile *file in requestFiles)
+        {
+            errors[file] = [NSString stringWithFormat:@"%@/%@: Failed to create empty Trash request", file.type, file.name];
+        }
+        return errors;
+    }
+
+    __block NSData *responseData = nil;
+    __block NSHTTPURLResponse *httpResponse = nil;
+    __block NSError *requestError = nil;
+    NSDictionary<NSString *, NSString *> *params = @{
+        @"deviceid": self.getDeviceId,
+        @"accessToken": self.getAccessToken
+    };
+    [OANetworkUtilities sendRequestWithUrl:EMPTY_TRASH_URL
+                                    params:params
+                                      body:body
+                               contentType:@"application/json"
+                                      post:YES
+                                     async:NO
+                                onComplete:^(NSData *data, NSURLResponse *response, NSError *error) {
+        responseData = data;
+        httpResponse = (NSHTTPURLResponse *)response;
+        requestError = error;
+    }];
+
+    NSString *chunkError = nil;
+    NSDictionary *responseJson = nil;
+    if (requestError)
+    {
+        chunkError = requestError.localizedDescription;
+    }
+    else if (!httpResponse || !responseData)
+    {
+        chunkError = @"Empty Trash error: empty response";
+    }
+    else
+    {
+        NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
+        if (httpResponse.statusCode != 200)
+        {
+            chunkError = responseString.length > 0 ? responseString : @"Empty Trash request failed";
+        }
+        else
+        {
+            NSError *responseError = nil;
+            id json = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&responseError];
+            if (responseError || ![json isKindOfClass:NSDictionary.class]
+                || ![((NSDictionary *)json)[@"status"] isEqualToString:@"ok"])
+            {
+                chunkError = @"Empty Trash error: invalid response";
+            }
+            else
+            {
+                responseJson = json;
+            }
+        }
+    }
+
+    if (chunkError)
+    {
+        for (OARemoteFile *file in requestFiles)
+        {
+            errors[file] = [NSString stringWithFormat:@"%@/%@: %@", file.type, file.name, chunkError];
+        }
+        return errors;
+    }
+
+    id resultsValue = responseJson[@"results"];
+    if (!resultsValue)
+        return errors; // Legacy {"status":"ok"} response means the complete chunk succeeded.
+
+    if (![resultsValue isKindOfClass:NSArray.class])
+    {
+        for (OARemoteFile *file in requestFiles)
+        {
+            errors[file] = [NSString stringWithFormat:@"%@/%@: Empty Trash error: invalid results", file.type, file.name];
+        }
+        return errors;
+    }
+
+    NSMutableIndexSet *matchedFiles = [NSMutableIndexSet indexSet];
+    for (id value in (NSArray *)resultsValue)
+    {
+        if (![value isKindOfClass:NSDictionary.class])
+            continue;
+
+        NSDictionary *result = value;
+        NSString *name = [result[@"name"] isKindOfClass:NSString.class] ? result[@"name"] : nil;
+        NSString *type = [result[@"type"] isKindOfClass:NSString.class] ? result[@"type"] : nil;
+        NSNumber *updatetime = [result[@"updatetime"] isKindOfClass:NSNumber.class] ? result[@"updatetime"] : nil;
+        NSString *status = [result[@"status"] isKindOfClass:NSString.class] ? result[@"status"] : nil;
+        if (!name || !type || !updatetime || !status)
+            continue;
+
+        NSUInteger fileIndex = [requestFiles indexOfObjectPassingTest:^BOOL(OARemoteFile *file, NSUInteger idx, BOOL *stop) {
+            return ![matchedFiles containsIndex:idx]
+                && [file.name isEqualToString:name]
+                && [file.type isEqualToString:type]
+                && file.updatetimems == updatetime.longValue;
+        }];
+        if (fileIndex == NSNotFound)
+            continue;
+
+        [matchedFiles addIndex:fileIndex];
+        OARemoteFile *file = requestFiles[fileIndex];
+        if ([status isEqualToString:@"deleted"] || [status isEqualToString:@"already_missing"])
+            continue;
+
+        NSString *message = [result[@"message"] isKindOfClass:NSString.class] ? result[@"message"] : nil;
+        if (message.length == 0)
+        {
+            if ([status isEqualToString:@"skipped_not_trash"])
+                message = @"The file is no longer in Trash";
+            else if ([status isEqualToString:@"failed"])
+                message = @"Failed to delete the file from Trash";
+            else
+                message = [NSString stringWithFormat:@"Unknown empty Trash result: %@", status];
+        }
+        errors[file] = [NSString stringWithFormat:@"%@/%@: %@", file.type, file.name, message];
+    }
+
+    [requestFiles enumerateObjectsUsingBlock:^(OARemoteFile *file, NSUInteger idx, BOOL *stop) {
+        if (![matchedFiles containsIndex:idx])
+            errors[file] = [NSString stringWithFormat:@"%@/%@: Empty Trash response did not include this file", file.type, file.name];
+    }];
+    return errors;
+}
+
 - (void) emptyTrash:(NSArray<OARemoteFile *> *)deletedFiles listener:(id<OAOnDeleteFilesListener>)listener
 {
     @try
@@ -688,101 +846,43 @@ static NSCharacterSet* URL_PATH_CHARACTER_SET;
             [_backupListeners addDeleteFilesListener:listener];
 
         [_executor addOperationWithBlock:^{
-            OAOperationLog *operationLog = [[OAOperationLog alloc] initWithOperationName:@"emptyTrash" debug:BACKUP_DEBUG_LOGS];
-            [operationLog startOperation];
+            @try
+            {
+                OAOperationLog *operationLog = [[OAOperationLog alloc] initWithOperationName:@"emptyTrash" debug:BACKUP_DEBUG_LOGS];
+                [operationLog startOperation];
 
-            NSArray<id<OAOnDeleteFilesListener>> *listeners = self->_backupListeners.getDeleteFilesListeners;
-            for (id<OAOnDeleteFilesListener> deleteListener in listeners)
-                [deleteListener onFilesDeleteStarted:files];
+                NSArray<id<OAOnDeleteFilesListener>> *listeners = self->_backupListeners.getDeleteFilesListeners;
+                for (id<OAOnDeleteFilesListener> deleteListener in listeners)
+                    [deleteListener onFilesDeleteStarted:files];
 
-            NSMutableArray<NSDictionary *> *filesJson = [NSMutableArray array];
-            for (OARemoteFile *file in files)
-            {
-                [filesJson addObject:@{
-                    @"name": file.name,
-                    @"type": file.type,
-                    @"updatetime": @(file.updatetimems)
-                }];
-            }
-
-            NSError *jsonError = nil;
-            NSData *bodyData = [NSJSONSerialization dataWithJSONObject:filesJson options:0 error:&jsonError];
-            NSString *body = bodyData ? [[NSString alloc] initWithData:bodyData encoding:NSUTF8StringEncoding] : nil;
-            __block NSData *responseData = nil;
-            __block NSHTTPURLResponse *httpResponse = nil;
-            __block NSError *requestError = nil;
-
-            if (!jsonError && body)
-            {
-                NSDictionary<NSString *, NSString *> *params = @{
-                    @"deviceid": self.getDeviceId,
-                    @"accessToken": self.getAccessToken
-                };
-                [OANetworkUtilities sendRequestWithUrl:EMPTY_TRASH_URL
-                                                params:params
-                                                  body:body
-                                           contentType:@"application/json"
-                                                  post:YES
-                                                 async:NO
-                                            onComplete:^(NSData *data, NSURLResponse *response, NSError *error) {
-                    responseData = data;
-                    httpResponse = (NSHTTPURLResponse *)response;
-                    requestError = error;
-                }];
-            }
-
-            NSInteger errorStatus = STATUS_SERVER_ERROR;
-            NSString *errorMessage = nil;
-            if (jsonError || !body)
-            {
-                errorStatus = STATUS_PARSE_JSON_ERROR;
-                errorMessage = @"Failed to create empty trash request";
-            }
-            else if (requestError)
-            {
-                errorMessage = requestError.localizedDescription;
-            }
-            else if (!httpResponse || !responseData)
-            {
-                errorStatus = STATUS_EMPTY_RESPONSE_ERROR;
-                errorMessage = @"Empty trash error: empty response";
-            }
-            else
-            {
-                NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
-                if (httpResponse.statusCode != 200)
+                NSMutableDictionary<OARemoteFile *, NSString *> *errors = [NSMutableDictionary dictionary];
+                for (NSUInteger offset = 0; offset < files.count; offset += EMPTY_TRASH_CHUNK_SIZE)
                 {
-                    errorMessage = responseString.length > 0 ? responseString : @"Empty trash request failed";
+                    NSUInteger chunkSize = MIN(EMPTY_TRASH_CHUNK_SIZE, files.count - offset);
+                    NSArray<OARemoteFile *> *chunk = [files subarrayWithRange:NSMakeRange(offset, chunkSize)];
+                    [errors addEntriesFromDictionary:[self emptyTrashChunk:chunk]];
                 }
-                else
-                {
-                    NSError *responseError = nil;
-                    id responseJson = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&responseError];
-                    if (responseError || ![responseJson isKindOfClass:NSDictionary.class]
-                        || ![((NSDictionary *)responseJson)[@"status"] isEqualToString:@"ok"])
-                    {
-                        errorStatus = STATUS_PARSE_JSON_ERROR;
-                        errorMessage = @"Empty trash error: invalid response";
-                    }
-                }
-            }
 
-            [operationLog finishOperation:[NSString stringWithFormat:@"Files: %lu", (unsigned long)files.count]];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                NSArray<id<OAOnDeleteFilesListener>> *currentListeners = self->_backupListeners.getDeleteFilesListeners;
-                if (errorMessage)
-                {
+                [operationLog finishOperation:[NSString stringWithFormat:@"Files: %lu, errors: %lu",
+                                               (unsigned long)files.count, (unsigned long)errors.count]];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSArray<id<OAOnDeleteFilesListener>> *currentListeners = self->_backupListeners.getDeleteFilesListeners;
                     for (id<OAOnDeleteFilesListener> deleteListener in currentListeners)
-                        [deleteListener onFilesDeleteError:errorStatus message:errorMessage];
-                }
-                else
-                {
+                        [deleteListener onFilesDeleteDone:errors];
+                    if (listener != nil)
+                        [self->_backupListeners removeDeleteFilesListener:listener];
+                });
+            }
+            @catch (NSException *e)
+            {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSArray<id<OAOnDeleteFilesListener>> *currentListeners = self->_backupListeners.getDeleteFilesListeners;
                     for (id<OAOnDeleteFilesListener> deleteListener in currentListeners)
-                        [deleteListener onFilesDeleteDone:@{}];
-                }
-                if (listener != nil)
-                    [self->_backupListeners removeDeleteFilesListener:listener];
-            });
+                        [deleteListener onFilesDeleteError:STATUS_EXECUTION_ERROR message:@"Execution error while emptying trash"];
+                    if (listener != nil)
+                        [self->_backupListeners removeDeleteFilesListener:listener];
+                });
+            }
         }];
     }
     @catch (NSException *e)

--- a/Sources/Backup/OABackupHelper.mm
+++ b/Sources/Backup/OABackupHelper.mm
@@ -51,6 +51,7 @@ static NSString *LIST_FILES_URL = [SERVER_URL stringByAppendingString:@"/userdat
 static NSString *DOWNLOAD_FILE_URL = [SERVER_URL stringByAppendingString:@"/userdata/download-file"];
 static NSString *DELETE_FILE_URL = [SERVER_URL stringByAppendingString:@"/userdata/delete-file"];
 static NSString *DELETE_FILE_VERSION_URL = [SERVER_URL stringByAppendingString:@"/userdata/delete-file-version"];
+static NSString *EMPTY_TRASH_URL = [SERVER_URL stringByAppendingString:@"/userdata/empty-trash"];
 static NSString *ACCOUNT_DELETE_URL = [SERVER_URL stringByAppendingString:@"/userdata/delete-account"];
 static NSString *SEND_CODE_URL = [SERVER_URL stringByAppendingString:@"/userdata/send-code"];
 static NSString *CHECK_CODE_URL = [SERVER_URL stringByAppendingString:@"/userdata/auth/confirm-code"];
@@ -100,6 +101,11 @@ static NSCharacterSet* URL_PATH_CHARACTER_SET;
 + (NSString *) DELETE_FILE_URL
 {
     return DELETE_FILE_URL;
+}
+
++ (NSString *) EMPTY_TRASH_URL
+{
+    return EMPTY_TRASH_URL;
 }
 
 + (NSString *) ACCOUNT_DELETE_URL
@@ -667,6 +673,125 @@ static NSCharacterSet* URL_PATH_CHARACTER_SET;
         {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [listener onFilesDeleteError:STATUS_EXECUTION_ERROR message:@"Execution error while deleting files"];
+            });
+        }
+    }
+}
+
+- (void) emptyTrash:(NSArray<OARemoteFile *> *)deletedFiles listener:(id<OAOnDeleteFilesListener>)listener
+{
+    @try
+    {
+        [self checkRegistered];
+        NSArray<OARemoteFile *> *files = [deletedFiles copy];
+        if (listener != nil)
+            [_backupListeners addDeleteFilesListener:listener];
+
+        [_executor addOperationWithBlock:^{
+            OAOperationLog *operationLog = [[OAOperationLog alloc] initWithOperationName:@"emptyTrash" debug:BACKUP_DEBUG_LOGS];
+            [operationLog startOperation];
+
+            NSArray<id<OAOnDeleteFilesListener>> *listeners = self->_backupListeners.getDeleteFilesListeners;
+            for (id<OAOnDeleteFilesListener> deleteListener in listeners)
+                [deleteListener onFilesDeleteStarted:files];
+
+            NSMutableArray<NSDictionary *> *filesJson = [NSMutableArray array];
+            for (OARemoteFile *file in files)
+            {
+                [filesJson addObject:@{
+                    @"name": file.name,
+                    @"type": file.type,
+                    @"updatetime": @(file.updatetimems)
+                }];
+            }
+
+            NSError *jsonError = nil;
+            NSData *bodyData = [NSJSONSerialization dataWithJSONObject:filesJson options:0 error:&jsonError];
+            NSString *body = bodyData ? [[NSString alloc] initWithData:bodyData encoding:NSUTF8StringEncoding] : nil;
+            __block NSData *responseData = nil;
+            __block NSHTTPURLResponse *httpResponse = nil;
+            __block NSError *requestError = nil;
+
+            if (!jsonError && body)
+            {
+                NSDictionary<NSString *, NSString *> *params = @{
+                    @"deviceid": self.getDeviceId,
+                    @"accessToken": self.getAccessToken
+                };
+                [OANetworkUtilities sendRequestWithUrl:EMPTY_TRASH_URL
+                                                params:params
+                                                  body:body
+                                           contentType:@"application/json"
+                                                  post:YES
+                                                 async:NO
+                                            onComplete:^(NSData *data, NSURLResponse *response, NSError *error) {
+                    responseData = data;
+                    httpResponse = (NSHTTPURLResponse *)response;
+                    requestError = error;
+                }];
+            }
+
+            NSInteger errorStatus = STATUS_SERVER_ERROR;
+            NSString *errorMessage = nil;
+            if (jsonError || !body)
+            {
+                errorStatus = STATUS_PARSE_JSON_ERROR;
+                errorMessage = @"Failed to create empty trash request";
+            }
+            else if (requestError)
+            {
+                errorMessage = requestError.localizedDescription;
+            }
+            else if (!httpResponse || !responseData)
+            {
+                errorStatus = STATUS_EMPTY_RESPONSE_ERROR;
+                errorMessage = @"Empty trash error: empty response";
+            }
+            else
+            {
+                NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
+                if (httpResponse.statusCode != 200)
+                {
+                    errorMessage = responseString.length > 0 ? responseString : @"Empty trash request failed";
+                }
+                else
+                {
+                    NSError *responseError = nil;
+                    id responseJson = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&responseError];
+                    if (responseError || ![responseJson isKindOfClass:NSDictionary.class]
+                        || ![((NSDictionary *)responseJson)[@"status"] isEqualToString:@"ok"])
+                    {
+                        errorStatus = STATUS_PARSE_JSON_ERROR;
+                        errorMessage = @"Empty trash error: invalid response";
+                    }
+                }
+            }
+
+            [operationLog finishOperation:[NSString stringWithFormat:@"Files: %lu", (unsigned long)files.count]];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSArray<id<OAOnDeleteFilesListener>> *currentListeners = self->_backupListeners.getDeleteFilesListeners;
+                if (errorMessage)
+                {
+                    for (id<OAOnDeleteFilesListener> deleteListener in currentListeners)
+                        [deleteListener onFilesDeleteError:errorStatus message:errorMessage];
+                }
+                else
+                {
+                    for (id<OAOnDeleteFilesListener> deleteListener in currentListeners)
+                        [deleteListener onFilesDeleteDone:@{}];
+                }
+                if (listener != nil)
+                    [self->_backupListeners removeDeleteFilesListener:listener];
+            });
+        }];
+    }
+    @catch (NSException *e)
+    {
+        if (listener != nil)
+        {
+            [_backupListeners removeDeleteFilesListener:listener];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [listener onFilesDeleteError:STATUS_EXECUTION_ERROR message:@"Execution error while emptying trash"];
             });
         }
     }

--- a/Sources/Controllers/Cloud/CloudTrashViewController.swift
+++ b/Sources/Controllers/Cloud/CloudTrashViewController.swift
@@ -256,14 +256,11 @@ final class CloudTrashViewController: OABaseNavbarViewController, OAOnPrepareBac
     }
 
     private func clearTrash() {
-        var files: [OARemoteFile] = []
-        for item: TrashItem in collectTrashItems() {
-            files.append(contentsOf: item.remoteFiles)
-        }
+        let files = collectTrashItems().map(\.deletedFile)
 
         let trashDeletionListener = TrashDeletionListener(with: localizedString("trash_is_empty"), deleteAll: true)
         trashDeletionListener.delegate = self
-        backupHelper?.deleteFilesSync(files, byVersion: true, listener: trashDeletionListener)
+        backupHelper?.emptyTrash(files, listener: trashDeletionListener)
     }
 
     private func downloadItem(_ trashItem: TrashItem, shouldReplace: Bool) {
@@ -361,9 +358,7 @@ final class CloudTrashViewController: OABaseNavbarViewController, OAOnPrepareBac
         alert.addAction(UIAlertAction(title: localizedString("shared_string_delete"), style: .destructive) { [weak self] _ in
             let trashDeletionListener = TrashDeletionListener(with: String(format: localizedString("shared_string_is_deleted"), trashItem.name))
             trashDeletionListener.delegate = self
-            self?.backupHelper?.deleteFilesSync(trashItem.remoteFiles,
-                                                byVersion: true,
-                                                listener: trashDeletionListener)
+            self?.backupHelper?.emptyTrash([trashItem.deletedFile], listener: trashDeletionListener)
         })
         alert.addAction(UIAlertAction(title: localizedString("shared_string_cancel"), style: .cancel))
         present(alert, animated: true)

--- a/Sources/Controllers/Cloud/CloudTrashViewController.swift
+++ b/Sources/Controllers/Cloud/CloudTrashViewController.swift
@@ -378,13 +378,15 @@ final class CloudTrashViewController: OABaseNavbarViewController, OAOnPrepareBac
     }
 
     func onFilesDeleteDone(_ message: String, errors: [OARemoteFile: String], deleteAll: Bool) {
-        let hasErrors = !errors.isEmpty
-        if hasErrors || !message.isEmpty {
+        if !errors.isEmpty {
             resetSelectedIndexPath()
-            OAUtilities.showToast(hasErrors ? localizedString("subscribe_email_error") : message,
-                                  details: hasErrors ? errors.values.joined(separator: "\n") : nil,
+            OAUtilities.showToast(localizedString("shared_string_error"),
+                                  details: errors.values.sorted().joined(separator: "\n"),
                                   duration: 4,
                                   in: view)
+        } else if !message.isEmpty {
+            resetSelectedIndexPath()
+            OAUtilities.showToast(message, details: nil, duration: 4, in: view)
         }
         backupHelper?.prepareBackup()
     }


### PR DESCRIPTION
## Summary

- add an authenticated JSON request to `/userdata/empty-trash`
- use the endpoint when emptying the complete Trash
- use the same endpoint when permanently deleting one Trash item
- preserve the existing Restore behavior, which deletes only the tombstone version
- report request results through the existing delete-files listener callbacks

## Why

The previous implementation deleted only the tombstone and one preceding version. Older server versions could remain and reappear after synchronization.

## Dependency

Requires the corresponding OsmAnd-tools server PR that exposes `/userdata/empty-trash`.

Related to osmandapp/OsmAnd#24228