### PR TITLE
Fix overlapping context menu presentations

### DIFF
--- a/OsmAnd MapsTests/Panels/ContextMenuPresentationCoordinatorTest.swift
+++ b/OsmAnd MapsTests/Panels/ContextMenuPresentationCoordinatorTest.swift
@@ -29,14 +29,14 @@ final class ContextMenuPresentationCoordinatorTest: XCTestCase {
         var dismissCount = 0
         var presentedMenus: [String] = []
 
-        let dismissHandler: ContextMenuPresentationCoordinator.DismissHandler = { completion in
+        let dismissHandler = ContextMenuDismissHandler(handler: { completion in
             if dismissCount == 0 {
                 dismissCount += 1
                 pendingDismissalCompletion = completion
                 return true
             }
             return false
-        }
+        })
 
         coordinator.enqueuePresentation {
             presentedMenus.append("first")
@@ -67,14 +67,14 @@ final class ContextMenuPresentationCoordinatorTest: XCTestCase {
         var pendingDismissalCompletion: (() -> Void)?
         var presentationCount = 0
 
-        let dismissHandler: ContextMenuPresentationCoordinator.DismissHandler = { completion in
+        let dismissHandler = ContextMenuDismissHandler(handler: { completion in
             if remainingMenus > 0 {
                 remainingMenus -= 1
                 pendingDismissalCompletion = completion
                 return true
             }
             return false
-        }
+        })
 
         coordinator.enqueuePresentation {
             presentationCount += 1
@@ -100,14 +100,14 @@ final class ContextMenuPresentationCoordinatorTest: XCTestCase {
         var remainingMenus = 1
         var presentationCount = 0
 
-        let dismissHandler: ContextMenuPresentationCoordinator.DismissHandler = { completion in
+        let dismissHandler = ContextMenuDismissHandler(handler: { completion in
             if remainingMenus > 0 {
                 remainingMenus -= 1
                 completion()
                 return true
             }
             return false
-        }
+        })
 
         coordinator.enqueuePresentation {
             presentationCount += 1

--- a/OsmAnd MapsTests/Panels/ContextMenuPresentationCoordinatorTest.swift
+++ b/OsmAnd MapsTests/Panels/ContextMenuPresentationCoordinatorTest.swift
@@ -1,0 +1,121 @@
+//
+//  ContextMenuPresentationCoordinatorTest.swift
+//  OsmAnd MapsTests
+//
+//  Created by Oleksandr Panchenko on 01.09.2026.
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+import XCTest
+
+final class ContextMenuPresentationCoordinatorTest: XCTestCase {
+
+    func testRunsPresentationImmediatelyWhenNoMenuNeedsDismissal() {
+        let coordinator = ContextMenuPresentationCoordinator()
+        var presentationCount = 0
+
+        coordinator.enqueuePresentation {
+            presentationCount += 1
+        }
+        coordinator.processPendingPresentation(with: [])
+
+        XCTAssertEqual(presentationCount, 1)
+        XCTAssertFalse(coordinator.isTransitionInProgress)
+    }
+
+    func testKeepsOnlyLatestPresentationWhileDismissalIsInProgress() {
+        let coordinator = ContextMenuPresentationCoordinator()
+        var pendingDismissalCompletion: (() -> Void)?
+        var dismissCount = 0
+        var presentedMenus: [String] = []
+
+        let dismissHandler: ContextMenuPresentationCoordinator.DismissHandler = { completion in
+            if dismissCount == 0 {
+                dismissCount += 1
+                pendingDismissalCompletion = completion
+                return true
+            }
+            return false
+        }
+
+        coordinator.enqueuePresentation {
+            presentedMenus.append("first")
+        }
+        coordinator.processPendingPresentation(with: [dismissHandler])
+
+        XCTAssertEqual(dismissCount, 1)
+        XCTAssertTrue(coordinator.isTransitionInProgress)
+        XCTAssertEqual(presentedMenus, [])
+
+        coordinator.enqueuePresentation {
+            presentedMenus.append("second")
+        }
+        coordinator.processPendingPresentation(with: [dismissHandler])
+
+        XCTAssertEqual(dismissCount, 1)
+        XCTAssertEqual(presentedMenus, [])
+
+        pendingDismissalCompletion?()
+
+        XCTAssertEqual(presentedMenus, ["second"])
+        XCTAssertFalse(coordinator.isTransitionInProgress)
+    }
+
+    func testDismissesMenusOneAtATimeBeforePresenting() {
+        let coordinator = ContextMenuPresentationCoordinator()
+        var remainingMenus = 2
+        var pendingDismissalCompletion: (() -> Void)?
+        var presentationCount = 0
+
+        let dismissHandler: ContextMenuPresentationCoordinator.DismissHandler = { completion in
+            if remainingMenus > 0 {
+                remainingMenus -= 1
+                pendingDismissalCompletion = completion
+                return true
+            }
+            return false
+        }
+
+        coordinator.enqueuePresentation {
+            presentationCount += 1
+        }
+        coordinator.processPendingPresentation(with: [dismissHandler])
+
+        XCTAssertEqual(remainingMenus, 1)
+        XCTAssertEqual(presentationCount, 0)
+
+        pendingDismissalCompletion?()
+
+        XCTAssertEqual(remainingMenus, 0)
+        XCTAssertEqual(presentationCount, 0)
+
+        pendingDismissalCompletion?()
+
+        XCTAssertEqual(presentationCount, 1)
+        XCTAssertFalse(coordinator.isTransitionInProgress)
+    }
+
+    func testHandlesSynchronousDismissalCompletion() {
+        let coordinator = ContextMenuPresentationCoordinator()
+        var remainingMenus = 1
+        var presentationCount = 0
+
+        let dismissHandler: ContextMenuPresentationCoordinator.DismissHandler = { completion in
+            if remainingMenus > 0 {
+                remainingMenus -= 1
+                completion()
+                return true
+            }
+            return false
+        }
+
+        coordinator.enqueuePresentation {
+            presentationCount += 1
+        }
+        coordinator.processPendingPresentation(with: [dismissHandler])
+
+        XCTAssertEqual(remainingMenus, 0)
+        XCTAssertEqual(presentationCount, 1)
+        XCTAssertFalse(coordinator.isTransitionInProgress)
+    }
+}

--- a/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
+++ b/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
@@ -79,7 +79,7 @@ final class ContextMenuPresentationUITests: XCTestCase {
             .matching(identifier: AccessibilityIdentifier.ContextMenu.container)
             .firstMatch
             .exists {
-            XCTFail("Expected the queчued context menu presentation fixture to show the latest synthetic target.")
+            XCTFail("Expected the queue context menu presentation fixture to show the latest synthetic target.")
         }
         assertNoOverlappingContextMenus()
     }

--- a/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
+++ b/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
@@ -2,7 +2,7 @@
 //  ContextMenuPresentationUITests.swift
 //  OsmAnd MapsUITests
 //
-//  Created by Oleksandr Panchenko on 01.09.2026.
+//  Created by Oleksandr Panchenko on 02.09.2026.
 //  Copyright (c) 2026 OsmAnd. All rights reserved.
 //
 
@@ -10,12 +10,48 @@ import XCTest
 
 final class ContextMenuPresentationUITests: XCTestCase {
 
+    private enum LaunchArgument {
+        static let uiTesting = "-ui-testing"
+
+        enum ContextMenu {
+            static let presentationRace = "-ui-testing-context-menu-presentation-race"
+            static let gpxWaypointOpenTrack = "-ui-testing-gpx-waypoint-open-track"
+        }
+    }
+
+    private enum AccessibilityIdentifier {
+        static let firstUsageSkipDownloadButton = "first_usage_skip_download_button"
+
+        enum ContextMenu {
+            static let container = "context_menu_container"
+            static let multiContainer = "multi_context_menu_container"
+            static let presentationState = "context_menu_presentation_test_state"
+
+            enum GPX {
+                static let trackMenuTitle = "gpx_track_menu_title"
+                static let waypointOpenTrackButton = "gpx_waypoint_open_track_button"
+
+                static func waypoint(_ title: String) -> String {
+                    "gpx_track_menu_waypoint_\(title)"
+                }
+            }
+        }
+    }
+
+    private enum Timeout {
+        static let launch: TimeInterval = 30
+        static let startupPrompt: TimeInterval = 5
+        static let initialMenu: TimeInterval = 30
+        static let menu: TimeInterval = 10
+        static let transition: TimeInterval = 10
+    }
+
     private var app: XCUIApplication!
 
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchArguments += ["-ui-testing"]
+        app.launchArguments += [LaunchArgument.uiTesting]
     }
 
     override func tearDownWithError() throws {
@@ -23,13 +59,13 @@ final class ContextMenuPresentationUITests: XCTestCase {
     }
 
     func testQueuedContextMenuPresentationShowsLatestMenuAfterDismissal() {
-        app.launchArguments += ["-ui-testing-context-menu-presentation-race"]
+        app.launchArguments += [LaunchArgument.ContextMenu.presentationRace]
         app.launch()
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 30))
         dismissStartupIfNeeded()
 
         let stateMarker = app.descendants(matching: .any)
-            .matching(identifier: "context_menu_presentation_test_state")
+            .matching(identifier: AccessibilityIdentifier.ContextMenu.presentationState)
             .firstMatch
 
         XCTAssertTrue(stateMarker.waitForExistence(timeout: 30))
@@ -40,12 +76,29 @@ final class ContextMenuPresentationUITests: XCTestCase {
         XCTAssertFalse((stateMarker.value as? String)?.contains("UITest Parking B") ?? false)
 
         if !app.descendants(matching: .any)
-            .matching(identifier: "context_menu_container")
+            .matching(identifier: AccessibilityIdentifier.ContextMenu.container)
             .firstMatch
             .exists {
-            XCTFail("Expected the queued context menu presentation fixture to show the latest synthetic target.")
+            XCTFail("Expected the queчued context menu presentation fixture to show the latest synthetic target.")
         }
         assertNoOverlappingContextMenus()
+    }
+
+    func testWaypointOpenTrackReturnsToCurrentTrackMenu() {
+        app.launchArguments += [LaunchArgument.ContextMenu.gpxWaypointOpenTrack]
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: Timeout.launch))
+
+        let waypoint = element(identifier: AccessibilityIdentifier.ContextMenu.GPX.waypoint("UITest Waypoint A"))
+        XCTAssertTrue(waypoint.waitForExistence(timeout: Timeout.initialMenu))
+        waypoint.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        let openTrackButton = element(identifier: AccessibilityIdentifier.ContextMenu.GPX.waypointOpenTrackButton)
+        XCTAssertTrue(openTrackButton.waitForExistence(timeout: Timeout.transition))
+        openTrackButton.tap()
+
+        XCTAssertTrue(openTrackButton.waitForNonExistence(timeout: Timeout.transition))
+        XCTAssertTrue(element(identifier: AccessibilityIdentifier.ContextMenu.GPX.trackMenuTitle).waitForExistence(timeout: Timeout.transition))
     }
 
     private func waitForCurrentContextMenuPresentation(
@@ -77,11 +130,17 @@ final class ContextMenuPresentationUITests: XCTestCase {
     }
 
     private func dismissStartupIfNeeded() {
-        let skipDownloadButton = app.buttons["first_usage_skip_download_button"]
-        if skipDownloadButton.waitForExistence(timeout: 20) {
+        let skipDownloadButton = app.buttons[AccessibilityIdentifier.firstUsageSkipDownloadButton]
+        if skipDownloadButton.waitForExistence(timeout: Timeout.startupPrompt) {
             skipDownloadButton.tap()
-            XCTAssertTrue(skipDownloadButton.waitForNonExistence(timeout: 10))
+            XCTAssertTrue(skipDownloadButton.waitUntilHidden(timeout: Timeout.transition))
         }
+    }
+
+    private func element(identifier: String) -> XCUIElement {
+        app.descendants(matching: .any)
+            .matching(identifier: identifier)
+            .firstMatch
     }
 
     private func assertNoOverlappingContextMenus(
@@ -89,12 +148,20 @@ final class ContextMenuPresentationUITests: XCTestCase {
         line: UInt = #line
     ) {
         let regularMenus = app.descendants(matching: .any)
-            .matching(identifier: "context_menu_container")
+            .matching(identifier: AccessibilityIdentifier.ContextMenu.container)
             .count
         let multiMenus = app.descendants(matching: .any)
-            .matching(identifier: "multi_context_menu_container")
+            .matching(identifier: AccessibilityIdentifier.ContextMenu.multiContainer)
             .count
 
         XCTAssertLessThanOrEqual(regularMenus + multiMenus, 1, file: file, line: line)
+    }
+}
+
+private extension XCUIElement {
+    func waitUntilHidden(timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "exists == false OR hittable == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
     }
 }

--- a/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
+++ b/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
@@ -1,0 +1,100 @@
+//
+//  ContextMenuPresentationUITests.swift
+//  OsmAnd MapsUITests
+//
+//  Created by Oleksandr Panchenko on 01.09.2026.
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+import XCTest
+
+final class ContextMenuPresentationUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments += ["-ui-testing"]
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func testQueuedContextMenuPresentationShowsLatestMenuAfterDismissal() {
+        app.launchArguments += ["-ui-testing-context-menu-presentation-race"]
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 30))
+        dismissStartupIfNeeded()
+
+        let stateMarker = app.descendants(matching: .any)
+            .matching(identifier: "context_menu_presentation_test_state")
+            .firstMatch
+
+        XCTAssertTrue(stateMarker.waitForExistence(timeout: 30))
+
+        waitForContextMenuPresentationHistory(containing: "UITest Destination A", stateMarker: stateMarker)
+        waitForCurrentContextMenuPresentation("UITest My Location C", stateMarker: stateMarker)
+        waitForContextMenuPresentationHistory(containing: "UITest My Location C", stateMarker: stateMarker)
+        XCTAssertFalse((stateMarker.value as? String)?.contains("UITest Parking B") ?? false)
+
+        if !app.descendants(matching: .any)
+            .matching(identifier: "context_menu_container")
+            .firstMatch
+            .exists {
+            XCTFail("Expected the queued context menu presentation fixture to show the latest synthetic target.")
+        }
+        assertNoOverlappingContextMenus()
+    }
+
+    private func waitForCurrentContextMenuPresentation(
+        _ title: String,
+        stateMarker: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let predicate = NSPredicate(format: "label == %@", title)
+        let expectation = expectation(for: predicate, evaluatedWith: stateMarker)
+        let result = XCTWaiter().wait(for: [expectation], timeout: 30)
+        if result != .completed {
+            XCTFail("Expected context menu presentation state to become \(title).", file: file, line: line)
+        }
+    }
+
+    private func waitForContextMenuPresentationHistory(
+        containing title: String,
+        stateMarker: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let predicate = NSPredicate(format: "value CONTAINS %@", title)
+        let expectation = expectation(for: predicate, evaluatedWith: stateMarker)
+        let result = XCTWaiter().wait(for: [expectation], timeout: 30)
+        if result != .completed {
+            XCTFail("Expected context menu presentation history to contain \(title).", file: file, line: line)
+        }
+    }
+
+    private func dismissStartupIfNeeded() {
+        let skipDownloadButton = app.buttons["first_usage_skip_download_button"]
+        if skipDownloadButton.waitForExistence(timeout: 20) {
+            skipDownloadButton.tap()
+            XCTAssertTrue(skipDownloadButton.waitForNonExistence(timeout: 10))
+        }
+    }
+
+    private func assertNoOverlappingContextMenus(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let regularMenus = app.descendants(matching: .any)
+            .matching(identifier: "context_menu_container")
+            .count
+        let multiMenus = app.descendants(matching: .any)
+            .matching(identifier: "multi_context_menu_container")
+            .count
+
+        XCTAssertLessThanOrEqual(regularMenus + multiMenus, 1, file: file, line: line)
+    }
+}

--- a/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
+++ b/OsmAnd MapsUITests/ContextMenuPresentationUITests.swift
@@ -20,7 +20,6 @@ final class ContextMenuPresentationUITests: XCTestCase {
     }
 
     private enum AccessibilityIdentifier {
-        static let firstUsageSkipDownloadButton = "first_usage_skip_download_button"
 
         enum ContextMenu {
             static let container = "context_menu_container"
@@ -62,7 +61,6 @@ final class ContextMenuPresentationUITests: XCTestCase {
         app.launchArguments += [LaunchArgument.ContextMenu.presentationRace]
         app.launch()
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 30))
-        dismissStartupIfNeeded()
 
         let stateMarker = app.descendants(matching: .any)
             .matching(identifier: AccessibilityIdentifier.ContextMenu.presentationState)
@@ -126,14 +124,6 @@ final class ContextMenuPresentationUITests: XCTestCase {
         let result = XCTWaiter().wait(for: [expectation], timeout: 30)
         if result != .completed {
             XCTFail("Expected context menu presentation history to contain \(title).", file: file, line: line)
-        }
-    }
-
-    private func dismissStartupIfNeeded() {
-        let skipDownloadButton = app.buttons[AccessibilityIdentifier.firstUsageSkipDownloadButton]
-        if skipDownloadButton.waitForExistence(timeout: Timeout.startupPrompt) {
-            skipDownloadButton.tap()
-            XCTAssertTrue(skipDownloadButton.waitUntilHidden(timeout: Timeout.transition))
         }
     }
 

--- a/OsmAnd MapsUITests/Info.plist
+++ b/OsmAnd MapsUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -7,10 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C0D3C0012F60000100C0D301 /* OACrashDiagnosticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C0052F60000100C0D305 /* OACrashDiagnosticsManager.swift */; };
-		C0D3C0022F60000100C0D302 /* OACrashReportRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C0062F60000100C0D306 /* OACrashReportRepository.swift */; };
-		C0D3C00B2F60000100C0D30B /* OACrashReportPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C0092F60000100C0D309 /* OACrashReportPromptCoordinator.swift */; };
-		C0D3C00C2F60000100C0D30C /* OACrashReportPromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C00A2F60000100C0D30A /* OACrashReportPromptViewController.swift */; };
 		051177FF2B25A51A006B4774 /* OARouteRecalculationHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 051177FE2B25A51A006B4774 /* OARouteRecalculationHelper.mm */; };
 		0513AA382A9B530A00CFA2A0 /* OADestinationBarWidget.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0513AA372A9B530A00CFA2A0 /* OADestinationBarWidget.mm */; };
 		05541D95299267900014AEF8 /* contourlines.addon.render.xml in Resources */ = {isa = PBXBuildFile; fileRef = 05541D94299267900014AEF8 /* contourlines.addon.render.xml */; };
@@ -1383,6 +1379,7 @@
 		9F4844C22FD0000100484401 /* OAAisTrackerLayerBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F4844C12FD0000100484401 /* OAAisTrackerLayerBridge.mm */; };
 		9F4844D12FD0000100484401 /* AisTrackerProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4844D02FD0000100484401 /* AisTrackerProduct.swift */; };
 		9F5A00032FD0000100484401 /* AisObjectDrawable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F5A00022FD0000100484401 /* AisObjectDrawable.mm */; };
+		A11CE00233EF000100000002 /* ListFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CE00133EF000100000001 /* ListFormatter+Extension.swift */; };
 		A5A500022F50000100000002 /* AstronomyPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A500012F50000100000001 /* AstronomyPlugin.swift */; };
 		A5A500062F50000100000006 /* AstronomyPluginSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A500052F50000100000005 /* AstronomyPluginSettings.swift */; };
 		A5A500082F50000100000008 /* AstroDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A500072F50000100000007 /* AstroDataProvider.swift */; };
@@ -1500,6 +1497,13 @@
 		BBA3AF87197FC4BB0039D991 /* Shipped in Resources */ = {isa = PBXBuildFile; fileRef = BB451D8A18D70B4B005FBE09 /* Shipped */; };
 		BBA3AF97197FC4BB0039D991 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BB451DF318D8F7D7005FBE09 /* Localizable.strings */; };
 		BBA3AFC4197FC4BB0039D991 /* Resources.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BB451F1018EB34A5005FBE09 /* Resources.storyboard */; };
+		C0D3C0012F60000100C0D301 /* OACrashDiagnosticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C0052F60000100C0D305 /* OACrashDiagnosticsManager.swift */; };
+		C0D3C0022F60000100C0D302 /* OACrashReportRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C0062F60000100C0D306 /* OACrashReportRepository.swift */; };
+		C0D3C00B2F60000100C0D30B /* OACrashReportPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C0092F60000100C0D309 /* OACrashReportPromptCoordinator.swift */; };
+		C0D3C00C2F60000100C0D30C /* OACrashReportPromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3C00A2F60000100C0D30A /* OACrashReportPromptViewController.swift */; };
+		C0DA57122FE9000100C0DA57 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DA57102FE9000100C0DA57 /* AppEnvironment.swift */; };
+		C0DA57152FE9000200C0DA57 /* UITestState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DA57132FE9000200C0DA57 /* UITestState.swift */; };
+		C0DA57162FE9000200C0DA57 /* UITestAccessibilityIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DA57142FE9000200C0DA57 /* UITestAccessibilityIdentifier.swift */; };
 		C503AC6B2DC4896B00F154F0 /* ShowHideCoordinatesGridAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503AC6A2DC4896B00F154F0 /* ShowHideCoordinatesGridAction.swift */; };
 		C50611182DB9678300E8F204 /* OACoordinatesGridSettings.mm in Sources */ = {isa = PBXBuildFile; fileRef = C50611172DB9678300E8F204 /* OACoordinatesGridSettings.mm */; };
 		C50867882D9D4FB7000B7219 /* SegmentImagesTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C50867872D9D4FB7000B7219 /* SegmentImagesTableViewCell.xib */; };
@@ -1745,6 +1749,10 @@
 		D1A0B0032F50000100A0B001 /* OpeningHoursParserTestSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0002F50000100A0B001 /* OpeningHoursParserTestSupport.mm */; };
 		D1A0B0112F50001100A0B001 /* URLExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A0B0102F50001100A0B001 /* URLExtractionTests.swift */; };
 		D1A0B0122F50001100A0B001 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3216E9522BA097BD0087D0EF /* StringExtensions.swift */; };
+		D1C571200000000000000001 /* ContextMenuPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */; };
+		D1C571200000000000000002 /* ContextMenuPresentationCoordinatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */; };
+		D1C571200000000000000007 /* ContextMenuPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */; };
+		D1C571210000000000000001 /* ContextMenuPresentationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */; };
 		D71B9A8C2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71B9A8B2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift */; };
 		D71B9A8E2FC96D2D00FBB0F3 /* OrganizeByTypeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71B9A8D2FC96D2D00FBB0F3 /* OrganizeByTypeExtension.swift */; };
 		D71B9A902FC99D5D00FBB0F3 /* OrganizeByTypeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71B9A8F2FC99D5D00FBB0F3 /* OrganizeByTypeCell.swift */; };
@@ -1758,7 +1766,6 @@
 		D7210171301B768C003CECB8 /* PlanRouteProfileGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210145301B768C003CECB8 /* PlanRouteProfileGroupCell.swift */; };
 		D7210172301B768C003CECB8 /* PlanRouteSegmentHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210146301B768C003CECB8 /* PlanRouteSegmentHeaderView.swift */; };
 		D7210173301B768C003CECB8 /* PlanRouteStartSegmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210147301B768C003CECB8 /* PlanRouteStartSegmentCell.swift */; };
-		D7210AA0301B768C003CECB8 /* PlanRouteSegmentGapCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210AA1301B768C003CECB8 /* PlanRouteSegmentGapCell.swift */; };
 		D7210174301B768C003CECB8 /* RoadAttributeLegendItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210148301B768C003CECB8 /* RoadAttributeLegendItem.swift */; };
 		D7210175301B768C003CECB8 /* RouteGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210149301B768C003CECB8 /* RouteGroupCell.swift */; };
 		D7210176301B768C003CECB8 /* RouteSettingNavigationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721014A301B768C003CECB8 /* RouteSettingNavigationCell.swift */; };
@@ -1767,7 +1774,6 @@
 		D7210179301B768C003CECB8 /* SegmentReorderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721014D301B768C003CECB8 /* SegmentReorderCell.swift */; };
 		D721017B301B768C003CECB8 /* SyntheticSteepnessSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721014F301B768C003CECB8 /* SyntheticSteepnessSegment.swift */; };
 		D721017C301B768C003CECB8 /* PlanRouteAnalyzeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210151301B768C003CECB8 /* PlanRouteAnalyzeViewController.swift */; };
-		A11CE00233EF000100000002 /* ListFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CE00133EF000100000001 /* ListFormatter+Extension.swift */; };
 		D721017D301B768C003CECB8 /* PlanRoutePoiViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210152301B768C003CECB8 /* PlanRoutePoiViewController.swift */; };
 		D721017E301B768C003CECB8 /* PlanRouteRouteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210153301B768C003CECB8 /* PlanRouteRouteViewController.swift */; };
 		D721017F301B768C003CECB8 /* GetElevationDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210155301B768C003CECB8 /* GetElevationDataViewController.swift */; };
@@ -1788,6 +1794,7 @@
 		D721018E301B768C003CECB8 /* SegmentRouteSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210165301B768C003CECB8 /* SegmentRouteSettingsViewController.swift */; };
 		D721018F301B768C003CECB8 /* TrackFavoriteSortModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210166301B768C003CECB8 /* TrackFavoriteSortModeHelper.swift */; };
 		D7210190301B768C003CECB8 /* TwoLineTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210167301B768C003CECB8 /* TwoLineTitleView.swift */; };
+		D7210AA0301B768C003CECB8 /* PlanRouteSegmentGapCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7210AA1301B768C003CECB8 /* PlanRouteSegmentGapCell.swift */; };
 		D7B76D0D2FD16070004EE3E9 /* OrganizeByStepSizeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B76D0C2FD16070004EE3E9 /* OrganizeByStepSizeViewController.swift */; };
 		D7BF04782FD2DB4400BABB31 /* TracksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BF04772FD2DB4400BABB31 /* TracksViewController.swift */; };
 		D7EE671A3017818E0047F171 /* CancelableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EE67193017818E0047F171 /* CancelableTableView.swift */; };
@@ -3106,10 +3113,6 @@
 		DA6F7C97216602F7006F14E3 /* ic_action_directions_from@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA6F7C94216602F6006F14E3 /* ic_action_directions_from@2x.png */; };
 		DA6F7C99216602F7006F14E3 /* ic_action_directions_from@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA6F7C95216602F6006F14E3 /* ic_action_directions_from@3x.png */; };
 		DA72AB952508F44900851313 /* SearchUICoreTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA72AB942508F44900851313 /* SearchUICoreTest.mm */; };
-		D1C571200000000000000001 /* ContextMenuPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */; };
-		D1C571200000000000000002 /* ContextMenuPresentationCoordinatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */; };
-		D1C571200000000000000007 /* ContextMenuPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */; };
-		D1C571210000000000000001 /* ContextMenuPresentationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */; };
 		DA73EF7429A3B5410071935D /* publictransportroutes.addon.render.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA73EF7329A3B5410071935D /* publictransportroutes.addon.render.xml */; };
 		DA775B8727E5F30E0081B9C1 /* OARemoteFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DA775B8627E5F30E0081B9C1 /* OARemoteFile.m */; };
 		DA775B8A27E6109F0081B9C1 /* OALocalFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DA775B8927E6109F0081B9C1 /* OALocalFile.m */; };
@@ -3600,14 +3603,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		DA72AB8E2508F41000851313 /* PBXContainerItemProxy */ = {
+		D1C571210000000000000006 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BB098CE91793F7FD00423944 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = BBA3AF30197FC4BB0039D991;
 			remoteInfo = "OsmAnd Maps";
 		};
-		D1C571210000000000000006 /* PBXContainerItemProxy */ = {
+		DA72AB8E2508F41000851313 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BB098CE91793F7FD00423944 /* Project object */;
 			proxyType = 1;
@@ -3645,10 +3648,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		C0D3C0052F60000100C0D305 /* OACrashDiagnosticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashDiagnosticsManager.swift; sourceTree = "<group>"; };
-		C0D3C0062F60000100C0D306 /* OACrashReportRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashReportRepository.swift; sourceTree = "<group>"; };
-		C0D3C0092F60000100C0D309 /* OACrashReportPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashReportPromptCoordinator.swift; sourceTree = "<group>"; };
-		C0D3C00A2F60000100C0D30A /* OACrashReportPromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashReportPromptViewController.swift; sourceTree = "<group>"; };
 		0215F9145791D44EF7A9E6BA /* es-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "es-US"; path = "es-US.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		0309480ECBC201C5E8317E6D /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ko; path = ko.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		040A97D4493C89D048F33E9F /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = cs; path = cs.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -5345,6 +5344,8 @@
 		9F5A00022FD0000100484401 /* AisObjectDrawable.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AisObjectDrawable.mm; sourceTree = "<group>"; };
 		A0CF279954D69E24AEAACBF0 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = pl; path = pl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		A0EC68AFE40C27F9670CE9C5 /* hi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = hi; path = hi.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		A11323A22608070000000002 /* OARouteParametersInternal+cpp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OARouteParametersInternal+cpp.h"; sourceTree = "<group>"; };
+		A11CE00133EF000100000001 /* ListFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListFormatter+Extension.swift"; sourceTree = "<group>"; };
 		A5A500012F50000100000001 /* AstronomyPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AstronomyPlugin.swift; sourceTree = "<group>"; };
 		A5A500052F50000100000005 /* AstronomyPluginSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AstronomyPluginSettings.swift; sourceTree = "<group>"; };
 		A5A500072F50000100000007 /* AstroDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AstroDataProvider.swift; sourceTree = "<group>"; };
@@ -5521,6 +5522,13 @@
 		BCFEE2D9C1986E49AFD9A27A /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		BD862AFCF495F2E8367D299D /* ku */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ku; path = ku.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		BF9A08FCACC60D4CA32DFC31 /* mk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = mk; path = mk.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		C0D3C0052F60000100C0D305 /* OACrashDiagnosticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashDiagnosticsManager.swift; sourceTree = "<group>"; };
+		C0D3C0062F60000100C0D306 /* OACrashReportRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashReportRepository.swift; sourceTree = "<group>"; };
+		C0D3C0092F60000100C0D309 /* OACrashReportPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashReportPromptCoordinator.swift; sourceTree = "<group>"; };
+		C0D3C00A2F60000100C0D30A /* OACrashReportPromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OACrashReportPromptViewController.swift; sourceTree = "<group>"; };
+		C0DA57102FE9000100C0DA57 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		C0DA57132FE9000200C0DA57 /* UITestState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestState.swift; sourceTree = "<group>"; };
+		C0DA57142FE9000200C0DA57 /* UITestAccessibilityIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestAccessibilityIdentifier.swift; sourceTree = "<group>"; };
 		C1687F4567959C306956D92A /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = kab; path = kab.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		C173345D7277A340D99DE996 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = es; path = es.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		C1AB8471989D79CC4F5F17A1 /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = my; path = my.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -5920,6 +5928,11 @@
 		D1A0AFFF2F50000100A0B001 /* OpeningHoursParserTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpeningHoursParserTestSupport.h; sourceTree = "<group>"; };
 		D1A0B0002F50000100A0B001 /* OpeningHoursParserTestSupport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OpeningHoursParserTestSupport.mm; sourceTree = "<group>"; };
 		D1A0B0102F50001100A0B001 /* URLExtractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtractionTests.swift; sourceTree = "<group>"; };
+		D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationCoordinator.swift; sourceTree = "<group>"; };
+		D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationCoordinatorTest.swift; sourceTree = "<group>"; };
+		D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationUITests.swift; sourceTree = "<group>"; };
+		D1C571210000000000000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D1C571210000000000000004 /* OsmAnd MapsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OsmAnd MapsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3CA6B52398C60EDCB0357E5 /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ka; path = ka.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		D71B9A8B2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeTracksByViewController.swift; sourceTree = "<group>"; };
 		D71B9A8D2FC96D2D00FBB0F3 /* OrganizeByTypeExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeByTypeExtension.swift; sourceTree = "<group>"; };
@@ -5934,7 +5947,6 @@
 		D7210145301B768C003CECB8 /* PlanRouteProfileGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteProfileGroupCell.swift; sourceTree = "<group>"; };
 		D7210146301B768C003CECB8 /* PlanRouteSegmentHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteSegmentHeaderView.swift; sourceTree = "<group>"; };
 		D7210147301B768C003CECB8 /* PlanRouteStartSegmentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteStartSegmentCell.swift; sourceTree = "<group>"; };
-		D7210AA1301B768C003CECB8 /* PlanRouteSegmentGapCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteSegmentGapCell.swift; sourceTree = "<group>"; };
 		D7210148301B768C003CECB8 /* RoadAttributeLegendItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadAttributeLegendItem.swift; sourceTree = "<group>"; };
 		D7210149301B768C003CECB8 /* RouteGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteGroupCell.swift; sourceTree = "<group>"; };
 		D721014A301B768C003CECB8 /* RouteSettingNavigationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteSettingNavigationCell.swift; sourceTree = "<group>"; };
@@ -5943,7 +5955,6 @@
 		D721014D301B768C003CECB8 /* SegmentReorderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentReorderCell.swift; sourceTree = "<group>"; };
 		D721014F301B768C003CECB8 /* SyntheticSteepnessSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticSteepnessSegment.swift; sourceTree = "<group>"; };
 		D7210151301B768C003CECB8 /* PlanRouteAnalyzeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteAnalyzeViewController.swift; sourceTree = "<group>"; };
-		A11CE00133EF000100000001 /* ListFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListFormatter+Extension.swift"; sourceTree = "<group>"; };
 		D7210152301B768C003CECB8 /* PlanRoutePoiViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRoutePoiViewController.swift; sourceTree = "<group>"; };
 		D7210153301B768C003CECB8 /* PlanRouteRouteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteRouteViewController.swift; sourceTree = "<group>"; };
 		D7210155301B768C003CECB8 /* GetElevationDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetElevationDataViewController.swift; sourceTree = "<group>"; };
@@ -5965,6 +5976,7 @@
 		D7210165301B768C003CECB8 /* SegmentRouteSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentRouteSettingsViewController.swift; sourceTree = "<group>"; };
 		D7210166301B768C003CECB8 /* TrackFavoriteSortModeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackFavoriteSortModeHelper.swift; sourceTree = "<group>"; };
 		D7210167301B768C003CECB8 /* TwoLineTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoLineTitleView.swift; sourceTree = "<group>"; };
+		D7210AA1301B768C003CECB8 /* PlanRouteSegmentGapCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteSegmentGapCell.swift; sourceTree = "<group>"; };
 		D7B76D0C2FD16070004EE3E9 /* OrganizeByStepSizeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeByStepSizeViewController.swift; sourceTree = "<group>"; };
 		D7BF04772FD2DB4400BABB31 /* TracksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksViewController.swift; sourceTree = "<group>"; };
 		D7EE67193017818E0047F171 /* CancelableTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelableTableView.swift; sourceTree = "<group>"; };
@@ -7225,7 +7237,6 @@
 		DA5A7D5E26C563A300F274C7 /* OAAppModeView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OAAppModeView.xib; sourceTree = "<group>"; };
 		DA5A7D6026C563A300F274C7 /* OAAppModeCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OAAppModeCell.xib; sourceTree = "<group>"; };
 		DA5A7D6126C563A300F274C7 /* OARoutePreferencesParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OARoutePreferencesParameters.h; sourceTree = "<group>"; };
-		A11323A22608070000000002 /* OARouteParametersInternal+cpp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OARouteParametersInternal+cpp.h"; sourceTree = "<group>"; };
 		DA5A7D6226C563A300F274C7 /* OARouteSettingsParameterController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OARouteSettingsParameterController.h; sourceTree = "<group>"; };
 		DA5A7D6326C563A300F274C7 /* GpxUIHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GpxUIHelper.swift; sourceTree = "<group>"; };
 		DA5A7D6426C563A300F274C7 /* OANavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OANavigationController.h; sourceTree = "<group>"; };
@@ -8062,11 +8073,6 @@
 		DA72AB892508F40F00851313 /* OsmAnd MapsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OsmAnd MapsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA72AB8D2508F41000851313 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA72AB942508F44900851313 /* SearchUICoreTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SearchUICoreTest.mm; sourceTree = "<group>"; };
-		D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationCoordinator.swift; sourceTree = "<group>"; };
-		D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationCoordinatorTest.swift; sourceTree = "<group>"; };
-		D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationUITests.swift; sourceTree = "<group>"; };
-		D1C571210000000000000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D1C571210000000000000004 /* OsmAnd MapsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OsmAnd MapsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA73EF7329A3B5410071935D /* publictransportroutes.addon.render.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = publictransportroutes.addon.render.xml; path = ../resources/rendering_styles/publictransportroutes.addon.render.xml; sourceTree = "<group>"; };
 		DA775B8527E5F30E0081B9C1 /* OARemoteFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OARemoteFile.h; sourceTree = "<group>"; };
 		DA775B8627E5F30E0081B9C1 /* OARemoteFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OARemoteFile.m; sourceTree = "<group>"; };
@@ -8685,6 +8691,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D1C57121000000000000000A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA72AB862508F40F00851313 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -8701,13 +8714,6 @@
 				DA80DAC2251E2CB8008E6267 /* libQt5Concurrent.a in Frameworks */,
 				DA80DACB251E3412008E6267 /* libQt5Core.a in Frameworks */,
 				DA80DABC251E2CB7008E6267 /* libQt5Network.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D1C57121000000000000000A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11132,6 +11138,17 @@
 			name = Resources;
 			sourceTree = "<group>";
 		};
+		C0D3C0082F60000100C0D308 /* CrashDiagnostics */ = {
+			isa = PBXGroup;
+			children = (
+				C0D3C0052F60000100C0D305 /* OACrashDiagnosticsManager.swift */,
+				C0D3C0062F60000100C0D306 /* OACrashReportRepository.swift */,
+				C0D3C0092F60000100C0D309 /* OACrashReportPromptCoordinator.swift */,
+				C0D3C00A2F60000100C0D30A /* OACrashReportPromptViewController.swift */,
+			);
+			path = CrashDiagnostics;
+			sourceTree = "<group>";
+		};
 		CE7AC19F2FE02A2600495411 /* MapPreviewRenderer */ = {
 			isa = PBXGroup;
 			children = (
@@ -11166,6 +11183,23 @@
 				CE7AC1A62FE02A2600495411 /* SelectPointsViewController.swift */,
 			);
 			path = Import;
+			sourceTree = "<group>";
+		};
+		D1C571200000000000000006 /* Panels */ = {
+			isa = PBXGroup;
+			children = (
+				D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */,
+			);
+			path = Panels;
+			sourceTree = "<group>";
+		};
+		D1C571210000000000000005 /* OsmAnd MapsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */,
+				D1C571210000000000000003 /* Info.plist */,
+			);
+			path = "OsmAnd MapsUITests";
 			sourceTree = "<group>";
 		};
 		D7210150301B768C003CECB8 /* Cells */ = {
@@ -14444,9 +14478,28 @@
 			path = XibViews;
 			sourceTree = "<group>";
 		};
+		C0DA57172FE9000200C0DA57 /* AppEnvironment */ = {
+			isa = PBXGroup;
+			children = (
+				C0DA57102FE9000100C0DA57 /* AppEnvironment.swift */,
+			);
+			path = AppEnvironment;
+			sourceTree = "<group>";
+		};
+		C0DA57182FE9000200C0DA57 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				C0DA57142FE9000200C0DA57 /* UITestAccessibilityIdentifier.swift */,
+				C0DA57132FE9000200C0DA57 /* UITestState.swift */,
+			);
+			path = UITests;
+			sourceTree = "<group>";
+		};
 		DA5A808E26C563A500F274C7 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				C0DA57172FE9000200C0DA57 /* AppEnvironment */,
+				C0DA57182FE9000200C0DA57 /* UITests */,
 				FAB7440F2FB467160001FFF8 /* AlertPresenter */,
 				FA29F6132F9610DB00257B88 /* DeepLinkManager */,
 				FA4FC4AA2F4F3F8F009ABB6E /* SharedLibSmartFolderHelper.swift */,
@@ -14744,23 +14797,6 @@
 				DA72AB942508F44900851313 /* SearchUICoreTest.mm */,
 			);
 			path = Search;
-			sourceTree = "<group>";
-		};
-		D1C571200000000000000006 /* Panels */ = {
-			isa = PBXGroup;
-			children = (
-				D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */,
-			);
-			path = Panels;
-			sourceTree = "<group>";
-		};
-		D1C571210000000000000005 /* OsmAnd MapsUITests */ = {
-			isa = PBXGroup;
-			children = (
-				D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */,
-				D1C571210000000000000003 /* Info.plist */,
-			);
-			path = "OsmAnd MapsUITests";
 			sourceTree = "<group>";
 		};
 		DA7F2587231A68CD00E54F77 /* Libraries */ = {
@@ -15565,17 +15601,6 @@
 			path = AppStartupMonitor;
 			sourceTree = "<group>";
 		};
-		C0D3C0082F60000100C0D308 /* CrashDiagnostics */ = {
-			isa = PBXGroup;
-			children = (
-				C0D3C0052F60000100C0D305 /* OACrashDiagnosticsManager.swift */,
-				C0D3C0062F60000100C0D306 /* OACrashReportRepository.swift */,
-				C0D3C0092F60000100C0D309 /* OACrashReportPromptCoordinator.swift */,
-				C0D3C00A2F60000100C0D30A /* OACrashReportPromptViewController.swift */,
-			);
-			path = CrashDiagnostics;
-			sourceTree = "<group>";
-		};
 		FAB6243D2E0953580048965E /* Managers */ = {
 			isa = PBXGroup;
 			children = (
@@ -15727,24 +15752,6 @@
 			productReference = BBA3AFEE197FC4BB0039D991 /* OsmAnd Maps.app */;
 			productType = "com.apple.product-type.application";
 		};
-		DA72AB882508F40F00851313 /* OsmAnd MapsTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DA72AB922508F41000851313 /* Build configuration list for PBXNativeTarget "OsmAnd MapsTests" */;
-			buildPhases = (
-				DA72AB852508F40F00851313 /* Sources */,
-				DA72AB862508F40F00851313 /* Frameworks */,
-				DA72AB872508F40F00851313 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DA72AB8F2508F41000851313 /* PBXTargetDependency */,
-			);
-			name = "OsmAnd MapsTests";
-			productName = "OsmAnd MapsTests";
-			productReference = DA72AB892508F40F00851313 /* OsmAnd MapsTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		D1C571210000000000000007 /* OsmAnd MapsUITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D1C571210000000000000008 /* Build configuration list for PBXNativeTarget "OsmAnd MapsUITests" */;
@@ -15762,6 +15769,24 @@
 			productName = "OsmAnd MapsUITests";
 			productReference = D1C571210000000000000004 /* OsmAnd MapsUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		DA72AB882508F40F00851313 /* OsmAnd MapsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA72AB922508F41000851313 /* Build configuration list for PBXNativeTarget "OsmAnd MapsTests" */;
+			buildPhases = (
+				DA72AB852508F40F00851313 /* Sources */,
+				DA72AB862508F40F00851313 /* Frameworks */,
+				DA72AB872508F40F00851313 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA72AB8F2508F41000851313 /* PBXTargetDependency */,
+			);
+			name = "OsmAnd MapsTests";
+			productName = "OsmAnd MapsTests";
+			productReference = DA72AB892508F40F00851313 /* OsmAnd MapsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -15785,13 +15810,13 @@
 							};
 						};
 					};
+					D1C571210000000000000007 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = BBA3AF30197FC4BB0039D991;
+					};
 					DA72AB882508F40F00851313 = {
 						CreatedOnToolsVersion = 11.7;
 						LastSwiftMigration = 1620;
-						TestTargetID = BBA3AF30197FC4BB0039D991;
-					};
-					D1C571210000000000000007 = {
-						CreatedOnToolsVersion = 26.6;
 						TestTargetID = BBA3AF30197FC4BB0039D991;
 					};
 				};
@@ -17755,18 +17780,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D1C57121000000000000000B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA72AB872508F40F00851313 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				8EBE587727297A320075B834 /* test-resources in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D1C57121000000000000000B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -19015,6 +19040,9 @@
 				277BE07F2EAFACFB00C007E3 /* RouteParamVehicleHelper.swift in Sources */,
 				DA5A833626C563A800F274C7 /* OAImagesCollectionViewCell.m in Sources */,
 				DA5A854826C563A900F274C7 /* OADebugSettings.mm in Sources */,
+				C0DA57122FE9000100C0DA57 /* AppEnvironment.swift in Sources */,
+				C0DA57152FE9000200C0DA57 /* UITestState.swift in Sources */,
+				C0DA57162FE9000200C0DA57 /* UITestAccessibilityIdentifier.swift in Sources */,
 				32ABB6502AEC01C000491E99 /* ImageToStringConverter.swift in Sources */,
 				329B392A2E3BB663006A774B /* OALocalItemType.m in Sources */,
 				DA5A818F26C563A700F274C7 /* OAShowHidePoiAction.m in Sources */,
@@ -19571,6 +19599,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D1C571210000000000000009 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1C571210000000000000001 /* ContextMenuPresentationUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA72AB852508F40F00851313 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -19588,26 +19624,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D1C571210000000000000009 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D1C571210000000000000001 /* ContextMenuPresentationUITests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		DA72AB8F2508F41000851313 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = BBA3AF30197FC4BB0039D991 /* OsmAnd Maps */;
-			targetProxy = DA72AB8E2508F41000851313 /* PBXContainerItemProxy */;
-		};
 		D1C57121000000000000000C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BBA3AF30197FC4BB0039D991 /* OsmAnd Maps */;
 			targetProxy = D1C571210000000000000006 /* PBXContainerItemProxy */;
+		};
+		DA72AB8F2508F41000851313 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BBA3AF30197FC4BB0039D991 /* OsmAnd Maps */;
+			targetProxy = DA72AB8E2508F41000851313 /* PBXContainerItemProxy */;
 		};
 		FAB2B14D2C787E4400B59B7A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -20231,6 +20259,107 @@
 			};
 			name = Release;
 		};
+		D1C57121000000000000000D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "OsmAnd MapsUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.osmand.maps.OsmAnd-MapsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "OsmAnd Maps";
+			};
+			name = Debug;
+		};
+		D1C57121000000000000000E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "OsmAnd MapsUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.osmand.maps.OsmAnd-MapsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "OsmAnd Maps";
+			};
+			name = Release;
+		};
 		DA72AB902508F41000851313 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -20372,107 +20501,6 @@
 			};
 			name = Release;
 		};
-		D1C57121000000000000000D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_STYLE = Automatic;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "OsmAnd MapsUITests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "net.osmand.maps.OsmAnd-MapsUITests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "OsmAnd Maps";
-			};
-			name = Debug;
-		};
-		D1C57121000000000000000E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "OsmAnd MapsUITests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "net.osmand.maps.OsmAnd-MapsUITests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "OsmAnd Maps";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -20494,20 +20522,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DA72AB922508F41000851313 /* Build configuration list for PBXNativeTarget "OsmAnd MapsTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DA72AB902508F41000851313 /* Debug */,
-				DA72AB912508F41000851313 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		D1C571210000000000000008 /* Build configuration list for PBXNativeTarget "OsmAnd MapsUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D1C57121000000000000000D /* Debug */,
 				D1C57121000000000000000E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA72AB922508F41000851313 /* Build configuration list for PBXNativeTarget "OsmAnd MapsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA72AB902508F41000851313 /* Debug */,
+				DA72AB912508F41000851313 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -3106,6 +3106,10 @@
 		DA6F7C97216602F7006F14E3 /* ic_action_directions_from@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA6F7C94216602F6006F14E3 /* ic_action_directions_from@2x.png */; };
 		DA6F7C99216602F7006F14E3 /* ic_action_directions_from@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = DA6F7C95216602F6006F14E3 /* ic_action_directions_from@3x.png */; };
 		DA72AB952508F44900851313 /* SearchUICoreTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA72AB942508F44900851313 /* SearchUICoreTest.mm */; };
+		D1C571200000000000000001 /* ContextMenuPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */; };
+		D1C571200000000000000002 /* ContextMenuPresentationCoordinatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */; };
+		D1C571200000000000000007 /* ContextMenuPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */; };
+		D1C571210000000000000001 /* ContextMenuPresentationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */; };
 		DA73EF7429A3B5410071935D /* publictransportroutes.addon.render.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA73EF7329A3B5410071935D /* publictransportroutes.addon.render.xml */; };
 		DA775B8727E5F30E0081B9C1 /* OARemoteFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DA775B8627E5F30E0081B9C1 /* OARemoteFile.m */; };
 		DA775B8A27E6109F0081B9C1 /* OALocalFile.m in Sources */ = {isa = PBXBuildFile; fileRef = DA775B8927E6109F0081B9C1 /* OALocalFile.m */; };
@@ -3597,6 +3601,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		DA72AB8E2508F41000851313 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BB098CE91793F7FD00423944 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BBA3AF30197FC4BB0039D991;
+			remoteInfo = "OsmAnd Maps";
+		};
+		D1C571210000000000000006 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BB098CE91793F7FD00423944 /* Project object */;
 			proxyType = 1;
@@ -8051,6 +8062,11 @@
 		DA72AB892508F40F00851313 /* OsmAnd MapsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OsmAnd MapsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA72AB8D2508F41000851313 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA72AB942508F44900851313 /* SearchUICoreTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SearchUICoreTest.mm; sourceTree = "<group>"; };
+		D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationCoordinator.swift; sourceTree = "<group>"; };
+		D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationCoordinatorTest.swift; sourceTree = "<group>"; };
+		D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationUITests.swift; sourceTree = "<group>"; };
+		D1C571210000000000000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D1C571210000000000000004 /* OsmAnd MapsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OsmAnd MapsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA73EF7329A3B5410071935D /* publictransportroutes.addon.render.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = publictransportroutes.addon.render.xml; path = ../resources/rendering_styles/publictransportroutes.addon.render.xml; sourceTree = "<group>"; };
 		DA775B8527E5F30E0081B9C1 /* OARemoteFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OARemoteFile.h; sourceTree = "<group>"; };
 		DA775B8627E5F30E0081B9C1 /* OARemoteFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OARemoteFile.m; sourceTree = "<group>"; };
@@ -8685,6 +8701,13 @@
 				DA80DAC2251E2CB8008E6267 /* libQt5Concurrent.a in Frameworks */,
 				DA80DACB251E3412008E6267 /* libQt5Core.a in Frameworks */,
 				DA80DABC251E2CB7008E6267 /* libQt5Network.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1C57121000000000000000A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10944,6 +10967,7 @@
 				DA5A78FF26C5639F00F274C7 /* Sources */,
 				DA32848026CD38170036BA73 /* Support Files */,
 				DA72AB8A2508F40F00851313 /* OsmAnd MapsTests */,
+				D1C571210000000000000005 /* OsmAnd MapsUITests */,
 				BB098CF31793F7FD00423944 /* Frameworks */,
 				BB098CF21793F7FD00423944 /* Products */,
 				8A41EAD02309AD2C002F2515 /* Recovered References */,
@@ -10956,6 +10980,7 @@
 			children = (
 				BBA3AFEE197FC4BB0039D991 /* OsmAnd Maps.app */,
 				DA72AB892508F40F00851313 /* OsmAnd MapsTests.xctest */,
+				D1C571210000000000000004 /* OsmAnd MapsUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -13222,6 +13247,7 @@
 			children = (
 				DA5A7DA326C563A300F274C7 /* OADirectionAppearanceViewController.h */,
 				DA5A7D9F26C563A300F274C7 /* OADirectionAppearanceViewController.m */,
+				D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */,
 				DA5A7D9E26C563A300F274C7 /* OAMapPanelViewController.h */,
 				DA5A7DA126C563A300F274C7 /* OAMapPanelViewController.mm */,
 				DA5A7DA026C563A300F274C7 /* OAOptionsPanelBlackViewController.h */,
@@ -14702,6 +14728,7 @@
 				FA7EA4082FD2ACF700509B01 /* Extensions */,
 				FAB624402E0953870048965E /* OsmAnd MapsTests-Bridging-Header.h */,
 				FAB6243D2E0953580048965E /* Managers */,
+				D1C571200000000000000006 /* Panels */,
 				DA80DAA8251E0C0C008E6267 /* Router */,
 				8A1CF862250D145C003D3829 /* test-resources */,
 				DA72AB932508F44900851313 /* Search */,
@@ -14717,6 +14744,23 @@
 				DA72AB942508F44900851313 /* SearchUICoreTest.mm */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		D1C571200000000000000006 /* Panels */ = {
+			isa = PBXGroup;
+			children = (
+				D1C571200000000000000005 /* ContextMenuPresentationCoordinatorTest.swift */,
+			);
+			path = Panels;
+			sourceTree = "<group>";
+		};
+		D1C571210000000000000005 /* OsmAnd MapsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */,
+				D1C571210000000000000003 /* Info.plist */,
+			);
+			path = "OsmAnd MapsUITests";
 			sourceTree = "<group>";
 		};
 		DA7F2587231A68CD00E54F77 /* Libraries */ = {
@@ -15701,6 +15745,24 @@
 			productReference = DA72AB892508F40F00851313 /* OsmAnd MapsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D1C571210000000000000007 /* OsmAnd MapsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D1C571210000000000000008 /* Build configuration list for PBXNativeTarget "OsmAnd MapsUITests" */;
+			buildPhases = (
+				D1C571210000000000000009 /* Sources */,
+				D1C57121000000000000000A /* Frameworks */,
+				D1C57121000000000000000B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D1C57121000000000000000C /* PBXTargetDependency */,
+			);
+			name = "OsmAnd MapsUITests";
+			productName = "OsmAnd MapsUITests";
+			productReference = D1C571210000000000000004 /* OsmAnd MapsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -15726,6 +15788,10 @@
 					DA72AB882508F40F00851313 = {
 						CreatedOnToolsVersion = 11.7;
 						LastSwiftMigration = 1620;
+						TestTargetID = BBA3AF30197FC4BB0039D991;
+					};
+					D1C571210000000000000007 = {
+						CreatedOnToolsVersion = 26.6;
 						TestTargetID = BBA3AF30197FC4BB0039D991;
 					};
 				};
@@ -15838,6 +15904,7 @@
 			targets = (
 				BBA3AF30197FC4BB0039D991 /* OsmAnd Maps */,
 				DA72AB882508F40F00851313 /* OsmAnd MapsTests */,
+				D1C571210000000000000007 /* OsmAnd MapsUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -17696,6 +17763,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D1C57121000000000000000B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -19489,6 +19563,7 @@
 				FACB02B52D562C4200EBE87F /* ExpandableTextView.swift in Sources */,
 				27E8D9F12ED4688D00F98462 /* SegmentButtonsSliderTableViewCell.swift in Sources */,
 				FA740D3A2A7C006900BD12DC /* OAAppDelegate.mm in Sources */,
+				D1C571200000000000000001 /* ContextMenuPresentationCoordinator.swift in Sources */,
 				FA2431802DD202E800B52998 /* VehicleMetricsSensorsController.swift in Sources */,
 				CA4ED17832F287267D3F813A /* OAStorageStateValuesCell.m in Sources */,
 				CA4ED87EDFA076F9F7F63A4C /* OABenefitsOsmContributorsViewController.m in Sources */,
@@ -19508,6 +19583,16 @@
 				FAB624412E0954F90048965E /* SelectionManager.swift in Sources */,
 				D1A0B0122F50001100A0B001 /* StringExtensions.swift in Sources */,
 				DA72AB952508F44900851313 /* SearchUICoreTest.mm in Sources */,
+				D1C571200000000000000007 /* ContextMenuPresentationCoordinator.swift in Sources */,
+				D1C571200000000000000002 /* ContextMenuPresentationCoordinatorTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1C571210000000000000009 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D1C571210000000000000001 /* ContextMenuPresentationUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -19518,6 +19603,11 @@
 			isa = PBXTargetDependency;
 			target = BBA3AF30197FC4BB0039D991 /* OsmAnd Maps */;
 			targetProxy = DA72AB8E2508F41000851313 /* PBXContainerItemProxy */;
+		};
+		D1C57121000000000000000C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BBA3AF30197FC4BB0039D991 /* OsmAnd Maps */;
+			targetProxy = D1C571210000000000000006 /* PBXContainerItemProxy */;
 		};
 		FAB2B14D2C787E4400B59B7A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -20282,6 +20372,107 @@
 			};
 			name = Release;
 		};
+		D1C57121000000000000000D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "OsmAnd MapsUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.osmand.maps.OsmAnd-MapsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "OsmAnd Maps";
+			};
+			name = Debug;
+		};
+		D1C57121000000000000000E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "OsmAnd MapsUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.osmand.maps.OsmAnd-MapsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "OsmAnd Maps";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -20308,6 +20499,15 @@
 			buildConfigurations = (
 				DA72AB902508F41000851313 /* Debug */,
 				DA72AB912508F41000851313 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D1C571210000000000000008 /* Build configuration list for PBXNativeTarget "OsmAnd MapsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1C57121000000000000000D /* Debug */,
+				D1C57121000000000000000E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/OsmAnd.xcworkspace/xcshareddata/xcschemes/OsmAnd Maps.xcscheme
+++ b/OsmAnd.xcworkspace/xcshareddata/xcschemes/OsmAnd Maps.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:OsmAnd.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D1C571210000000000000007"
+               BuildableName = "OsmAnd MapsUITests.xctest"
+               BlueprintName = "OsmAnd MapsUITests"
+               ReferencedContainer = "container:OsmAnd.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -46,6 +60,16 @@
                BlueprintIdentifier = "DA72AB882508F40F00851313"
                BuildableName = "OsmAnd MapsTests.xctest"
                BlueprintName = "OsmAnd MapsTests"
+               ReferencedContainer = "container:OsmAnd.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D1C571210000000000000007"
+               BuildableName = "OsmAnd MapsUITests.xctest"
+               BlueprintName = "OsmAnd MapsUITests"
                ReferencedContainer = "container:OsmAnd.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Sources/AppHost/OAAppDelegate.mm
+++ b/Sources/AppHost/OAAppDelegate.mm
@@ -188,7 +188,7 @@ NSNotificationName const OALaunchUpdateStateNotification = @"OALaunchUpdateState
                     break;
                 }
             }
-            if (!mapInstalled)
+            if (!mapInstalled && !AppEnvironment.isUITesting)
             {
                 [self configureAppLaunchEvent:AppLaunchEventFirstLaunch];
                 LogStartup(@"initialize: first launch detected (no maps)");

--- a/Sources/Controllers/Base/OABaseScrollableHudViewController.h
+++ b/Sources/Controllers/Base/OABaseScrollableHudViewController.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, EOAScrollableMenuHudMode)
 - (void) hide:(BOOL)animated duration:(NSTimeInterval)duration onComplete:(void (^)(void))onComplete;
 - (void) hide;
 - (void) forceHide;
+- (void)forceHideWithCompletion:(nullable void (^)(void))onComplete;
 
 - (void) goExpanded;
 - (void) goMinimized;

--- a/Sources/Controllers/Base/OABaseScrollableHudViewController.mm
+++ b/Sources/Controllers/Base/OABaseScrollableHudViewController.mm
@@ -35,6 +35,7 @@
     
     BOOL _isDragging;
     BOOL _isHiding;
+    void (^_forceHideCompletion)(void);
     CGFloat _initialTouchPoint;
     CGFloat _tableViewContentOffsetY;
 }
@@ -488,6 +489,12 @@
     [self hide];
 }
 
+- (void)forceHideWithCompletion:(void (^)(void))onComplete
+{
+    _forceHideCompletion = [onComplete copy];
+    [self forceHide];
+}
+
 - (void) hide:(BOOL)animated duration:(NSTimeInterval)duration onComplete:(void (^)(void))onComplete
 {
     _isHiding = YES;
@@ -502,14 +509,28 @@
             [_mapPanel hideScrollableHudViewController];
             _scrollableView.frame = frame;
         } completion:^(BOOL finished) {
-            [self dismissViewControllerAnimated:NO completion:onComplete];
+            [self dismissViewControllerAnimated:NO completion:^{
+                if (onComplete)
+                    onComplete();
+                void (^forceHideCompletion)(void) = _forceHideCompletion;
+                _forceHideCompletion = nil;
+                if (forceHideCompletion)
+                    forceHideCompletion();
+            }];
         }];
     }
     else
     {
         [_mapPanel hideScrollableHudViewController];
         _scrollableView.frame = frame;
-        [self dismissViewControllerAnimated:YES completion:onComplete];
+        [self dismissViewControllerAnimated:YES completion:^{
+            if (onComplete)
+                onComplete();
+            void (^forceHideCompletion)(void) = _forceHideCompletion;
+            _forceHideCompletion = nil;
+            if (forceHideCompletion)
+                forceHideCompletion();
+        }];
     }
 }
 

--- a/Sources/Controllers/Map/Helpers/OASelectedGPXHelper.mm
+++ b/Sources/Controllers/Map/Helpers/OASelectedGPXHelper.mm
@@ -16,6 +16,7 @@
 #import "OAObservable.h"
 #import "OsmAndSharedWrapper.h"
 #import "OsmAnd_Maps-Swift.h"
+#import "OASavingTrackHelper.h"
 
 static NSString *kBackupSuffix = @"_osmand_backup";
 
@@ -186,12 +187,17 @@ static NSString *kBackupSuffix = @"_osmand_backup";
     [[_app updateGpxTracksOnMapObservable] notifyEvent];
 }
 
-- (OASGpxFile *)getSelectedGpx:(OASWptPt *)gpxWpt {
+- (OASGpxFile *)getSelectedGpx:(OASWptPt *)gpxWpt
+{
     for (OASGpxFile *gpxFile in _activeGpx.allValues) {
-        if ([[gpxFile getPointsList] containsObject:gpxWpt]) {
+        if ([[gpxFile getPointsList] containsObject:gpxWpt] || [[gpxFile getRoutePoints] containsObject:gpxWpt])
             return gpxFile;
-        }
     }
+    
+    OASGpxFile *currentTrack = [OASavingTrackHelper sharedInstance].currentTrack;
+    if ([[currentTrack getPointsList] containsObject:gpxWpt] || [[currentTrack getRoutePoints] containsObject:gpxWpt])
+        return currentTrack;
+    
     return nil;
 }
 

--- a/Sources/Controllers/Map/OAMapViewController.mm
+++ b/Sources/Controllers/Map/OAMapViewController.mm
@@ -607,6 +607,9 @@ static char kMapSourceUpdateQueueKey;
 
 - (void) showWhatsNewDialogIfNeeded
 {
+    if (AppEnvironment.isUITesting)
+        return;
+
     if ([OAAppSettings sharedManager].shouldShowWhatsNewScreen && !UIApplication.sharedApplication.isAnyCarPlaySceneActive)
     {
         OAWhatsNewBottomSheetViewController *bottomSheet = [[OAWhatsNewBottomSheetViewController alloc] init];

--- a/Sources/Controllers/Panels/ContextMenuPresentationCoordinator.swift
+++ b/Sources/Controllers/Panels/ContextMenuPresentationCoordinator.swift
@@ -7,10 +7,26 @@
 //
 
 @objcMembers
+final class ContextMenuDismissHandler: NSObject {
+
+    typealias Completion = @convention(block) () -> Void
+    typealias Handler = @convention(block) (@escaping Completion) -> Bool
+
+    private let handler: Handler
+
+    @objc(initWithHandler:) init(handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    func dismiss(completion: @escaping Completion) -> Bool {
+        handler(completion)
+    }
+}
+
+@objcMembers
 final class ContextMenuPresentationCoordinator: NSObject {
 
-    typealias DismissCompletion = @convention(block) () -> Void
-    typealias DismissHandler = @convention(block) (@escaping DismissCompletion) -> Bool
+    typealias DismissCompletion = ContextMenuDismissHandler.Completion
 
     var isTransitionInProgress: Bool {
         transitionInProgressValue
@@ -24,17 +40,11 @@ final class ContextMenuPresentationCoordinator: NSObject {
     }
 
     @nonobjc
-    func processPendingPresentation(with dismissHandlers: [DismissHandler]) {
+    func processPendingPresentation(with dismissHandlers: [ContextMenuDismissHandler]) {
         processPendingPresentation(withDismissHandlers: dismissHandlers)
     }
 
-    @objc(processPendingPresentationWithDismissHandlers:)
-    func processPendingPresentation(withDismissHandlers dismissHandlers: NSArray) {
-        let handlers = dismissHandlers.map { unsafeBitCast($0 as AnyObject, to: DismissHandler.self) }
-        processPendingPresentation(withDismissHandlers: handlers)
-    }
-
-    private func processPendingPresentation(withDismissHandlers dismissHandlers: [DismissHandler]) {
+    func processPendingPresentation(withDismissHandlers dismissHandlers: [ContextMenuDismissHandler]) {
         guard !transitionInProgressValue, let pendingPresentation else {
             return
         }
@@ -55,7 +65,7 @@ final class ContextMenuPresentationCoordinator: NSObject {
                 self.processPendingPresentation(withDismissHandlers: dismissHandlers)
             }
 
-            if dismissHandler(completion) {
+            if dismissHandler.dismiss(completion: completion) {
                 transitionInProgressValue = true
                 if completedSynchronously {
                     transitionInProgressValue = false

--- a/Sources/Controllers/Panels/ContextMenuPresentationCoordinator.swift
+++ b/Sources/Controllers/Panels/ContextMenuPresentationCoordinator.swift
@@ -1,0 +1,71 @@
+//
+//  ContextMenuPresentationCoordinator.swift
+//  OsmAnd Maps
+//
+//  Created by Oleksandr Panchenko on 02.09.2026.
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+@objcMembers
+final class ContextMenuPresentationCoordinator: NSObject {
+
+    typealias DismissCompletion = @convention(block) () -> Void
+    typealias DismissHandler = @convention(block) (@escaping DismissCompletion) -> Bool
+
+    var isTransitionInProgress: Bool {
+        transitionInProgressValue
+    }
+    
+    private var pendingPresentation: DismissCompletion?
+    private var transitionInProgressValue = false
+
+    func enqueuePresentation(_ presentation: @escaping DismissCompletion) {
+        pendingPresentation = presentation
+    }
+
+    @nonobjc
+    func processPendingPresentation(with dismissHandlers: [DismissHandler]) {
+        processPendingPresentation(withDismissHandlers: dismissHandlers)
+    }
+
+    @objc(processPendingPresentationWithDismissHandlers:)
+    func processPendingPresentation(withDismissHandlers dismissHandlers: NSArray) {
+        let handlers = dismissHandlers.map { unsafeBitCast($0 as AnyObject, to: DismissHandler.self) }
+        processPendingPresentation(withDismissHandlers: handlers)
+    }
+
+    private func processPendingPresentation(withDismissHandlers dismissHandlers: [DismissHandler]) {
+        guard !transitionInProgressValue, let pendingPresentation else {
+            return
+        }
+
+        for dismissHandler in dismissHandlers {
+            var completedSynchronously = false
+            let completion: DismissCompletion = { [weak self] in
+                guard let self else {
+                    return
+                }
+
+                guard self.transitionInProgressValue else {
+                    completedSynchronously = true
+                    return
+                }
+
+                self.transitionInProgressValue = false
+                self.processPendingPresentation(withDismissHandlers: dismissHandlers)
+            }
+
+            if dismissHandler(completion) {
+                transitionInProgressValue = true
+                if completedSynchronously {
+                    transitionInProgressValue = false
+                    processPendingPresentation(withDismissHandlers: dismissHandlers)
+                }
+                return
+            }
+        }
+
+        self.pendingPresentation = nil
+        pendingPresentation()
+    }
+}

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -2827,6 +2827,9 @@ typedef enum
         [self restoreFromContextMenuMode];
     
     [self.targetMenuView hide:YES duration:animationDuration onComplete:^{
+        if (onComplete)
+            onComplete();
+
         if (_activeTargetType != OATargetNone)
         {
             if (_activeTargetActive || _activeTargetChildPushed)
@@ -2849,9 +2852,6 @@ typedef enum
         {
             [_hudViewController updateDependentButtonsVisibility];
         }
-
-        if (onComplete)
-            onComplete();
     }];
     
     [_hudViewController updateControlsLayout:YES];

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -149,17 +149,6 @@ typedef enum
 
 @property (strong, nonatomic) OARouteInfoView* routeInfoView;
 
-- (void)enqueueContextMenuPresentation:(void (^)(void))presentation;
-- (void)processPendingContextMenuPresentation;
-- (void)presentContextMenuWithPoints:(NSArray<OATargetPoint *> *)targetPoints
-                     selectedObjects:(nullable NSArray<SelectedMapObject *> *)selectedObjects
-                    touchPointLatLon:(nullable CLLocation *)touchPointLatLon;
-- (void)presentContextMenu:(OATargetPoint *)targetPoint selectedObject:(nullable SelectedMapObject *)selectedObject;
-- (void)presentContextMenu:(OATargetPoint *)targetPoint
-                 saveState:(BOOL)saveState
-             preferredZoom:(float)preferredZoom
-            selectedObject:(nullable SelectedMapObject *)selectedObject;
-
 @end
 
 @implementation OAMapPanelViewController

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -1422,6 +1422,9 @@ typedef enum
 
 - (void) showContextMenuWithPoints:(NSArray<OATargetPoint *> *)targetPoints selectedObjects:(nullable NSArray<SelectedMapObject *> *)selectedObjects touchPointLatLon:(nullable CLLocation *)touchPointLatLon
 {
+    if (self.isNewContextMenuDisabled)
+        return;
+
     __weak __typeof(self) weakSelf = self;
     [self enqueueContextMenuPresentation:^{
         __strong __typeof(weakSelf) strongSelf = weakSelf;
@@ -1507,6 +1510,9 @@ typedef enum
 
 - (void)showContextMenu:(OATargetPoint *)targetPoint saveState:(BOOL)saveState preferredZoom:(float)preferredZoom
 {
+    if (self.isNewContextMenuDisabled)
+        return;
+
     __weak __typeof(self) weakSelf = self;
     [self enqueueContextMenuPresentation:^{
         __strong __typeof(weakSelf) strongSelf = weakSelf;
@@ -3168,13 +3174,14 @@ typedef enum
                         state:(OATrackMenuViewControllerState *)state
                      analysis:(nullable OASGpxTrackAnalysis *)analysis;
 {
+    BOOL shouldClearNavControllerHistory = _scrollableHudViewController && !state.openedFromTrackMenu;
     __weak __typeof(self) weakSelf = self;
     [self enqueueContextMenuPresentation:^{
         __strong __typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf)
             return;
 
-        if (!state.openedFromTrackMenu)
+        if (shouldClearNavControllerHistory)
             state.navControllerHistory = nil;
 
         [strongSelf doShowGpxItem:item items:items routeKey:routeKey state:state trackHudMode:trackHudMode analysis:analysis];
@@ -3196,7 +3203,7 @@ typedef enum
             if (!strongSelf || !strongSelf->_scrollableHudViewController)
                 return NO;
 
-            [strongSelf->_scrollableHudViewController forceHideWithCompletion:completion];
+            [strongSelf->_scrollableHudViewController hide:YES duration:0.2 onComplete:completion];
             return YES;
         },
         ^BOOL(dispatch_block_t completion) {
@@ -3212,7 +3219,8 @@ typedef enum
             if (!strongSelf || !strongSelf.targetMenuView.superview)
                 return NO;
 
-            [strongSelf hideTargetPointMenu:0.2 onComplete:completion];
+            strongSelf->_prevScrollableHudViewController = nil;
+            [strongSelf hideTargetPointMenu:0.2 onComplete:completion hideActiveTarget:YES mapGestureAction:NO];
             return YES;
         },
     ]];

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -201,7 +201,6 @@ typedef enum
 
     MBProgressHUD *_gpxProgress;
     ContextMenuPresentationCoordinator *_contextMenuPresentationCoordinator;
-    BOOL _contextMenuPresentationUITestFixtureStarted;
     UIView *_contextMenuPresentationUITestStateView;
 }
 
@@ -287,7 +286,7 @@ typedef enum
 
     // Setup target point menu
     self.targetMenuView = [[OATargetPointView alloc] initWithFrame:CGRectMake(0.0, 0.0, DeviceScreenWidth, DeviceScreenHeight)];
-    self.targetMenuView.accessibilityIdentifier = @"context_menu_container";
+    self.targetMenuView.accessibilityIdentifier = UITestAccessibilityIdentifier.contextMenuContainer;
     self.targetMenuView.isAccessibilityElement = [self isContextMenuPresentationUITestingEnabled];
     self.targetMenuView.menuViewDelegate = self;
     [self.targetMenuView setMapViewInstance:_mapViewController.view];
@@ -298,7 +297,7 @@ typedef enum
 
     // Setup target multi menu
     self.targetMultiMenuView = [[OATargetMultiView alloc] initWithFrame:CGRectMake(0.0, 0.0, DeviceScreenWidth, 140.0)];
-    self.targetMultiMenuView.accessibilityIdentifier = @"multi_context_menu_container";
+    self.targetMultiMenuView.accessibilityIdentifier = UITestAccessibilityIdentifier.multiContextMenuContainer;
     self.targetMultiMenuView.isAccessibilityElement = [self isContextMenuPresentationUITestingEnabled];
 
     [self setupContextMenuPresentationUITestStateViewIfNeeded];
@@ -327,12 +326,13 @@ typedef enum
     BOOL isCarPlayConnected = UIApplication.sharedApplication.isCarPlayConnected;
     if ([_mapViewController parentViewController] != self && !isCarPlayConnected)
         [self doMapRestore];
-    
+
     if (isCarPlayConnected)
         [self onCarPlayConnected];
-    
+
+    [self runUITestsIfNeeded];
+
     [[OADiscountHelper instance] checkAndDisplay];
-    [self runContextMenuPresentationUITestFixtureIfNeeded];
 }
 
 - (void) viewWillLayoutSubviews
@@ -4733,9 +4733,20 @@ typedef enum
 
 #pragma mark - UI Tests
 
+- (void)runUITestsIfNeeded
+{
+    [self runContextMenuPresentationUITestFixtureIfNeeded];
+    [self runGpxWaypointOpenTrackUITestFixtureIfNeeded];
+}
+
 - (BOOL)isContextMenuPresentationUITestingEnabled
 {
-    return [[[NSProcessInfo processInfo] arguments] containsObject:@"-ui-testing-context-menu-presentation-race"];
+    return UITestState.isContextMenuPresentationRaceEnabled;
+}
+
+- (BOOL)isGpxWaypointOpenTrackUITestingEnabled
+{
+    return UITestState.isGpxWaypointOpenTrackEnabled;
 }
 
 - (void)setupContextMenuPresentationUITestStateViewIfNeeded
@@ -4746,7 +4757,7 @@ typedef enum
     _contextMenuPresentationUITestStateView = [[UIButton alloc] initWithFrame:CGRectMake(0.0, 0.0, 44.0, 44.0)];
     _contextMenuPresentationUITestStateView.backgroundColor = UIColor.clearColor;
     _contextMenuPresentationUITestStateView.isAccessibilityElement = YES;
-    _contextMenuPresentationUITestStateView.accessibilityIdentifier = @"context_menu_presentation_test_state";
+    _contextMenuPresentationUITestStateView.accessibilityIdentifier = UITestAccessibilityIdentifier.contextMenuPresentationState;
     _contextMenuPresentationUITestStateView.accessibilityLabel = @"idle";
     _contextMenuPresentationUITestStateView.accessibilityValue = @"idle";
     [self.view addSubview:_contextMenuPresentationUITestStateView];
@@ -4771,10 +4782,8 @@ typedef enum
 
 - (void)runContextMenuPresentationUITestFixtureIfNeeded
 {
-    if (![self isContextMenuPresentationUITestingEnabled] || _contextMenuPresentationUITestFixtureStarted)
+    if (![UITestState shouldRunContextMenuPresentationRaceFixture])
         return;
-
-    _contextMenuPresentationUITestFixtureStarted = YES;
 
     __weak __typeof(self) weakSelf = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -4841,6 +4850,46 @@ typedef enum
     [self.view bringSubviewToFront:_contextMenuPresentationUITestStateView];
 
     [self showTargetPointMenu:NO showFullMenu:NO onComplete:onComplete];
+}
+
+- (void)runGpxWaypointOpenTrackUITestFixtureIfNeeded
+{
+    if (![UITestState shouldRunGpxWaypointOpenTrackFixture])
+        return;
+
+    __weak __typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+
+        OASGpxFile *currentTrack = [OASavingTrackHelper sharedInstance].currentTrack;
+        NSString *waypointName = @"UITest Waypoint A";
+        BOOL hasFixtureWaypoint = NO;
+        for (OASWptPt *point in [currentTrack getPointsList])
+        {
+            if ([point.name isEqualToString:waypointName])
+            {
+                hasFixtureWaypoint = YES;
+                break;
+            }
+        }
+
+        if (!hasFixtureWaypoint)
+        {
+            OASWptPt *waypoint = [[OASWptPt alloc] initWithLat:52.379189 lon:4.899431];
+            waypoint.name = waypointName;
+            waypoint.category = @"UITest";
+            [currentTrack addPointPoint:waypoint];
+            [currentTrack processPoints];
+        }
+
+        OASTrackItem *trackItem = [[OASTrackItem alloc] initWithGpxFile:currentTrack];
+        [strongSelf openTargetViewWithGPX:trackItem
+                              selectedTab:EOATrackMenuHudPointsTab
+                     selectedStatisticsTab:EOATrackMenuHudSegmentsStatisticsOverviewTab
+                            openedFromMap:NO];
+    });
 }
 
 @end

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -3214,7 +3214,7 @@ typedef enum
             if (!strongSelf || !strongSelf->_scrollableHudViewController)
                 return NO;
 
-            [strongSelf->_scrollableHudViewController hide:YES duration:0.2 onComplete:completion];
+            [strongSelf->_scrollableHudViewController forceHideWithCompletion:completion];
             return YES;
         }],
         [[ContextMenuDismissHandler alloc] initWithHandler:^BOOL(dispatch_block_t completion) {

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -200,8 +200,9 @@ typedef enum
     BOOL _isNewContextMenuStillEnabled;
 
     MBProgressHUD *_gpxProgress;
-    BOOL _contextMenuTransitionInProgress;
-    void (^_pendingContextMenuPresentation)(void);
+    ContextMenuPresentationCoordinator *_contextMenuPresentationCoordinator;
+    BOOL _contextMenuPresentationUITestFixtureStarted;
+    UIView *_contextMenuPresentationUITestStateView;
 }
 
 - (instancetype) init
@@ -226,6 +227,7 @@ typedef enum
     _destinationsHelper = [OADestinationsHelper instance];
     _mapWidgetRegistry = [OAMapWidgetRegistry sharedInstance];
     _weatherToolbarStateChangeObservable = [[OAObservable alloc] init];
+    _contextMenuPresentationCoordinator = [ContextMenuPresentationCoordinator new];
 
     _addonsSwitchObserver = [[OAAutoObserverProxy alloc] initWith:self
                                                       withHandler:@selector(onAddonsSwitch:withKey:andValue:)
@@ -285,6 +287,8 @@ typedef enum
 
     // Setup target point menu
     self.targetMenuView = [[OATargetPointView alloc] initWithFrame:CGRectMake(0.0, 0.0, DeviceScreenWidth, DeviceScreenHeight)];
+    self.targetMenuView.accessibilityIdentifier = @"context_menu_container";
+    self.targetMenuView.isAccessibilityElement = [self isContextMenuPresentationUITestingEnabled];
     self.targetMenuView.menuViewDelegate = self;
     [self.targetMenuView setMapViewInstance:_mapViewController.view];
     [self.targetMenuView setParentViewInstance:self.view];
@@ -294,6 +298,10 @@ typedef enum
 
     // Setup target multi menu
     self.targetMultiMenuView = [[OATargetMultiView alloc] initWithFrame:CGRectMake(0.0, 0.0, DeviceScreenWidth, 140.0)];
+    self.targetMultiMenuView.accessibilityIdentifier = @"multi_context_menu_container";
+    self.targetMultiMenuView.isAccessibilityElement = [self isContextMenuPresentationUITestingEnabled];
+
+    [self setupContextMenuPresentationUITestStateViewIfNeeded];
 
     [self updateHUD:NO];
 }
@@ -324,6 +332,7 @@ typedef enum
         [self onCarPlayConnected];
     
     [[OADiscountHelper instance] checkAndDisplay];
+    [self runContextMenuPresentationUITestFixtureIfNeeded];
 }
 
 - (void) viewWillLayoutSubviews
@@ -1546,6 +1555,8 @@ typedef enum
     
     [self applyTargetPoint:targetPoint];
     [_targetMenuView setTargetPoint:targetPoint];
+    _targetMenuView.accessibilityValue = targetPoint.title;
+    _contextMenuPresentationUITestStateView.accessibilityValue = targetPoint.title;
     
     [_targetMenuView setSelectedObject:selectedObject.object];
 
@@ -3172,63 +3183,39 @@ typedef enum
 
 - (void)enqueueContextMenuPresentation:(void (^)(void))presentation
 {
-    _pendingContextMenuPresentation = [presentation copy];
+    [_contextMenuPresentationCoordinator enqueuePresentation:presentation];
     [self processPendingContextMenuPresentation];
 }
 
 - (void)processPendingContextMenuPresentation
 {
-    if (_contextMenuTransitionInProgress || !_pendingContextMenuPresentation)
-        return;
-
-    if (_scrollableHudViewController)
-    {
-        _contextMenuTransitionInProgress = YES;
-        __weak __typeof(self) weakSelf = self;
-        [_scrollableHudViewController forceHideWithCompletion:^{
+    __weak __typeof(self) weakSelf = self;
+    [_contextMenuPresentationCoordinator processPendingPresentationWithDismissHandlers:@[
+        ^BOOL(dispatch_block_t completion) {
             __strong __typeof(weakSelf) strongSelf = weakSelf;
-            if (!strongSelf)
-                return;
+            if (!strongSelf || !strongSelf->_scrollableHudViewController)
+                return NO;
 
-            strongSelf->_contextMenuTransitionInProgress = NO;
-            [strongSelf processPendingContextMenuPresentation];
-        }];
-        return;
-    }
-
-    if (self.targetMultiMenuView.superview)
-    {
-        _contextMenuTransitionInProgress = YES;
-        __weak __typeof(self) weakSelf = self;
-        [self.targetMultiMenuView hide:YES duration:0.2 onComplete:^{
+            [strongSelf->_scrollableHudViewController forceHideWithCompletion:completion];
+            return YES;
+        },
+        ^BOOL(dispatch_block_t completion) {
             __strong __typeof(weakSelf) strongSelf = weakSelf;
-            if (!strongSelf)
-                return;
+            if (!strongSelf || !strongSelf.targetMultiMenuView.superview)
+                return NO;
 
-            strongSelf->_contextMenuTransitionInProgress = NO;
-            [strongSelf processPendingContextMenuPresentation];
-        }];
-        return;
-    }
-
-    if (self.targetMenuView.superview)
-    {
-        _contextMenuTransitionInProgress = YES;
-        __weak __typeof(self) weakSelf = self;
-        [self hideTargetPointMenu:0.2 onComplete:^{
+            [strongSelf.targetMultiMenuView hide:YES duration:0.2 onComplete:completion];
+            return YES;
+        },
+        ^BOOL(dispatch_block_t completion) {
             __strong __typeof(weakSelf) strongSelf = weakSelf;
-            if (!strongSelf)
-                return;
+            if (!strongSelf || !strongSelf.targetMenuView.superview)
+                return NO;
 
-            strongSelf->_contextMenuTransitionInProgress = NO;
-            [strongSelf processPendingContextMenuPresentation];
-        }];
-        return;
-    }
-
-    void (^presentation)(void) = _pendingContextMenuPresentation;
-    _pendingContextMenuPresentation = nil;
-    presentation();
+            [strongSelf hideTargetPointMenu:0.2 onComplete:completion];
+            return YES;
+        },
+    ]];
 }
 
 - (void)doShowGpxItem:(OASTrackItem *)item
@@ -4734,6 +4721,118 @@ typedef enum
     if (gpxFileName && gpxFileName.length > 0)
         fullPath = [OsmAndApp.instance.gpxPath stringByAppendingPathComponent:gpxFileName];
     [self targetPointAddWaypoint:fullPath];
+}
+
+#pragma mark - UI Tests
+
+- (BOOL)isContextMenuPresentationUITestingEnabled
+{
+    return [[[NSProcessInfo processInfo] arguments] containsObject:@"-ui-testing-context-menu-presentation-race"];
+}
+
+- (void)setupContextMenuPresentationUITestStateViewIfNeeded
+{
+    if (![self isContextMenuPresentationUITestingEnabled])
+        return;
+
+    _contextMenuPresentationUITestStateView = [[UIButton alloc] initWithFrame:CGRectMake(0.0, 0.0, 44.0, 44.0)];
+    _contextMenuPresentationUITestStateView.backgroundColor = UIColor.clearColor;
+    _contextMenuPresentationUITestStateView.isAccessibilityElement = YES;
+    _contextMenuPresentationUITestStateView.accessibilityIdentifier = @"context_menu_presentation_test_state";
+    _contextMenuPresentationUITestStateView.accessibilityLabel = @"idle";
+    _contextMenuPresentationUITestStateView.accessibilityValue = @"idle";
+    [self.view addSubview:_contextMenuPresentationUITestStateView];
+}
+
+- (OATargetPoint *)contextMenuPresentationUITestTargetWithType:(OATargetPointType)type
+                                                         title:(NSString *)title
+                                                      latitude:(CLLocationDegrees)latitude
+                                                     longitude:(CLLocationDegrees)longitude
+{
+    OATargetPoint *targetPoint = [[OATargetPoint alloc] init];
+    targetPoint.type = type;
+    targetPoint.location = CLLocationCoordinate2DMake(latitude, longitude);
+    targetPoint.title = title;
+    targetPoint.titleAddress = title;
+    targetPoint.addressFound = YES;
+    targetPoint.toolbarNeeded = NO;
+    if (type == OATargetDestination)
+        targetPoint.targetObj = [[OADestination alloc] initWithDesc:title latitude:latitude longitude:longitude];
+    return targetPoint;
+}
+
+- (void)runContextMenuPresentationUITestFixtureIfNeeded
+{
+    if (![self isContextMenuPresentationUITestingEnabled] || _contextMenuPresentationUITestFixtureStarted)
+        return;
+
+    _contextMenuPresentationUITestFixtureStarted = YES;
+
+    __weak __typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+
+        OATargetPoint *firstTarget = [strongSelf contextMenuPresentationUITestTargetWithType:OATargetDestination
+                                                                                       title:@"UITest Destination A"
+                                                                                    latitude:52.379189
+                                                                                   longitude:4.899431];
+        [strongSelf enqueueContextMenuPresentation:^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (strongSelf)
+                [strongSelf presentContextMenuPresentationUITestTarget:firstTarget onComplete:^{
+                    [strongSelf enqueueContextMenuPresentationUITestFollowUps];
+                }];
+        }];
+    });
+}
+
+- (void)enqueueContextMenuPresentationUITestFollowUps
+{
+    OATargetPoint *secondTarget = [self contextMenuPresentationUITestTargetWithType:OATargetParking
+                                                                              title:@"UITest Parking B"
+                                                                           latitude:52.380189
+                                                                          longitude:4.900431];
+    __weak __typeof(self) weakSelf = self;
+    [self enqueueContextMenuPresentation:^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf)
+            [strongSelf presentContextMenuPresentationUITestTarget:secondTarget onComplete:nil];
+    }];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+
+        OATargetPoint *thirdTarget = [strongSelf contextMenuPresentationUITestTargetWithType:OATargetMyLocation
+                                                                                       title:@"UITest My Location C"
+                                                                                    latitude:52.381189
+                                                                                   longitude:4.901431];
+        [strongSelf enqueueContextMenuPresentation:^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (strongSelf)
+                [strongSelf presentContextMenuPresentationUITestTarget:thirdTarget onComplete:nil];
+        }];
+    });
+}
+
+- (void)presentContextMenuPresentationUITestTarget:(OATargetPoint *)targetPoint
+                                        onComplete:(void (^)(void))onComplete
+{
+    [self applyTargetPoint:targetPoint];
+    [_targetMenuView setTargetPoint:targetPoint];
+    _targetMenuView.accessibilityValue = targetPoint.title;
+    _contextMenuPresentationUITestStateView.accessibilityLabel = targetPoint.title;
+    NSString *presentationHistory = _contextMenuPresentationUITestStateView.accessibilityValue;
+    if (!presentationHistory || [presentationHistory isEqualToString:@"idle"])
+        _contextMenuPresentationUITestStateView.accessibilityValue = targetPoint.title;
+    else
+        _contextMenuPresentationUITestStateView.accessibilityValue = [presentationHistory stringByAppendingFormat:@"|%@", targetPoint.title];
+    [self.view bringSubviewToFront:_contextMenuPresentationUITestStateView];
+
+    [self showTargetPointMenu:NO showFullMenu:NO onComplete:onComplete];
 }
 
 @end

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -3185,13 +3185,13 @@ typedef enum
                         state:(OATrackMenuViewControllerState *)state
                      analysis:(nullable OASGpxTrackAnalysis *)analysis;
 {
+    BOOL shouldClearNavControllerHistory = _scrollableHudViewController != nil && !state.openedFromTrackMenu;
     __weak __typeof(self) weakSelf = self;
     [self enqueueContextMenuPresentation:^{
         __strong __typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf)
             return;
 
-        BOOL shouldClearNavControllerHistory = strongSelf->_scrollableHudViewController && !state.openedFromTrackMenu;
         if (shouldClearNavControllerHistory)
             state.navControllerHistory = nil;
 

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -149,6 +149,17 @@ typedef enum
 
 @property (strong, nonatomic) OARouteInfoView* routeInfoView;
 
+- (void)enqueueContextMenuPresentation:(void (^)(void))presentation;
+- (void)processPendingContextMenuPresentation;
+- (void)presentContextMenuWithPoints:(NSArray<OATargetPoint *> *)targetPoints
+                     selectedObjects:(nullable NSArray<SelectedMapObject *> *)selectedObjects
+                    touchPointLatLon:(nullable CLLocation *)touchPointLatLon;
+- (void)presentContextMenu:(OATargetPoint *)targetPoint selectedObject:(nullable SelectedMapObject *)selectedObject;
+- (void)presentContextMenu:(OATargetPoint *)targetPoint
+                 saveState:(BOOL)saveState
+             preferredZoom:(float)preferredZoom
+            selectedObject:(nullable SelectedMapObject *)selectedObject;
+
 @end
 
 @implementation OAMapPanelViewController
@@ -200,6 +211,8 @@ typedef enum
     BOOL _isNewContextMenuStillEnabled;
 
     MBProgressHUD *_gpxProgress;
+    BOOL _contextMenuTransitionInProgress;
+    void (^_pendingContextMenuPresentation)(void);
 }
 
 - (instancetype) init
@@ -1411,9 +1424,16 @@ typedef enum
 
 - (void) showContextMenuWithPoints:(NSArray<OATargetPoint *> *)targetPoints selectedObjects:(nullable NSArray<SelectedMapObject *> *)selectedObjects touchPointLatLon:(nullable CLLocation *)touchPointLatLon
 {
-    if (_activeTargetType == OATargetGPX && _scrollableHudViewController)
-        [_scrollableHudViewController forceHide];
+    __weak __typeof(self) weakSelf = self;
+    [self enqueueContextMenuPresentation:^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf)
+            [strongSelf presentContextMenuWithPoints:targetPoints selectedObjects:selectedObjects touchPointLatLon:touchPointLatLon];
+    }];
+}
 
+- (void)presentContextMenuWithPoints:(NSArray<OATargetPoint *> *)targetPoints selectedObjects:(nullable NSArray<SelectedMapObject *> *)selectedObjects touchPointLatLon:(nullable CLLocation *)touchPointLatLon
+{
     if (self.isNewContextMenuDisabled)
         return;
 
@@ -1451,11 +1471,11 @@ typedef enum
     }
     if (selectedObjects.count == 1)
     {
-        [self showContextMenu:validPoints[0] selectedObject:selectedObjects[0]];
+        [self presentContextMenu:validPoints[0] selectedObject:selectedObjects[0]];
     }
     else if (validPoints.count == 1)
     {
-        [self showContextMenu:validPoints[0] selectedObject:validSelectedObjects ? validSelectedObjects[0] : nil];
+        [self presentContextMenu:validPoints[0] selectedObject:validSelectedObjects ? validSelectedObjects[0] : nil];
     }
     else
     {
@@ -1489,14 +1509,16 @@ typedef enum
 
 - (void)showContextMenu:(OATargetPoint *)targetPoint saveState:(BOOL)saveState preferredZoom:(float)preferredZoom
 {
-    [self showContextMenu:targetPoint saveState:saveState preferredZoom:preferredZoom selectedObject:nil];
+    __weak __typeof(self) weakSelf = self;
+    [self enqueueContextMenuPresentation:^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf)
+            [strongSelf presentContextMenu:targetPoint saveState:saveState preferredZoom:preferredZoom selectedObject:nil];
+    }];
 }
 
-- (void)showContextMenu:(OATargetPoint *)targetPoint saveState:(BOOL)saveState preferredZoom:(float)preferredZoom selectedObject:(SelectedMapObject *)selectedObject
+- (void)presentContextMenu:(OATargetPoint *)targetPoint saveState:(BOOL)saveState preferredZoom:(float)preferredZoom selectedObject:(SelectedMapObject *)selectedObject
 {
-    if (_activeTargetType == OATargetGPX)
-        [self hideScrollableHudViewController];
-
     if (self.isNewContextMenuDisabled)
         return;
 
@@ -1638,6 +1660,16 @@ typedef enum
 
 - (void) showContextMenu:(OATargetPoint *)targetPoint selectedObject:(SelectedMapObject *)selectedObject
 {
+    __weak __typeof(self) weakSelf = self;
+    [self enqueueContextMenuPresentation:^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf)
+            [strongSelf presentContextMenu:targetPoint selectedObject:selectedObject];
+    }];
+}
+
+- (void)presentContextMenu:(OATargetPoint *)targetPoint selectedObject:(SelectedMapObject *)selectedObject
+{
     if (targetPoint.type == OATargetGPX)
     {
         OASTrackItem *trackItem;
@@ -1682,7 +1714,7 @@ typedef enum
     }
     else
     {
-        [self showContextMenu:targetPoint saveState:YES preferredZoom:PREFERRED_FAVORITE_ZOOM selectedObject:selectedObject];
+        [self presentContextMenu:targetPoint saveState:YES preferredZoom:PREFERRED_FAVORITE_ZOOM selectedObject:selectedObject];
     }
 }
 
@@ -2791,9 +2823,6 @@ typedef enum
             }
         }
         
-        if (onComplete)
-            onComplete();
-
         if (_prevScrollableHudViewController)
         {
             [self showScrollableHudViewController:_prevScrollableHudViewController];
@@ -2803,6 +2832,9 @@ typedef enum
         {
             [_hudViewController updateDependentButtonsVisibility];
         }
+
+        if (onComplete)
+            onComplete();
     }];
     
     [_hudViewController updateControlsLayout:YES];
@@ -3136,17 +3168,78 @@ typedef enum
                         state:(OATrackMenuViewControllerState *)state
                      analysis:(nullable OASGpxTrackAnalysis *)analysis;
 {
+    __weak __typeof(self) weakSelf = self;
+    [self enqueueContextMenuPresentation:^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+
+        if (!state.openedFromTrackMenu)
+            state.navControllerHistory = nil;
+
+        [strongSelf doShowGpxItem:item items:items routeKey:routeKey state:state trackHudMode:trackHudMode analysis:analysis];
+    }];
+}
+
+- (void)enqueueContextMenuPresentation:(void (^)(void))presentation
+{
+    _pendingContextMenuPresentation = [presentation copy];
+    [self processPendingContextMenuPresentation];
+}
+
+- (void)processPendingContextMenuPresentation
+{
+    if (_contextMenuTransitionInProgress || !_pendingContextMenuPresentation)
+        return;
+
     if (_scrollableHudViewController)
     {
-        [_scrollableHudViewController hide:YES duration:0.2 onComplete:^{
-            if (!state.openedFromTrackMenu)
-                state.navControllerHistory = nil;
+        _contextMenuTransitionInProgress = YES;
+        __weak __typeof(self) weakSelf = self;
+        [_scrollableHudViewController forceHideWithCompletion:^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf)
+                return;
 
-            [self doShowGpxItem:item items:items routeKey:routeKey state:state trackHudMode:trackHudMode analysis:analysis];
+            strongSelf->_contextMenuTransitionInProgress = NO;
+            [strongSelf processPendingContextMenuPresentation];
         }];
         return;
     }
-    [self doShowGpxItem:item items:items routeKey:routeKey state:state trackHudMode:trackHudMode analysis:analysis];
+
+    if (self.targetMultiMenuView.superview)
+    {
+        _contextMenuTransitionInProgress = YES;
+        __weak __typeof(self) weakSelf = self;
+        [self.targetMultiMenuView hide:YES duration:0.2 onComplete:^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf)
+                return;
+
+            strongSelf->_contextMenuTransitionInProgress = NO;
+            [strongSelf processPendingContextMenuPresentation];
+        }];
+        return;
+    }
+
+    if (self.targetMenuView.superview)
+    {
+        _contextMenuTransitionInProgress = YES;
+        __weak __typeof(self) weakSelf = self;
+        [self hideTargetPointMenu:0.2 onComplete:^{
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf)
+                return;
+
+            strongSelf->_contextMenuTransitionInProgress = NO;
+            [strongSelf processPendingContextMenuPresentation];
+        }];
+        return;
+    }
+
+    void (^presentation)(void) = _pendingContextMenuPresentation;
+    _pendingContextMenuPresentation = nil;
+    presentation();
 }
 
 - (void)doShowGpxItem:(OASTrackItem *)item
@@ -3158,8 +3251,7 @@ typedef enum
 {
     BOOL showCurrentTrack = item.isShowCurrentTrack;
 
-    [self hideMultiMenuIfNeeded];
-    [self hideTargetPointMenu];
+    [_mapViewController hidePolygonHighlight];
     
     if (_dashboard)
         [self closeDashboard];

--- a/Sources/Controllers/Panels/OAMapPanelViewController.mm
+++ b/Sources/Controllers/Panels/OAMapPanelViewController.mm
@@ -1422,7 +1422,7 @@ typedef enum
 
 - (void) showContextMenuWithPoints:(NSArray<OATargetPoint *> *)targetPoints selectedObjects:(nullable NSArray<SelectedMapObject *> *)selectedObjects touchPointLatLon:(nullable CLLocation *)touchPointLatLon
 {
-    if (self.isNewContextMenuDisabled)
+    if (!self.canPresentNewContextMenu)
         return;
 
     __weak __typeof(self) weakSelf = self;
@@ -1435,7 +1435,7 @@ typedef enum
 
 - (void)presentContextMenuWithPoints:(NSArray<OATargetPoint *> *)targetPoints selectedObjects:(nullable NSArray<SelectedMapObject *> *)selectedObjects touchPointLatLon:(nullable CLLocation *)touchPointLatLon
 {
-    if (self.isNewContextMenuDisabled)
+    if (!self.canPresentNewContextMenu)
         return;
 
     [self.hudViewController hideWeatherToolbarIfNeeded];
@@ -1508,9 +1508,14 @@ typedef enum
     || _activeTargetType == OATargetMapModeParametersSettings;
 }
 
+- (BOOL)canPresentNewContextMenu
+{
+    return !self.isNewContextMenuDisabled || _activeTargetType == OATargetGPX;
+}
+
 - (void)showContextMenu:(OATargetPoint *)targetPoint saveState:(BOOL)saveState preferredZoom:(float)preferredZoom
 {
-    if (self.isNewContextMenuDisabled)
+    if (!self.canPresentNewContextMenu)
         return;
 
     __weak __typeof(self) weakSelf = self;
@@ -1523,7 +1528,7 @@ typedef enum
 
 - (void)presentContextMenu:(OATargetPoint *)targetPoint saveState:(BOOL)saveState preferredZoom:(float)preferredZoom selectedObject:(SelectedMapObject *)selectedObject
 {
-    if (self.isNewContextMenuDisabled)
+    if (!self.canPresentNewContextMenu)
         return;
 
     NSLog(@"[ContextMenu] Target setup BEGIN targetType=%ld object=%@",
@@ -1666,6 +1671,9 @@ typedef enum
 
 - (void) showContextMenu:(OATargetPoint *)targetPoint selectedObject:(SelectedMapObject *)selectedObject
 {
+    if (!self.canPresentNewContextMenu)
+        return;
+
     __weak __typeof(self) weakSelf = self;
     [self enqueueContextMenuPresentation:^{
         __strong __typeof(weakSelf) strongSelf = weakSelf;
@@ -1676,6 +1684,9 @@ typedef enum
 
 - (void)presentContextMenu:(OATargetPoint *)targetPoint selectedObject:(SelectedMapObject *)selectedObject
 {
+    if (!self.canPresentNewContextMenu)
+        return;
+
     if (targetPoint.type == OATargetGPX)
     {
         OASTrackItem *trackItem;
@@ -3174,13 +3185,13 @@ typedef enum
                         state:(OATrackMenuViewControllerState *)state
                      analysis:(nullable OASGpxTrackAnalysis *)analysis;
 {
-    BOOL shouldClearNavControllerHistory = _scrollableHudViewController && !state.openedFromTrackMenu;
     __weak __typeof(self) weakSelf = self;
     [self enqueueContextMenuPresentation:^{
         __strong __typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf)
             return;
 
+        BOOL shouldClearNavControllerHistory = strongSelf->_scrollableHudViewController && !state.openedFromTrackMenu;
         if (shouldClearNavControllerHistory)
             state.navControllerHistory = nil;
 
@@ -3198,23 +3209,23 @@ typedef enum
 {
     __weak __typeof(self) weakSelf = self;
     [_contextMenuPresentationCoordinator processPendingPresentationWithDismissHandlers:@[
-        ^BOOL(dispatch_block_t completion) {
+        [[ContextMenuDismissHandler alloc] initWithHandler:^BOOL(dispatch_block_t completion) {
             __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf || !strongSelf->_scrollableHudViewController)
                 return NO;
 
             [strongSelf->_scrollableHudViewController hide:YES duration:0.2 onComplete:completion];
             return YES;
-        },
-        ^BOOL(dispatch_block_t completion) {
+        }],
+        [[ContextMenuDismissHandler alloc] initWithHandler:^BOOL(dispatch_block_t completion) {
             __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf || !strongSelf.targetMultiMenuView.superview)
                 return NO;
 
             [strongSelf.targetMultiMenuView hide:YES duration:0.2 onComplete:completion];
             return YES;
-        },
-        ^BOOL(dispatch_block_t completion) {
+        }],
+        [[ContextMenuDismissHandler alloc] initWithHandler:^BOOL(dispatch_block_t completion) {
             __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf || !strongSelf.targetMenuView.superview)
                 return NO;
@@ -3222,7 +3233,7 @@ typedef enum
             strongSelf->_prevScrollableHudViewController = nil;
             [strongSelf hideTargetPointMenu:0.2 onComplete:completion hideActiveTarget:YES mapGestureAction:NO];
             return YES;
-        },
+        }],
     ]];
 }
 

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -23,6 +23,18 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         .lightContent
     }
 
+    override var currentState: EOADraggableMenuState {
+        sheetState
+    }
+
+    var mapViewportBounds: CGRect {
+        let bounds = view.bounds
+        let minY = bounds.minY + getNavbarHeight()
+        let sheetHeight = height(for: sheetState)
+        let maxY = max(minY, bounds.maxY - sheetHeight)
+        return CGRect(x: bounds.minX, y: minY, width: bounds.width, height: maxY - minY)
+    }
+
     private let dataProvider: PlanRouteDataProvider
 
     private let sheetView = UIView()
@@ -80,14 +92,6 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         return view.bounds.height
     }
 
-    var mapViewportBounds: CGRect {
-        let bounds = view.bounds
-        let minY = bounds.minY + getNavbarHeight()
-        let sheetHeight = height(for: sheetState)
-        let maxY = max(minY, bounds.maxY - sheetHeight)
-        return CGRect(x: bounds.minX, y: minY, width: bounds.width, height: maxY - minY)
-    }
-
     init(dataProvider: PlanRouteDataProvider) {
         self.dataProvider = dataProvider
         sheetState = dataProvider.mode.isNewRoute ? .initial : .expanded
@@ -96,10 +100,6 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        dayNightObserver?.detach()
     }
 
     @objc static func showNewRoute() {
@@ -262,8 +262,12 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
     }
 
     override func forceHide() {
+        forceHide(completion: nil)
+    }
+
+    override func forceHide(completion onComplete: (() -> Void)?) {
         isForceHiding = true
-        hide(false, duration: 0, onComplete: nil)
+        hide(false, duration: 0, onComplete: onComplete)
     }
 
     override func hide(_ animated: Bool, duration: TimeInterval, onComplete: (() -> Void)?) {
@@ -292,10 +296,6 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         false
     }
     
-    override var currentState: EOADraggableMenuState {
-        sheetState
-    }
-
     func reloadData() {
         let routeInfo = dataProvider.routeInfo
         topPartView.configure(with: routeInfo, isCalculatingRoute: dataProvider.isCalculatingRoute)
@@ -650,10 +650,9 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         presentApproximationWarning(force: false)
     }
 
-    @discardableResult
-    private func presentApproximationWarning(force: Bool) -> Bool {
+    @discardableResult private func presentApproximationWarning(force: Bool) -> Bool {
         if approximationNavigationController != nil { return true }
-        guard (force || dataProvider.shouldShowApproximationWarning),
+        guard force || dataProvider.shouldShowApproximationWarning,
               let warningViewController = dataProvider.approximationWarningViewController else { return false }
         let navigationController = UINavigationController(rootViewController: warningViewController)
         navigationController.setNavigationBarHidden(true, animated: false)
@@ -1158,6 +1157,10 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         default:
             break
         }
+    }
+
+    deinit {
+        dayNightObserver?.detach()
     }
 }
 

--- a/Sources/Controllers/TargetMenu/GPX/OAGPXWptViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/OAGPXWptViewController.mm
@@ -65,6 +65,7 @@ static const NSInteger kOrderWptPointLinkRow = 2;
         self.topToolbarType = ETopToolbarTypeMiddleFixed;
         self.leftControlButton = [[OATargetMenuControlButton alloc] init];
         self.leftControlButton.title = OALocalizedString(@"shared_string_open_track");
+        self.leftControlButton.accessibilityIdentifier = UITestAccessibilityIdentifier.gpxWaypointOpenTrackButton;
     }
     return self;
 }

--- a/Sources/Controllers/TargetMenu/GPX/OAGPXWptViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/OAGPXWptViewController.mm
@@ -50,9 +50,11 @@ static const NSInteger kOrderWptPointLinkRow = 2;
     if (self)
     {
         _app = [OsmAndApp instance];
-        if (!wpt.docPath)
+        if (wpt.docPath.length == 0)
         {
-            wpt.docPath = [[OASelectedGPXHelper instance] getSelectedGpx:wpt.point].path;
+            OASGpxFile *selectedGpx = [[OASelectedGPXHelper instance] getSelectedGpx:wpt.point];
+            if (selectedGpx && !selectedGpx.isShowCurrentTrack)
+                wpt.docPath = selectedGpx.path;
         }
         self.wpt = wpt;
         NSDictionary<NSString *, NSString *> *extensions = [self.wpt.point getExtensionsToRead];
@@ -144,7 +146,7 @@ static const NSInteger kOrderWptPointLinkRow = 2;
 - (void) buildWaypointsView:(NSMutableArray<OAAmenityInfoRow *> *)rows
 {
     NSString *name = OALocalizedString(@"context_menu_points_of_group");
-    NSString *gpxName = self.wpt.docPath == nil ? OALocalizedString(@"shared_string_currently_recording_track") : [self.wpt.docPath.lastPathComponent stringByDeletingPathExtension];
+    NSString *gpxName = self.wpt.docPath.length == 0 ? OALocalizedString(@"shared_string_currently_recording_track") : [self.wpt.docPath.lastPathComponent stringByDeletingPathExtension];
     UIColor *color = [self getItemColor];
     UIImage *icon = [UIImage templateImageNamed:@"ic_custom_folder"];
     
@@ -260,15 +262,27 @@ static const NSInteger kOrderWptPointLinkRow = 2;
 
 - (void) leftControlButtonPressed
 {
-    OASGpxDataItem *gpx = [[OAGPXDatabase sharedDb] getGPXItem:[OAUtilities getGpxShortPath:self.wpt.docPath]];
-    OAMapPanelViewController *mapPanel = [OARootViewController instance].mapPanel;
-    [mapPanel targetHideMenu:0 backButtonClicked:YES onComplete:^{
+    OASTrackItem *trackItem = nil;
+    if (self.wpt.docPath.length > 0)
+    {
+        OASGpxDataItem *gpx = [[OAGPXDatabase sharedDb] getGPXItem:[OAUtilities getGpxShortPath:self.wpt.docPath]];
         if (gpx)
         {
-            auto trackItem = [[OASTrackItem alloc] initWithFile:gpx.file];
+            trackItem = [[OASTrackItem alloc] initWithFile:gpx.file];
             trackItem.dataItem = gpx;
-            [mapPanel openTargetViewWithGPX:trackItem selectedTab:EOATrackMenuHudOverviewTab selectedStatisticsTab:EOATrackMenuHudSegmentsStatisticsOverviewTab openedFromMap:YES];
         }
+    }
+    else
+    {
+        OASGpxFile *selectedGpx = [[OASelectedGPXHelper instance] getSelectedGpx:self.wpt.point];
+        if (selectedGpx.isShowCurrentTrack)
+            trackItem = [[OASTrackItem alloc] initWithGpxFile:selectedGpx];
+    }
+
+    OAMapPanelViewController *mapPanel = [OARootViewController instance].mapPanel;
+    [mapPanel targetHideMenu:0 backButtonClicked:YES onComplete:^{
+        if (trackItem)
+            [mapPanel openTargetViewWithGPX:trackItem selectedTab:EOATrackMenuHudOverviewTab selectedStatisticsTab:EOATrackMenuHudSegmentsStatisticsOverviewTab openedFromMap:YES];
     }];
 }
 

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHeaderView.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHeaderView.mm
@@ -142,6 +142,7 @@
     if (_selectedTab != EOATrackMenuHudActionsTab)
     {
         [self.titleView setText:currentTrack ? OALocalizedString(@"shared_string_currently_recording_track") : title];
+        self.titleView.accessibilityIdentifier = UITestAccessibilityIdentifier.gpxTrackMenuTitle;
         self.titleIconView.image = icon;
         self.titleIconView.tintColor = [UIColor colorNamed:ACColorNameIconColorSecondary];
     }

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
@@ -701,6 +701,8 @@
         for (OASWptPt *gpxWpt in self.doc.getPointsList)
         {
             OAGpxWptItem *gpxWptItem = [OAGpxWptItem withGpxWpt:gpxWpt];
+            if (!self.isCurrentTrack)
+                gpxWptItem.docPath = self.doc.path;
             if (gpxWpt.category.length == 0)
             {
                 NSMutableArray<OAGpxWptItem *> *withoutGroup = _waypointGroups[OALocalizedString(@"shared_string_gpx_points")];
@@ -737,6 +739,8 @@
         for (OASWptPt *rtePt in [self.doc getRoutePoints])
         {
             OAGpxWptItem *rtePtItem = [OAGpxWptItem withGpxWpt:rtePt];
+            if (!self.isCurrentTrack)
+                rtePtItem.docPath = self.doc.path;
             rtePtItem.routePoint = YES;
             NSMutableArray<OAGpxWptItem *> *rtePtsGroup = _waypointGroups[OALocalizedString(@"route_points")];
             if (!rtePtsGroup)

--- a/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
+++ b/Sources/Controllers/TargetMenu/GPX/TrackMenu/OATrackMenuHudViewController.mm
@@ -2549,6 +2549,7 @@
                 cell.directionIconView.image = [UIImage templateImageNamed:@"ic_small_direction"];
                 cell.directionIconView.tintColor = UIColorFromRGB(color_active_light);
             }
+            cell.accessibilityIdentifier = [UITestAccessibilityIdentifier gpxTrackMenuWaypoint:cellData.title];
         }
         outCell = cell;
     }

--- a/Sources/Controllers/TargetMenu/OATargetMenuViewController.h
+++ b/Sources/Controllers/TargetMenu/OATargetMenuViewController.h
@@ -67,6 +67,7 @@ typedef void (^ContentHeightChangeListenerBlock)(CGFloat newHeight);
 @interface OATargetMenuControlButton : NSObject
 
 @property (nonatomic) NSString *title;
+@property (nonatomic, nullable) NSString *accessibilityIdentifier;
 @property (nonatomic) BOOL disabled;
 
 @end

--- a/Sources/Controllers/TargetMenu/Transport/OATransportRouteController.mm
+++ b/Sources/Controllers/TargetMenu/Transport/OATransportRouteController.mm
@@ -291,8 +291,9 @@ static OATransportRouteToolbarViewController *toolbarController;
     toolbarController = nil;
 }
 
-- (void) onMenuSwipedOff
+- (void)onMenuDismissed
 {
+    [super onMenuDismissed];
     [self.class hideToolbar];
     
     OAMapPanelViewController *mapPanel = [OARootViewController instance].mapPanel;

--- a/Sources/FirstUsage/OAFirstUsageWizardController.mm
+++ b/Sources/FirstUsage/OAFirstUsageWizardController.mm
@@ -144,6 +144,7 @@ typedef enum
     _lbDescription.text = OALocalizedString(@"first_usage_wizard_desc");
     _lbDescription.font = [UIFont scaledSystemFontOfSize:14.];
     [_btnSkip setTitle:OALocalizedString(@"skip_download") forState:UIControlStateNormal];
+    _btnSkip.accessibilityIdentifier = @"first_usage_skip_download_button";
     _btnSkip.titleLabel.font = [UIFont scaledSystemFontOfSize:14.];
     
     // Init no location view
@@ -266,6 +267,7 @@ typedef enum
     [items addObject:flexibleSpaceItem];
     
     UIBarButtonItem *skipDownloadButtonItem = [[UIBarButtonItem alloc] initWithTitle:OALocalizedString(@"skip_download") style:UIBarButtonItemStylePlain target:self action:@selector(closeWizard)];
+    skipDownloadButtonItem.accessibilityIdentifier = @"first_usage_skip_download_button";
     [skipDownloadButtonItem setTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys: [UIColor colorNamed:ACColorNameTextColorActive], NSForegroundColorAttributeName,nil] forState:UIControlStateNormal];
     [items addObject:skipDownloadButtonItem];
 

--- a/Sources/Helpers/AppEnvironment/AppEnvironment.swift
+++ b/Sources/Helpers/AppEnvironment/AppEnvironment.swift
@@ -1,0 +1,14 @@
+//
+//  AppEnvironment.swift
+//  OsmAnd Maps
+//
+//  Created by Oleksandr Panchenko on 02.09.2026.
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+@objcMembers
+final class AppEnvironment: NSObject {
+    static var isUITesting: Bool {
+        ProcessInfo.processInfo.arguments.contains("-ui-testing")
+    }
+}

--- a/Sources/Helpers/UITests/UITestAccessibilityIdentifier.swift
+++ b/Sources/Helpers/UITests/UITestAccessibilityIdentifier.swift
@@ -1,0 +1,58 @@
+//
+//  UITestAccessibilityIdentifier.swift
+//  OsmAnd Maps
+//
+//  Created by Oleksandr Panchenko on 03.09.2026.
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+@objcMembers
+final class UITestAccessibilityIdentifier: NSObject {
+    static var firstUsageSkipDownloadButton: String {
+        "first_usage_skip_download_button"
+    }
+
+    enum ContextMenu {
+        static let container = "context_menu_container"
+        static let multiContainer = "multi_context_menu_container"
+        static let presentationState = "context_menu_presentation_test_state"
+
+        enum GPX {
+            static let trackMenuTitle = "gpx_track_menu_title"
+            static let waypointPrefix = "gpx_track_menu_waypoint_"
+            static let waypointOpenTrackButton = "gpx_waypoint_open_track_button"
+
+            static func waypoint(_ title: String) -> String {
+                waypointPrefix + title
+            }
+        }
+    }
+
+    static var contextMenuContainer: String {
+        ContextMenu.container
+    }
+
+    static var multiContextMenuContainer: String {
+        ContextMenu.multiContainer
+    }
+
+    static var contextMenuPresentationState: String {
+        ContextMenu.presentationState
+    }
+
+    static var gpxTrackMenuTitle: String {
+        ContextMenu.GPX.trackMenuTitle
+    }
+
+    static var gpxTrackMenuWaypointPrefix: String {
+        ContextMenu.GPX.waypointPrefix
+    }
+
+    static var gpxWaypointOpenTrackButton: String {
+        ContextMenu.GPX.waypointOpenTrackButton
+    }
+
+    static func gpxTrackMenuWaypoint(_ title: String) -> String {
+        ContextMenu.GPX.waypoint(title)
+    }
+}

--- a/Sources/Helpers/UITests/UITestAccessibilityIdentifier.swift
+++ b/Sources/Helpers/UITests/UITestAccessibilityIdentifier.swift
@@ -8,9 +8,6 @@
 
 @objcMembers
 final class UITestAccessibilityIdentifier: NSObject {
-    static var firstUsageSkipDownloadButton: String {
-        "first_usage_skip_download_button"
-    }
 
     enum ContextMenu {
         static let container = "context_menu_container"

--- a/Sources/Helpers/UITests/UITestState.swift
+++ b/Sources/Helpers/UITests/UITestState.swift
@@ -1,0 +1,54 @@
+//
+//  UITestState.swift
+//  OsmAnd Maps
+//
+//  Created by Oleksandr Panchenko on 03.09.2026.
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+@objcMembers
+final class UITestState: NSObject {
+    enum LaunchArgument {
+        enum ContextMenu {
+            static let presentationRace = "-ui-testing-context-menu-presentation-race"
+            static let gpxWaypointOpenTrack = "-ui-testing-gpx-waypoint-open-track"
+        }
+    }
+
+    static var isContextMenuPresentationRaceEnabled: Bool {
+        AppEnvironment.isUITesting && hasLaunchArgument(LaunchArgument.ContextMenu.presentationRace)
+    }
+
+    static var isGpxWaypointOpenTrackEnabled: Bool {
+        AppEnvironment.isUITesting && hasLaunchArgument(LaunchArgument.ContextMenu.gpxWaypointOpenTrack)
+    }
+
+    private static var contextMenuPresentationRaceFixtureStarted = false
+    private static var gpxWaypointOpenTrackFixtureStarted = false
+
+    static func shouldRunContextMenuPresentationRaceFixture() -> Bool {
+        shouldRunFixture(
+            isEnabled: isContextMenuPresentationRaceEnabled,
+            started: &contextMenuPresentationRaceFixtureStarted
+        )
+    }
+
+    static func shouldRunGpxWaypointOpenTrackFixture() -> Bool {
+        shouldRunFixture(
+            isEnabled: isGpxWaypointOpenTrackEnabled,
+            started: &gpxWaypointOpenTrackFixtureStarted
+        )
+    }
+
+    private static func hasLaunchArgument(_ argument: String) -> Bool {
+        ProcessInfo.processInfo.arguments.contains(argument)
+    }
+
+    private static func shouldRunFixture(isEnabled: Bool, started: inout Bool) -> Bool {
+        guard isEnabled, !started else {
+            return false
+        }
+        started = true
+        return true
+    }
+}

--- a/Sources/Views/OATargetPointView.mm
+++ b/Sources/Views/OATargetPointView.mm
@@ -935,6 +935,7 @@ static const NSInteger _buttonsCount = 4;
 - (void) hide:(BOOL)animated duration:(NSTimeInterval)duration onComplete:(void (^)(void))onComplete
 {
     _hiding = YES;
+    OATargetMenuViewController *customController = self.customController;
     [self.menuViewDelegate contextMenuDidHide];
     [[OARootViewController instance].mapPanel.hudViewController updateControlsLayout:YES];
     
@@ -972,11 +973,12 @@ static const NSInteger _buttonsCount = 4;
                 
                 [self removeFromSuperview];
 
-                if (self.menuViewDelegate && self.customController && self.customController.needsMapRuler)
+                if (self.menuViewDelegate && customController && customController.needsMapRuler)
                     [self.menuViewDelegate targetResetRulerPosition];
 
-                [self clearCustomControllerIfNeeded];
                 [self restoreTargetType];
+                [customController onMenuDismissed];
+                [self clearCustomControllerIfNeeded];
 
                 if (onComplete)
                     onComplete();
@@ -991,11 +993,12 @@ static const NSInteger _buttonsCount = 4;
             
             [self removeFromSuperview];
             
-            if (self.menuViewDelegate && self.customController && self.customController.needsMapRuler)
+            if (self.menuViewDelegate && customController && customController.needsMapRuler)
                 [self.menuViewDelegate targetResetRulerPosition];
-            
-            [self clearCustomControllerIfNeeded];
+
             [self restoreTargetType];
+            [customController onMenuDismissed];
+            [self clearCustomControllerIfNeeded];
 
             if (onComplete)
                 onComplete();
@@ -1007,9 +1010,7 @@ static const NSInteger _buttonsCount = 4;
     {
         _hiding = NO;
     }
-    if (self.customController)
-        [self.customController onMenuDismissed];
-    
+
     [self stopLocationUpdate];
 }
 

--- a/Sources/Views/OATargetPointView.mm
+++ b/Sources/Views/OATargetPointView.mm
@@ -1647,11 +1647,20 @@ static const NSInteger _buttonsCount = 4;
     if (self.customController)
     {
         if (self.customController.leftControlButton)
+        {
             [_controlButtonLeft setTitle:self.customController.leftControlButton.title forState:UIControlStateNormal];
+            _controlButtonLeft.accessibilityIdentifier = self.customController.leftControlButton.accessibilityIdentifier;
+        }
         if (self.customController.rightControlButton)
+        {
             [_controlButtonRight setTitle:self.customController.rightControlButton.title forState:UIControlStateNormal];
+            _controlButtonRight.accessibilityIdentifier = self.customController.rightControlButton.accessibilityIdentifier;
+        }
         if (self.customController.downloadControlButton)
+        {
             [_controlButtonDownload setTitle:self.customController.downloadControlButton.title forState:UIControlStateNormal];
+            _controlButtonDownload.accessibilityIdentifier = self.customController.downloadControlButton.accessibilityIdentifier;
+        }
         
         if ([self.customController isKindOfClass:OAFavoriteViewController.class])
         {
@@ -2376,7 +2385,10 @@ static const NSInteger _buttonsCount = 4;
 - (void) contentChanged
 {
     if (![_controlButtonDownload.titleLabel.text isEqualToString:self.customController.downloadControlButton.title])
+    {
         [_controlButtonDownload setTitle:self.customController.downloadControlButton.title forState:UIControlStateNormal];
+        _controlButtonDownload.accessibilityIdentifier = self.customController.downloadControlButton.accessibilityIdentifier;
+    }
 
     [self doLayoutSubviews:YES];
 }


### PR DESCRIPTION
## Related issue / task

Fixes # https://github.com/osmandapp/OsmAnd-Issues/issues/3307

## Summary

* Fixed a race condition when rapidly switching between POI, GPX, and multi-context menus.
* Added a shared context-menu presentation coordinator.
* New menu presentations now wait until the current menu is fully dismissed.
* While a transition is in progress, only the latest presentation request is retained.
* Added cleanup for stale polygon highlighting and transport-route UI state.
* Preserved the existing GPX track navigation-history behavior.
* Added unit and UI test coverage for context-menu presentation transitions.

## Testing

**Tested on:**

* Device / Simulator: iPhone 16 Pro Simulator
* iOS: 18.6

### Scenarios

* Rapidly switch between POI and different GPX tracks.
* Open a multi-context menu while another context menu is being dismissed.
* Verify that only the latest queued context menu is presented.
* Verify that regular and multi-context menus do not overlap.
* Open a waypoint from the current track menu and use **Open track**.
* Verify that the current track menu is restored correctly.

## Relevant checks

* [ ] Portrait / Landscape tested
* [ ] Light / Dark mode tested
* [ ] Different profiles tested
* [ ] Localization / RTL checked
* [ ] VoiceOver / Accessibility checked
* [ ] CarPlay checked
* [ ] Android parity checked
* [x] Performance impact checked

## AI disclaimer

**Implementation:**

* Tool / Agent: Codex
* Model: GPT-5.6 Sol

**Prompts used (summarised):**

1. Analyze the context-menu overlap race when rapidly switching between POI, GPX, and multi-context menus.
2. Fix presentation ordering so a new context menu is shown only after the previous one is fully dismissed.
3. Preserve existing GPX track navigation behavior and related menu cleanup.
4. Add automated coverage for the context-menu presentation race.
5. Add UI tests and configure them to run in CI.

**Decided by the agent, not requested explicitly:**

* Introduced a shared `ContextMenuPresentationCoordinator` instead of duplicating transition handling across individual presentation paths.
* Used a latest-request-wins strategy while a menu dismissal is in progress.
* Added dedicated UI-test launch arguments and accessibility identifiers for deterministic test scenarios.
* Added unit tests for coordinator state transitions in addition to UI tests.

**Final review:**

* Tool / Agent: ChatGPT
* Model: GPT-5.6 Sol
* [x] Final diff reviewed

**Significant findings:**

* Reviewed navigation-history restoration when replacing GPX track menus.
* Reviewed dismissal completion ordering and transport-route cleanup.
* Reviewed stale polygon-highlight handling.
* Reviewed UI-test coverage for queued menu presentation and current-track waypoint flow.
