### PR TITLE
Auto-merge independent Favorites changes across devices

### DIFF
--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -1810,6 +1810,7 @@
 		DA04D779284F86060097CAED /* ic_custom_five_downloads_big@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA04D773284F86050097CAED /* ic_custom_five_downloads_big@3x.png */; };
 		DA04D77A284F86060097CAED /* ic_custom_five_downloads_big@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA04D774284F86060097CAED /* ic_custom_five_downloads_big@2x.png */; };
 		DA05A6A3285B3DCE00D0AFAB /* OABackupExporter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA05A6A2285B3DCE00D0AFAB /* OABackupExporter.m */; };
+		C0D517770001000000000003 /* OAFavoritesBackupMerger.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D517770001000000000002 /* OAFavoritesBackupMerger.mm */; };
 		DA06BB5529967A4C003B9212 /* depthcontourlines.addon.render.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA06BB5429967A4C003B9212 /* depthcontourlines.addon.render.xml */; };
 		DA08A0D2227096DA000A53BA /* offroad.render.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA08A0D1227096DA000A53BA /* offroad.render.xml */; };
 		DA08A14A2A41DA7400205D7E /* RulerDistanceWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA08A1492A41DA7400205D7E /* RulerDistanceWidget.swift */; };
@@ -5977,6 +5978,8 @@
 		DA04D774284F86060097CAED /* ic_custom_five_downloads_big@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ic_custom_five_downloads_big@2x.png"; path = "Resources/Icons/ic_custom_five_downloads_big@2x.png"; sourceTree = "<group>"; };
 		DA05A6A1285B3DCE00D0AFAB /* OABackupExporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OABackupExporter.h; sourceTree = "<group>"; };
 		DA05A6A2285B3DCE00D0AFAB /* OABackupExporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OABackupExporter.m; sourceTree = "<group>"; };
+		C0D517770001000000000001 /* OAFavoritesBackupMerger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAFavoritesBackupMerger.h; sourceTree = "<group>"; };
+		C0D517770001000000000002 /* OAFavoritesBackupMerger.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OAFavoritesBackupMerger.mm; sourceTree = "<group>"; };
 		DA06BB5429967A4C003B9212 /* depthcontourlines.addon.render.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = depthcontourlines.addon.render.xml; path = ../resources/rendering_styles/depthcontourlines.addon.render.xml; sourceTree = "<group>"; };
 		DA08A0D1227096DA000A53BA /* offroad.render.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = offroad.render.xml; path = ../resources/rendering_styles/offroad.render.xml; sourceTree = "<group>"; };
 		DA08A1492A41DA7400205D7E /* RulerDistanceWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulerDistanceWidget.swift; sourceTree = "<group>"; };
@@ -14910,6 +14913,8 @@
 			isa = PBXGroup;
 			children = (
 				46D5E4192D31A3EC00428227 /* BackupUtils.swift */,
+				C0D517770001000000000001 /* OAFavoritesBackupMerger.h */,
+				C0D517770001000000000002 /* OAFavoritesBackupMerger.mm */,
 				DAA9F44B27EC9E99002BB1A8 /* Commands */,
 				DA4ABED22876D98D00B996EF /* LocalBackup */,
 				4657490F2B68129B0006046B /* BackupUiUtils.swift */,
@@ -18040,6 +18045,7 @@
 				46220B702AD6D6F2006C3248 /* OABaseEditorViewController.mm in Sources */,
 				DA5A855B26C563A900F274C7 /* OAWorldRegion.mm in Sources */,
 				DAEDAAA12865A0F100CE54D0 /* OAGenerateBackupInfoTask.m in Sources */,
+				C0D517770001000000000003 /* OAFavoritesBackupMerger.mm in Sources */,
 				32839A372AF0F911007B5057 /* WikiImageCacheHelper.swift in Sources */,
 				4663AB412951CB6200D9781E /* OAInputTableViewCell.m in Sources */,
 				FAAD725A2E1BBE51000807A0 /* AppStartupMonitor.swift in Sources */,

--- a/Sources/Backup/OABackupExporter.m
+++ b/Sources/Backup/OABackupExporter.m
@@ -8,6 +8,7 @@
 
 #import "OABackupExporter.h"
 #import "OABackupHelper.h"
+#import "OAFavoritesBackupMerger.h"
 #import "OASettingsItem.h"
 #import "OABackupListeners.h"
 #import "OAAbstractWriter.h"
@@ -293,7 +294,10 @@
     if (error.length > 0)
         [_errors setObjectSync:error forKey:[NSString stringWithFormat:@"%@/%@", type, fileName]];
     else
+    {
         [self markOldFileForDeletion:item fileName:fileName];
+        [OAFavoritesBackupMerger onUploadSuccess:item fileName:fileName uploadTime:uploadTime];
+    }
     int p = [_dataProgress addAndGet:(APPROXIMATE_FILE_SIZE_BYTES / 1024)];
     __strong id<OANetworkExportProgressListener> listener = _listener;
     if (listener)

--- a/Sources/Backup/OABackupImporter.m
+++ b/Sources/Backup/OABackupImporter.m
@@ -8,6 +8,7 @@
 
 #import "OABackupImporter.h"
 #import "OABackupHelper.h"
+#import "OAFavoritesBackupMerger.h"
 #import "OABackupListeners.h"
 #import "OABackupDbHelper.h"
 #import "OAPrepareBackupResult.h"
@@ -297,6 +298,7 @@
 
                 [self updateFileMd5Digest:remoteFile item:item];
                 [self updateFileUploadTime:remoteFile item:item];
+                [OAFavoritesBackupMerger onDownloadSuccess:item remoteFile:remoteFile];
             }
             if ([NSFileManager.defaultManager fileExistsAtPath:tempFilePath])
                 [NSFileManager.defaultManager removeItemAtPath:tempFilePath error:nil];

--- a/Sources/Backup/OAFavoritesBackupMerger.h
+++ b/Sources/Backup/OAFavoritesBackupMerger.h
@@ -5,6 +5,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class OABackupHelper, OABackupInfo, OARemoteFile, OASettingsItem;
 
 @interface OAFavoritesBackupMerger : NSObject
@@ -14,3 +16,5 @@
 + (void)onDownloadSuccess:(OASettingsItem *)item remoteFile:(OARemoteFile *)remoteFile;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Backup/OAFavoritesBackupMerger.h
+++ b/Sources/Backup/OAFavoritesBackupMerger.h
@@ -1,0 +1,16 @@
+//
+//  OAFavoritesBackupMerger.h
+//  OsmAnd Maps
+//
+
+#import <Foundation/Foundation.h>
+
+@class OABackupHelper, OABackupInfo, OARemoteFile, OASettingsItem;
+
+@interface OAFavoritesBackupMerger : NSObject
+
++ (void)prepareMergeUploads:(OABackupInfo *)info backupHelper:(OABackupHelper *)backupHelper;
++ (void)onUploadSuccess:(OASettingsItem *)item fileName:(NSString *)fileName uploadTime:(long)uploadTime;
++ (void)onDownloadSuccess:(OASettingsItem *)item remoteFile:(OARemoteFile *)remoteFile;
+
+@end

--- a/Sources/Backup/OAFavoritesBackupMerger.mm
+++ b/Sources/Backup/OAFavoritesBackupMerger.mm
@@ -20,31 +20,6 @@
 
 static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
 
-@interface OAFavoritesBackupMerger ()
-
-+ (OAFavoriteGroup *)downloadGroup:(OARemoteFile *)remoteFile backupHelper:(OABackupHelper *)backupHelper;
-+ (OAFavoriteGroup *)loadSnapshot:(NSString *)fileName syncTime:(long)syncTime;
-+ (void)saveSnapshot:(OAFavoriteGroup *)group fileName:(NSString *)fileName syncTime:(long)syncTime;
-+ (NSString *)snapshotRoot;
-+ (NSString *)snapshotPath:(NSString *)fileName syncTime:(long)syncTime;
-+ (OAFavoriteGroup *)readGroup:(NSString *)path;
-+ (OAFavoriteGroup *)mergeBase:(OAFavoriteGroup *)base local:(OAFavoriteGroup *)local remote:(OAFavoriteGroup *)remote;
-+ (NSMutableDictionary<NSString *, OAFavoriteItem *> *)pointsByName:(OAFavoriteGroup *)group;
-+ (BOOL)sameAppearance:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second;
-+ (BOOL)sameGroup:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second;
-+ (BOOL)samePoint:(OAFavoriteItem *)first other:(OAFavoriteItem *)second;
-+ (BOOL)samePointContent:(OAFavoriteItem *)first other:(OAFavoriteItem *)second;
-+ (BOOL)hasRenameOf:(OAFavoriteItem *)basePoint
-                 in:(NSDictionary<NSString *, OAFavoriteItem *> *)additions;
-+ (BOOL)sameText:(NSString *)first other:(NSString *)second;
-+ (BOOL)sameTime:(NSDate *)first other:(NSDate *)second;
-+ (NSString *)normalizedIcon:(NSString *)icon;
-+ (NSString *)normalizedBackground:(NSString *)background;
-+ (OAFavoriteItem *)copyPoint:(OAFavoriteItem *)point;
-+ (OAFavoriteGroup *)copyGroup:(OAFavoriteGroup *)group;
-
-@end
-
 @interface OAMergedFavoritesSettingsItem : OAFavoritesSettingsItem
 
 - (instancetype)initWithBaseItem:(OAFavoritesSettingsItem *)baseItem

--- a/Sources/Backup/OAFavoritesBackupMerger.mm
+++ b/Sources/Backup/OAFavoritesBackupMerger.mm
@@ -33,6 +33,9 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
 + (BOOL)sameAppearance:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second;
 + (BOOL)sameGroup:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second;
 + (BOOL)samePoint:(OAFavoriteItem *)first other:(OAFavoriteItem *)second;
++ (BOOL)samePointContent:(OAFavoriteItem *)first other:(OAFavoriteItem *)second;
++ (BOOL)hasRenameOf:(OAFavoriteItem *)basePoint
+                 in:(NSDictionary<NSString *, OAFavoriteItem *> *)additions;
 + (BOOL)sameText:(NSString *)first other:(NSString *)second;
 + (BOOL)sameTime:(NSDate *)first other:(NSDate *)second;
 + (NSString *)normalizedIcon:(NSString *)icon;
@@ -244,6 +247,11 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
     if (!basePoints || !localPoints || !remotePoints)
         return nil;
 
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *localAdditions = localPoints.mutableCopy;
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *remoteAdditions = remotePoints.mutableCopy;
+    [localAdditions removeObjectsForKeys:basePoints.allKeys];
+    [remoteAdditions removeObjectsForKeys:basePoints.allKeys];
+
     NSMutableArray<OAFavoriteItem *> *mergedPoints = [NSMutableArray array];
     for (OAFavoriteItem *basePoint in base.points)
     {
@@ -254,7 +262,12 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
         [remotePoints removeObjectForKey:name];
 
         if (!localPoint && !remotePoint)
+        {
+            if ([self hasRenameOf:basePoint in:localAdditions] ||
+                [self hasRenameOf:basePoint in:remoteAdditions])
+                return nil;
             continue;
+        }
 
         BOOL localUnchanged = [self samePoint:basePoint other:localPoint];
         BOOL remoteUnchanged = [self samePoint:basePoint other:remotePoint];
@@ -322,8 +335,13 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
 
 + (BOOL)samePoint:(OAFavoriteItem *)first other:(OAFavoriteItem *)second
 {
-    if (!second || ![first.getName isEqualToString:second.getName] ||
-        ![first.getCategory isEqualToString:second.getCategory] ||
+    return second && [first.getName isEqualToString:second.getName] &&
+           [self samePointContent:first other:second];
+}
+
++ (BOOL)samePointContent:(OAFavoriteItem *)first other:(OAFavoriteItem *)second
+{
+    if (!second || ![first.getCategory isEqualToString:second.getCategory] ||
         ![self sameText:first.getDescription other:second.getDescription] ||
         ![self sameText:first.getAddress other:second.getAddress] ||
         ![self sameText:first.getAmenityOriginName other:second.getAmenityOriginName] ||
@@ -338,6 +356,17 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
     CLLocation *firstLocation = [[CLLocation alloc] initWithLatitude:first.getLatitude longitude:first.getLongitude];
     CLLocation *secondLocation = [[CLLocation alloc] initWithLatitude:second.getLatitude longitude:second.getLongitude];
     return [firstLocation distanceFromLocation:secondLocation] < 0.1;
+}
+
++ (BOOL)hasRenameOf:(OAFavoriteItem *)basePoint
+                 in:(NSDictionary<NSString *, OAFavoriteItem *> *)additions
+{
+    for (OAFavoriteItem *point in additions.allValues)
+    {
+        if ([self samePointContent:basePoint other:point])
+            return YES;
+    }
+    return NO;
 }
 
 + (BOOL)sameText:(NSString *)first other:(NSString *)second

--- a/Sources/Backup/OAFavoritesBackupMerger.mm
+++ b/Sources/Backup/OAFavoritesBackupMerger.mm
@@ -1,0 +1,438 @@
+//
+//  OAFavoritesBackupMerger.mm
+//  OsmAnd Maps
+//
+
+#import "OAFavoritesBackupMerger.h"
+
+#import <CoreLocation/CoreLocation.h>
+
+#import "OABackupHelper.h"
+#import "OABackupInfo.h"
+#import "OAFavoritesHelper.h"
+#import "OAFavoritesSettingsItem.h"
+#import "OAFavoriteItem.h"
+#import "OALocalFile.h"
+#import "OARemoteFile.h"
+#import "OAUtilities.h"
+#import "OsmAndApp.h"
+#import "OsmAnd_Maps-Swift.h"
+
+static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
+
+@interface OAFavoritesBackupMerger ()
+
++ (OAFavoriteGroup *)downloadGroup:(OARemoteFile *)remoteFile backupHelper:(OABackupHelper *)backupHelper;
++ (OAFavoriteGroup *)loadSnapshot:(NSString *)fileName syncTime:(long)syncTime;
++ (void)saveSnapshot:(OAFavoriteGroup *)group fileName:(NSString *)fileName syncTime:(long)syncTime;
++ (NSString *)snapshotRoot;
++ (NSString *)snapshotPath:(NSString *)fileName syncTime:(long)syncTime;
++ (OAFavoriteGroup *)readGroup:(NSString *)path;
++ (OAFavoriteGroup *)mergeBase:(OAFavoriteGroup *)base local:(OAFavoriteGroup *)local remote:(OAFavoriteGroup *)remote;
++ (NSMutableDictionary<NSString *, OAFavoriteItem *> *)pointsByName:(OAFavoriteGroup *)group;
++ (BOOL)sameAppearance:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second;
++ (BOOL)sameGroup:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second;
++ (BOOL)samePoint:(OAFavoriteItem *)first other:(OAFavoriteItem *)second;
++ (BOOL)sameText:(NSString *)first other:(NSString *)second;
++ (BOOL)sameTime:(NSDate *)first other:(NSDate *)second;
++ (NSString *)normalizedIcon:(NSString *)icon;
++ (NSString *)normalizedBackground:(NSString *)background;
++ (OAFavoriteItem *)copyPoint:(OAFavoriteItem *)point;
++ (OAFavoriteGroup *)copyGroup:(OAFavoriteGroup *)group;
+
+@end
+
+@interface OAMergedFavoritesSettingsItem : OAFavoritesSettingsItem
+
+- (instancetype)initWithBaseItem:(OAFavoritesSettingsItem *)baseItem
+                       localGroup:(OAFavoriteGroup *)localGroup
+                      mergedGroup:(OAFavoriteGroup *)mergedGroup
+               sourceModifiedTime:(long)sourceModifiedTime;
+- (void)finishUpload:(NSString *)fileName uploadTime:(long)uploadTime;
+
+@end
+
+@implementation OAFavoritesBackupMerger
+
++ (void)prepareMergeUploads:(OABackupInfo *)info backupHelper:(OABackupHelper *)backupHelper
+{
+    for (NSArray *pair in info.filesToMerge.copy)
+    {
+        if (pair.count != 2)
+            continue;
+
+        OALocalFile *localFile = pair.firstObject;
+        OARemoteFile *remoteFile = pair.lastObject;
+        if (![localFile.item isKindOfClass:OAFavoritesSettingsItem.class])
+            continue;
+
+        OAFavoritesSettingsItem *localItem = (OAFavoritesSettingsItem *)localFile.item;
+        OAFavoriteGroup *localGroup = localItem.items.count == 1 ? localItem.items.firstObject : nil;
+        if (!localGroup || localGroup.isPersonal)
+            continue;
+
+        OAFavoriteGroup *baseGroup = [self loadSnapshot:remoteFile.name syncTime:localFile.uploadTime];
+        OAFavoriteGroup *remoteGroup = baseGroup ? [self downloadGroup:remoteFile backupHelper:backupHelper] : nil;
+        OAFavoriteGroup *mergedGroup = [self mergeBase:baseGroup local:localGroup remote:remoteGroup];
+        if (!mergedGroup)
+            continue;
+
+        localFile.item = [[OAMergedFavoritesSettingsItem alloc] initWithBaseItem:localItem
+                                                                     localGroup:localGroup
+                                                                    mergedGroup:mergedGroup
+                                                             sourceModifiedTime:localFile.localModifiedTime];
+        [info.filesToUpload addObject:localFile];
+        [info.filesToMerge removeObject:pair];
+    }
+}
+
++ (void)onUploadSuccess:(OASettingsItem *)item fileName:(NSString *)fileName uploadTime:(long)uploadTime
+{
+    if (uploadTime <= 0 || ![item isKindOfClass:OAFavoritesSettingsItem.class])
+        return;
+    if (![fileName isEqualToString:[BackupUtils getItemFileName:item]])
+        return;
+
+    OAFavoritesSettingsItem *favoritesItem = (OAFavoritesSettingsItem *)item;
+    if ([favoritesItem isKindOfClass:OAMergedFavoritesSettingsItem.class])
+    {
+        [(OAMergedFavoritesSettingsItem *)favoritesItem finishUpload:fileName uploadTime:uploadTime];
+    }
+    else if (favoritesItem.localModifiedTime == favoritesItem.lastModifiedTime)
+    {
+        OAFavoriteGroup *group = favoritesItem.items.count == 1 ? favoritesItem.items.firstObject : nil;
+        [self saveSnapshot:group fileName:fileName syncTime:uploadTime];
+    }
+    else
+    {
+        OAFavoriteGroup *group = favoritesItem.items.count == 1 ? favoritesItem.items.firstObject : nil;
+        if (group && [OAFavoritesHelper groupByName:group.name])
+            favoritesItem.localModifiedTime = MAX((long)(NSDate.date.timeIntervalSince1970 * 1000.0), uploadTime + 1);
+    }
+}
+
++ (void)onDownloadSuccess:(OASettingsItem *)item remoteFile:(OARemoteFile *)remoteFile
+{
+    if (![item isKindOfClass:OAFavoritesSettingsItem.class])
+        return;
+
+    OAFavoritesSettingsItem *favoritesItem = (OAFavoritesSettingsItem *)item;
+    OAFavoriteGroup *downloaded = favoritesItem.items.count == 1 ? favoritesItem.items.firstObject : nil;
+    OAFavoriteGroup *current = downloaded ? [OAFavoritesHelper groupByName:downloaded.name] : nil;
+    if (downloaded && [self sameGroup:downloaded other:current])
+        [self saveSnapshot:downloaded fileName:remoteFile.name syncTime:remoteFile.updatetimems];
+}
+
+#pragma mark - Snapshots
+
++ (OAFavoriteGroup *)downloadGroup:(OARemoteFile *)remoteFile backupHelper:(OABackupHelper *)backupHelper
+{
+    if (remoteFile.isDeleted)
+        return nil;
+
+    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                      [NSString stringWithFormat:@"favorites-merge-%@.gpx", NSUUID.UUID.UUIDString]];
+    @try
+    {
+        NSString *error = [backupHelper downloadFile:path remoteFile:remoteFile listener:nil];
+        return error.length == 0 ? [self readGroup:path] : nil;
+    }
+    @catch (NSException *exception)
+    {
+        NSLog(@"FavoritesBackupMerger: failed to download %@: %@", remoteFile.name, exception.reason);
+        return nil;
+    }
+    @finally
+    {
+        [NSFileManager.defaultManager removeItemAtPath:path error:nil];
+    }
+}
+
++ (OAFavoriteGroup *)loadSnapshot:(NSString *)fileName syncTime:(long)syncTime
+{
+    NSString *path = [self snapshotPath:fileName syncTime:syncTime];
+    return path && [NSFileManager.defaultManager fileExistsAtPath:path] ? [self readGroup:path] : nil;
+}
+
++ (void)saveSnapshot:(OAFavoriteGroup *)group fileName:(NSString *)fileName syncTime:(long)syncTime
+{
+    NSString *path = [self snapshotPath:fileName syncTime:syncTime];
+    if (!group || !path || syncTime <= 0)
+        return;
+
+    NSFileManager *manager = NSFileManager.defaultManager;
+    NSString *directory = path.stringByDeletingLastPathComponent;
+    NSError *error = nil;
+    if (![manager createDirectoryAtPath:directory withIntermediateDirectories:YES attributes:nil error:&error])
+    {
+        NSLog(@"FavoritesBackupMerger: failed to create snapshot directory: %@", error.localizedDescription);
+        return;
+    }
+    [[NSURL fileURLWithPath:[self snapshotRoot]] setResourceValue:@YES
+                                                           forKey:NSURLIsExcludedFromBackupKey
+                                                            error:nil];
+
+    NSString *temporaryPath = [directory stringByAppendingPathComponent:
+                               [NSString stringWithFormat:@".%@.gpx", NSUUID.UUID.UUIDString]];
+    OAFavoriteGroup *snapshotGroup = [self copyGroup:group];
+    OASGpxFile *gpx = [OAFavoritesHelper asGpxFile:@[snapshotGroup]];
+    OASKException *exception = [OASGpxUtilities.shared writeGpxFileFile:
+                                [[OASKFile alloc] initWithFilePath:temporaryPath] gpxFile:gpx];
+    if (exception || ![manager fileExistsAtPath:temporaryPath])
+    {
+        [manager removeItemAtPath:temporaryPath error:nil];
+        NSLog(@"FavoritesBackupMerger: failed to save snapshot for %@", fileName);
+        return;
+    }
+
+    [manager removeItemAtPath:path error:nil];
+    if (![manager moveItemAtPath:temporaryPath toPath:path error:&error])
+    {
+        [manager removeItemAtPath:temporaryPath error:nil];
+        NSLog(@"FavoritesBackupMerger: failed to install snapshot for %@: %@", fileName, error.localizedDescription);
+        return;
+    }
+
+    for (NSString *oldFile in [manager contentsOfDirectoryAtPath:directory error:nil])
+    {
+        NSString *oldPath = [directory stringByAppendingPathComponent:oldFile];
+        if (![oldPath isEqualToString:path])
+            [manager removeItemAtPath:oldPath error:nil];
+    }
+}
+
++ (NSString *)snapshotRoot
+{
+    return [OsmAndApp.instance.dataPath stringByAppendingPathComponent:kFavoritesSnapshotDirectory];
+}
+
++ (NSString *)snapshotPath:(NSString *)fileName syncTime:(long)syncTime
+{
+    if (syncTime <= 0 || fileName.length == 0 || ![fileName.lastPathComponent isEqualToString:fileName])
+        return nil;
+    fileName = fileName.precomposedStringWithCanonicalMapping;
+    NSString *directory = [[self snapshotRoot] stringByAppendingPathComponent:fileName];
+    return [directory stringByAppendingPathComponent:[NSString stringWithFormat:@"%ld.gpx", syncTime]];
+}
+
++ (OAFavoriteGroup *)readGroup:(NSString *)path
+{
+    OASGpxFile *gpx = [OAFavoritesHelper loadGpxFile:path];
+    if (!gpx || gpx.pointsGroups.count != 1)
+        return nil;
+
+    OASGpxUtilitiesPointsGroup *pointsGroup = gpx.pointsGroups.allValues.firstObject;
+    OAFavoriteGroup *group = [OAFavoriteGroup fromPointsGroup:pointsGroup];
+    group.isVisible = !pointsGroup.isHidden;
+    return group.points.count == gpx.getPointsList.count ? group : nil;
+}
+
+#pragma mark - Merge
+
++ (OAFavoriteGroup *)mergeBase:(OAFavoriteGroup *)base
+                          local:(OAFavoriteGroup *)local
+                         remote:(OAFavoriteGroup *)remote
+{
+    if (!base || !local || !remote ||
+        ![self sameAppearance:base other:local] ||
+        ![self sameAppearance:base other:remote])
+        return nil;
+
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *basePoints = [self pointsByName:base];
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *localPoints = [self pointsByName:local];
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *remotePoints = [self pointsByName:remote];
+    if (!basePoints || !localPoints || !remotePoints)
+        return nil;
+
+    NSMutableArray<OAFavoriteItem *> *mergedPoints = [NSMutableArray array];
+    for (OAFavoriteItem *basePoint in base.points)
+    {
+        NSString *name = basePoint.getName;
+        OAFavoriteItem *localPoint = localPoints[name];
+        OAFavoriteItem *remotePoint = remotePoints[name];
+        [localPoints removeObjectForKey:name];
+        [remotePoints removeObjectForKey:name];
+
+        if (!localPoint && !remotePoint)
+            continue;
+
+        BOOL localUnchanged = [self samePoint:basePoint other:localPoint];
+        BOOL remoteUnchanged = [self samePoint:basePoint other:remotePoint];
+        if (!localUnchanged && !remoteUnchanged)
+            return nil;
+
+        OAFavoriteItem *result = localUnchanged ? remotePoint : localPoint;
+        if (result)
+            [mergedPoints addObject:[self copyPoint:result]];
+    }
+
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *additions = localPoints.mutableCopy;
+    for (NSString *name in remotePoints)
+    {
+        if (additions[name])
+            return nil;
+        additions[name] = remotePoints[name];
+    }
+    for (NSString *name in [additions.allKeys sortedArrayUsingSelector:@selector(compare:)])
+        [mergedPoints addObject:[self copyPoint:additions[name]]];
+
+    OAFavoriteGroup *merged = [self copyGroup:local];
+    merged.points = mergedPoints;
+    return merged;
+}
+
++ (NSMutableDictionary<NSString *, OAFavoriteItem *> *)pointsByName:(OAFavoriteGroup *)group
+{
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *points = [NSMutableDictionary dictionary];
+    for (OAFavoriteItem *point in group.points)
+    {
+        NSString *name = point.getName;
+        if (name.length == 0 || points[name])
+            return nil;
+        points[name] = point;
+    }
+    return points;
+}
+
++ (BOOL)sameAppearance:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second
+{
+    return second && [first.name isEqualToString:second.name] &&
+           first.color.toARGBNumber == second.color.toARGBNumber &&
+           [[self normalizedIcon:first.iconName] isEqualToString:[self normalizedIcon:second.iconName]] &&
+           [[self normalizedBackground:first.backgroundType] isEqualToString:[self normalizedBackground:second.backgroundType]] &&
+           first.isVisible == second.isVisible &&
+           first.isPinned == second.isPinned;
+}
+
++ (BOOL)sameGroup:(OAFavoriteGroup *)first other:(OAFavoriteGroup *)second
+{
+    if (!second || ![self sameAppearance:first other:second])
+        return NO;
+
+    NSMutableDictionary<NSString *, OAFavoriteItem *> *secondPoints = [self pointsByName:second];
+    if (!secondPoints || first.points.count != secondPoints.count)
+        return NO;
+    for (OAFavoriteItem *point in first.points)
+    {
+        if (![self samePoint:point other:secondPoints[point.getName]])
+            return NO;
+    }
+    return YES;
+}
+
++ (BOOL)samePoint:(OAFavoriteItem *)first other:(OAFavoriteItem *)second
+{
+    if (!second || ![first.getName isEqualToString:second.getName] ||
+        ![first.getCategory isEqualToString:second.getCategory] ||
+        ![self sameText:first.getDescription other:second.getDescription] ||
+        ![self sameText:first.getAddress other:second.getAddress] ||
+        ![self sameText:first.getAmenityOriginName other:second.getAmenityOriginName] ||
+        first.getCalendarEvent != second.getCalendarEvent ||
+        first.getColor.toARGBNumber != second.getColor.toARGBNumber ||
+        ![first.getIcon isEqualToString:second.getIcon] ||
+        ![first.getBackgroundIcon isEqualToString:second.getBackgroundIcon] ||
+        first.isVisible != second.isVisible ||
+        ![self sameTime:first.getPickupTime other:second.getPickupTime])
+        return NO;
+
+    CLLocation *firstLocation = [[CLLocation alloc] initWithLatitude:first.getLatitude longitude:first.getLongitude];
+    CLLocation *secondLocation = [[CLLocation alloc] initWithLatitude:second.getLatitude longitude:second.getLongitude];
+    return [firstLocation distanceFromLocation:secondLocation] < 0.1;
+}
+
++ (BOOL)sameText:(NSString *)first other:(NSString *)second
+{
+    return [first isEqualToString:second] || (first.length == 0 && second.length == 0);
+}
+
++ (BOOL)sameTime:(NSDate *)first other:(NSDate *)second
+{
+    if (!first || !second)
+        return first == second;
+    return fabs([first timeIntervalSinceDate:second]) < 1.0;
+}
+
++ (NSString *)normalizedIcon:(NSString *)icon
+{
+    return icon.length > 0 ? icon : DEFAULT_ICON_NAME_KEY;
+}
+
++ (NSString *)normalizedBackground:(NSString *)background
+{
+    return background.length > 0 ? background : DEFAULT_ICON_SHAPE_KEY;
+}
+
++ (OAFavoriteItem *)copyPoint:(OAFavoriteItem *)point
+{
+    std::shared_ptr<OsmAnd::IFavoriteLocation> favorite =
+        [OAFavoritesHelper getFavoritesCollection]->copyFavoriteLocation(point.favorite);
+    return [[OAFavoriteItem alloc] initWithFavorite:favorite];
+}
+
++ (OAFavoriteGroup *)copyGroup:(OAFavoriteGroup *)group
+{
+    OAFavoriteGroup *copy = [[OAFavoriteGroup alloc] initWithName:group.name
+                                                       isVisible:group.isVisible
+                                                           color:group.color];
+    copy.isPinned = group.isPinned;
+    copy.iconName = group.iconName;
+    copy.backgroundType = group.backgroundType;
+    for (OAFavoriteItem *point in group.points)
+        [copy.points addObject:[self copyPoint:point]];
+    return copy;
+}
+
+@end
+
+@implementation OAMergedFavoritesSettingsItem
+{
+    OAFavoriteGroup *_localGroup;
+    OAFavoriteGroup *_mergedGroup;
+    long _sourceModifiedTime;
+}
+
+- (instancetype)initWithBaseItem:(OAFavoritesSettingsItem *)baseItem
+                       localGroup:(OAFavoriteGroup *)localGroup
+                      mergedGroup:(OAFavoriteGroup *)mergedGroup
+               sourceModifiedTime:(long)sourceModifiedTime
+{
+    self = [super initWithItems:@[mergedGroup] baseItem:baseItem];
+    if (self)
+    {
+        _localGroup = [OAFavoritesBackupMerger copyGroup:localGroup];
+        _mergedGroup = mergedGroup;
+        _sourceModifiedTime = sourceModifiedTime;
+    }
+    return self;
+}
+
+- (long)lastModifiedTime
+{
+    return _sourceModifiedTime;
+}
+
+- (void)finishUpload:(NSString *)fileName uploadTime:(long)uploadTime
+{
+    OAFavoriteGroup *current = [OAFavoritesHelper groupByName:_localGroup.name];
+    if (![OAFavoritesBackupMerger sameGroup:_mergedGroup other:current] &&
+        [OAFavoritesBackupMerger sameGroup:_localGroup other:current])
+    {
+        self.shouldReplace = YES;
+        [self processDuplicateItems];
+        [self apply];
+        current = [OAFavoritesHelper groupByName:_mergedGroup.name];
+    }
+
+    if ([OAFavoritesBackupMerger sameGroup:_mergedGroup other:current])
+    {
+        self.localModifiedTime = _sourceModifiedTime;
+        [OAFavoritesBackupMerger saveSnapshot:_mergedGroup fileName:fileName syncTime:uploadTime];
+    }
+    else
+    {
+        if (current)
+            self.localModifiedTime = MAX((long)(NSDate.date.timeIntervalSince1970 * 1000.0), uploadTime + 1);
+    }
+}
+
+@end

--- a/Sources/Backup/OAGenerateBackupInfoTask.m
+++ b/Sources/Backup/OAGenerateBackupInfoTask.m
@@ -14,6 +14,7 @@
 #import "OABackupDbHelper.h"
 #import "OACollectionSettingsItem.h"
 #import "OABackupHelper.h"
+#import "OAFavoritesBackupMerger.h"
 #import "OAOperationLog.h"
 
 @implementation OAGenerateBackupInfoTask
@@ -162,6 +163,7 @@
                 [info.filesToUpload addObject:localFile];
         }
     }
+    [OAFavoritesBackupMerger prepareMergeUploads:info backupHelper:OABackupHelper.sharedInstance];
     [info createItemCollections];
     
     [_operationLog log:@"=== filesToUpload ==="];

--- a/Sources/Backup/OAGenerateBackupInfoTask.m
+++ b/Sources/Backup/OAGenerateBackupInfoTask.m
@@ -22,7 +22,7 @@
     NSDictionary<NSString *, OALocalFile *> *_localFiles;
     NSDictionary<NSString *, OALocalFile *> *_localFilesWithDecomposedNames;
     NSDictionary<NSString *, OARemoteFile *> *_uniqueRemoteFiles;
-    NSDictionary<NSString *, OARemoteFile *> *_uniqueRemoteFilesWithDecomposedNames;
+    NSDictionary<NSString *, OARemoteFile *> *_remoteFilesWithDecomposedNames;
     NSDictionary<NSString *, OARemoteFile *> *_deletedRemoteFiles;
     void (^_onComplete)(OABackupInfo *backupInfo, NSString *error);
     
@@ -46,13 +46,18 @@
         }
         _localFilesWithDecomposedNames = decomposedLocalFiles;
         _uniqueRemoteFiles = uniqueRemoteFiles;
-        NSMutableDictionary<NSString *, OARemoteFile *>* localMap = [NSMutableDictionary dictionaryWithCapacity:_uniqueRemoteFiles.count];
+        NSMutableDictionary<NSString *, OARemoteFile *>* localMap = [NSMutableDictionary dictionaryWithCapacity:_uniqueRemoteFiles.count + deletedRemoteFiles.count];
         for (NSString *originalKey in _uniqueRemoteFiles)
         {
             NSString *decomposedKey = [originalKey decomposedStringWithCanonicalMapping];
             localMap[decomposedKey] = _uniqueRemoteFiles[originalKey];
         }
-        _uniqueRemoteFilesWithDecomposedNames = localMap;
+        for (NSString *originalKey in deletedRemoteFiles)
+        {
+            NSString *decomposedKey = [originalKey decomposedStringWithCanonicalMapping];
+            localMap[decomposedKey] = deletedRemoteFiles[originalKey];
+        }
+        _remoteFilesWithDecomposedNames = localMap;
         _deletedRemoteFiles = deletedRemoteFiles;
         _onComplete = onComplete;
         _operationLog = [[OAOperationLog alloc] initWithOperationName:@"generateBackupInfo" debug:BACKUP_DEBUG_LOGS logThreshold:0.2];
@@ -154,7 +159,7 @@
         if (exportType == nil || ![OAExportSettingsType isTypeEnabled:exportType])
             continue;
         NSString *localKeyNfd = localFile.getTypeFileName.decomposedStringWithCanonicalMapping;
-        BOOL hasRemoteFile = _uniqueRemoteFilesWithDecomposedNames[localKeyNfd] != nil;
+        BOOL hasRemoteFile = _remoteFilesWithDecomposedNames[localKeyNfd] != nil;
         BOOL fileToDelete = [info.localFilesToDelete containsObject:localFile];
         if (!hasRemoteFile && !fileToDelete)
         {


### PR DESCRIPTION
Fixes #5177.

### Summary

Adds three-way merging for Favorites groups changed on multiple devices.

The merge uses a locally stored last-synced GPX snapshot as the base.

Merge preparation creates only an in-memory upload payload. Local Favorites are changed only after the merged file is uploaded successfully.

### Behavior

Automatically merges:

- Additions with different names.
- Edits, moves, deletions, and renames made to different points.
- The same point deleted on both devices.
- A one-sided rename when the other device did not change that point.

Keeps a conflict when:

- Both devices change the same point.
- The same point is renamed differently.
- One device renames a point while the other deletes it.
- Both devices add points with the same name.
- Group appearance is changed.
- A cloud-deleted group was also changed locally.
- The group is personal.
- Point names are empty or duplicated.

If no matching last-synced snapshot exists, the existing conflict behavior is preserved.

### Group deletion behavior

- If a group was deleted in the cloud and is unchanged locally, it is deleted locally.
- If the cloud-deleted group was changed locally, it remains a conflict.
- A cloud deletion marker is not treated as a missing remote file, so the group is not incorrectly shown as a new local upload.

### Implementation

The merge logic is isolated in `OAFavoritesBackupMerger`.

Small integration hooks were added for:

- Preparing a merged upload.
- Saving the snapshot after a successful upload.
- Saving the snapshot after a successful download.

`OANetworkWriter` and the Favorites data model are unchanged.

### Test plan

- Add different points to the same group on two devices and verify both are preserved.
- Edit, move, delete, or rename different points and verify automatic merging.
- Delete the same point on both devices and verify no conflict.
- Rename the same point differently on two devices and verify a conflict.
- Test rename versus deletion and verify a conflict.
- Add the same point name on both devices and verify a conflict.
- Change group appearance and verify a conflict.
- Delete a group in the cloud and verify an unchanged local copy is deleted.
- Delete a group in the cloud, modify it locally, and verify a conflict.
- Verify a cloud-deleted group is not shown as a new local upload.
- Verify pull-to-refresh/preparation does not modify local Favorites.