### PR TITLE
Fix context menu title when transliteration is enabled

### DIFF
--- a/Sources/Controllers/TargetMenu/POI/PlaceDetailsViewController.swift
+++ b/Sources/Controllers/TargetMenu/POI/PlaceDetailsViewController.swift
@@ -277,7 +277,9 @@ final class PlaceDetailsViewController: OAPOIViewController {
         guard let mapPanel = OARootViewController.instance()?.mapPanel,
               let targetPoint = mapPanel.getCurrentTargetPoint() else { return }
 
-        targetPoint.title = amenity.nameLocalized ?? amenity.name
+        if targetPoint.title?.isEmpty ?? true {
+            targetPoint.title = amenity.nameLocalized ?? amenity.name
+        }
         targetPoint.icon = amenity.type?.icon()
 
         mapPanel.update(targetPoint)


### PR DESCRIPTION
Preserve the map-rendered context menu title when it is already available.
Use the detailed amenity name only as a fallback for an empty title.