### PR TITLE
Retry only failed OSM uploads

### DIFF
--- a/Sources/Controllers/Settings/OSMEditing/OAUploadOsmPOINoteViewProgressController.m
+++ b/Sources/Controllers/Settings/OSMEditing/OAUploadOsmPOINoteViewProgressController.m
@@ -278,7 +278,7 @@ typedef NS_ENUM(NSInteger, EOAOsmUploadViewConrollerMode) {
         [self generateData];
         [self.tableView reloadData];
         _uploadTask.delegate = self;
-        [_uploadTask retryUpload];
+        [_uploadTask retryFailedPoints];
     }
     else
     {

--- a/Sources/OsmEdit/OAUploadOsmPointsAsyncTask.h
+++ b/Sources/OsmEdit/OAUploadOsmPointsAsyncTask.h
@@ -26,9 +26,9 @@
 
 - (id) initWithPlugin:(OAOsmEditingPlugin *)plugin points:(NSArray<OAOsmPoint *> *)points closeChangeset:(BOOL)closeChangeset anonymous:(BOOL)anonymous comment:(NSString *)comment;
 
-- (void) uploadPoints;
+- (void)uploadPoints;
 
-- (void) retryUpload;
+- (void)retryFailedPoints;
 
 - (void) setInterrupted:(BOOL)interrupted;
 

--- a/Sources/OsmEdit/OAUploadOsmPointsAsyncTask.m
+++ b/Sources/OsmEdit/OAUploadOsmPointsAsyncTask.m
@@ -23,12 +23,19 @@
 #import "OAOsmBugResult.h"
 #import "OARootViewController.h"
 
+@interface OAUploadOsmPointsAsyncTask ()
+
+- (void)uploadPoints:(NSArray<OAOsmPoint *> *)points;
+
+@end
+
 @implementation OAUploadOsmPointsAsyncTask
 {
     OAOsmEditingPlugin *_plugin;
     OsmAndAppInstance _app;
     
     NSArray<OAOsmPoint *> *_points;
+    NSArray<OAOsmPoint *> *_failedPoints;
     
     NSString *_comment;
     
@@ -45,23 +52,30 @@
         _plugin = plugin;
         _closeChangeSet = closeChangeset;
         _loadAnonymous = anonymous;
-        _points = points;
+        _points = [points copy];
+        _failedPoints = @[];
         _comment = comment;
     }
     return self;
 }
 
-- (void) uploadPoints
+- (void)uploadPoints
 {
+    [self uploadPoints:_points];
+}
+
+- (void)uploadPoints:(NSArray<OAOsmPoint *> *)points
+{
+    NSArray<OAOsmPoint *> *pointsForAttempt = [points copy];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSInteger lastIndex = _points.count - 1;
+        NSInteger lastIndex = pointsForAttempt.count - 1;
         NSMutableArray<OAOsmPoint *> *failedUploads = [NSMutableArray new];
-        for (NSInteger i = 0; i < _points.count; i++)
+        for (NSInteger i = 0; i < pointsForAttempt.count; i++)
         {
             if (_interruptUploading)
                 break;
             
-            OAOsmPoint *osmPoint = _points[i];
+            OAOsmPoint *osmPoint = pointsForAttempt[i];
             if (osmPoint.getGroup == EOAGroupPoi)
             {
                 OAOpenStreetMapRemoteUtil *editsUtil = (OAOpenStreetMapRemoteUtil *)_plugin.getPoiModificationRemoteUtil;
@@ -97,12 +111,15 @@
             dispatch_async(dispatch_get_main_queue(), ^{
                 if ([self.delegate respondsToSelector:@selector(uploadDidProgress:)])
                 {
-                    float progress = (float)(i + 1) / (float)_points.count;
+                    float progress = (float)(i + 1) / (float)pointsForAttempt.count;
                     [self.delegate uploadDidProgress:progress];
                 }
             });
         }
         dispatch_async(dispatch_get_main_queue(), ^{
+            if (!_interruptUploading)
+                _failedPoints = [failedUploads copy];
+
             if ([self.delegate respondsToSelector:@selector(uploadDidCompleteWithSuccess:)])
             {
                 [self.delegate uploadDidCompleteWithSuccess:failedUploads.count == 0];
@@ -110,7 +127,7 @@
             if (!_interruptUploading)
             {
                 if ([self.delegate respondsToSelector:@selector(uploadDidFinishWithFailedPoints:successfulUploads:)])
-                    [self.delegate uploadDidFinishWithFailedPoints:failedUploads successfulUploads:_points.count - failedUploads.count];
+                    [self.delegate uploadDidFinishWithFailedPoints:failedUploads successfulUploads:pointsForAttempt.count - failedUploads.count];
             }
         });
     });
@@ -121,9 +138,9 @@
     _interruptUploading = interrupted;
 }
 
-- (void)retryUpload
+- (void)retryFailedPoints
 {
-    [self uploadPoints];
+    [self uploadPoints:_failedPoints];
 }
 
 @end

--- a/Sources/OsmEdit/OAUploadOsmPointsAsyncTask.m
+++ b/Sources/OsmEdit/OAUploadOsmPointsAsyncTask.m
@@ -23,12 +23,6 @@
 #import "OAOsmBugResult.h"
 #import "OARootViewController.h"
 
-@interface OAUploadOsmPointsAsyncTask ()
-
-- (void)uploadPoints:(NSArray<OAOsmPoint *> *)points;
-
-@end
-
 @implementation OAUploadOsmPointsAsyncTask
 {
     OAOsmEditingPlugin *_plugin;


### PR DESCRIPTION
## Summary

- Retry only OSM points that failed during the previous upload attempt.
- Keep the original upload list unchanged and store failed points separately.
- Calculate progress using the number of points in the current attempt.
- Adjust progress increments automatically as the number of remaining points changes between retries.