### PR TITLE
Fix Quick Action ignoring predefined appearance for Add Waypoint/Favorite

### DIFF
--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -694,6 +694,7 @@
 		462148722B6BEF44003DA10C /* CloudTrashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462148712B6BEF44003DA10C /* CloudTrashViewController.swift */; };
 		46220B702AD6D6F2006C3248 /* OABaseEditorViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46220B6F2AD6D6F2006C3248 /* OABaseEditorViewController.mm */; };
 		46220B792AD70AF9006C3248 /* OAGroupEditorViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46220B782AD70AF9006C3248 /* OAGroupEditorViewController.mm */; };
+		C561F061C54B4D79BDBC3A62 /* OAQuickActionAppearanceViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7CB226EAEF254763967C4EA9 /* OAQuickActionAppearanceViewController.mm */; };
 		462545A828D3688900637964 /* ic_custom_cross_buy_colored_day@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 462545A428D3688700637964 /* ic_custom_cross_buy_colored_day@2x.png */; };
 		462545A928D3688900637964 /* ic_custom_cross_buy_colored_day_big@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 462545A528D3688700637964 /* ic_custom_cross_buy_colored_day_big@3x.png */; };
 		462545AA28D3688900637964 /* ic_custom_cross_buy_colored_day_big@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 462545A628D3688800637964 /* ic_custom_cross_buy_colored_day_big@2x.png */; };
@@ -4528,6 +4529,8 @@
 		46220B6F2AD6D6F2006C3248 /* OABaseEditorViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OABaseEditorViewController.mm; sourceTree = "<group>"; };
 		46220B772AD70A7B006C3248 /* OAGroupEditorViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAGroupEditorViewController.h; sourceTree = "<group>"; };
 		46220B782AD70AF9006C3248 /* OAGroupEditorViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OAGroupEditorViewController.mm; sourceTree = "<group>"; };
+		EB0C3423C8E548AB9EF560ED /* OAQuickActionAppearanceViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OAQuickActionAppearanceViewController.h; sourceTree = "<group>"; };
+		7CB226EAEF254763967C4EA9 /* OAQuickActionAppearanceViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OAQuickActionAppearanceViewController.mm; sourceTree = "<group>"; };
 		462545A428D3688700637964 /* ic_custom_cross_buy_colored_day@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ic_custom_cross_buy_colored_day@2x.png"; path = "Resources/Icons/ic_custom_cross_buy_colored_day@2x.png"; sourceTree = "<group>"; };
 		462545A528D3688700637964 /* ic_custom_cross_buy_colored_day_big@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ic_custom_cross_buy_colored_day_big@3x.png"; path = "Resources/Icons/ic_custom_cross_buy_colored_day_big@3x.png"; sourceTree = "<group>"; };
 		462545A628D3688800637964 /* ic_custom_cross_buy_colored_day_big@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ic_custom_cross_buy_colored_day_big@2x.png"; path = "Resources/Icons/ic_custom_cross_buy_colored_day_big@2x.png"; sourceTree = "<group>"; };
@@ -13567,6 +13570,8 @@
 				DA5A7E6426C563A400F274C7 /* OAGpxWptEditingHandler.mm */,
 				46220B772AD70A7B006C3248 /* OAGroupEditorViewController.h */,
 				46220B782AD70AF9006C3248 /* OAGroupEditorViewController.mm */,
+				EB0C3423C8E548AB9EF560ED /* OAQuickActionAppearanceViewController.h */,
+				7CB226EAEF254763967C4EA9 /* OAQuickActionAppearanceViewController.mm */,
 			);
 			path = PointEditing;
 			sourceTree = "<group>";
@@ -18973,6 +18978,7 @@
 				FA1394AD2EB11B2000197297 /* MapHudLayout.swift in Sources */,
 				DA5A846A26C563A900F274C7 /* OADestination.mm in Sources */,
 				46220B792AD70AF9006C3248 /* OAGroupEditorViewController.mm in Sources */,
+				C561F061C54B4D79BDBC3A62 /* OAQuickActionAppearanceViewController.mm in Sources */,
 				C5A466BC2D2E69B6008E0C87 /* ImageHeaderCell.swift in Sources */,
 				C5817F232F5D3C41002526E3 /* CompositeTrackPointsAnalyser.swift in Sources */,
 				DA5A816326C563A700F274C7 /* OADaytimeAppearance.m in Sources */,

--- a/Sources/Controllers/QuickAction/OAActionConfigurationViewController.mm
+++ b/Sources/Controllers/QuickAction/OAActionConfigurationViewController.mm
@@ -18,6 +18,8 @@
 #import "OAEditColorViewController.h"
 #import "OADefaultFavorite.h"
 #import "OAEditGroupViewController.h"
+#import "OAQuickActionAppearanceViewController.h"
+#import "OAGPXAppearanceCollection.h"
 #import "OANativeUtilities.h"
 #import "OsmAndApp.h"
 #import "OASimpleTableViewCell.h"
@@ -48,7 +50,7 @@
 
 #define KEY_MESSAGE @"message"
 
-@interface OAActionConfigurationViewController () <OAEditColorViewControllerDelegate, OAEditGroupViewControllerDelegate, OAAddCategoryDelegate, MGSwipeTableCellDelegate, OAAddMapStyleDelegate, OAAddMapSourceDelegate, OAAddProfileDelegate, MDCMultilineTextInputLayoutDelegate, UITextViewDelegate, OAPoiTypeSelectionDelegate, UIGestureRecognizerDelegate, OAKeyboardHintBarDelegate, ActionAddTerrainColorSchemeDelegate>
+@interface OAActionConfigurationViewController () <OAEditColorViewControllerDelegate, OAEditGroupViewControllerDelegate, OAAddCategoryDelegate, MGSwipeTableCellDelegate, OAAddMapStyleDelegate, OAAddMapSourceDelegate, OAAddProfileDelegate, MDCMultilineTextInputLayoutDelegate, UITextViewDelegate, OAPoiTypeSelectionDelegate, UIGestureRecognizerDelegate, OAKeyboardHintBarDelegate, ActionAddTerrainColorSchemeDelegate, OAEditorDelegate>
 
 @end
 
@@ -65,6 +67,7 @@
 
     OAEditColorViewController *_colorController;
     OAEditGroupViewController *_groupController;
+    OAQuickActionAppearanceViewController *_appearanceController;
     
     UIView *_tableHeaderView;
     OAKeyboardHintBar *_hintView;
@@ -449,11 +452,16 @@
                 cell.leftIconView.layer.cornerRadius = cell.leftIconView.frame.size.height / 2;
                 cell.leftIconView.backgroundColor = color.color;
             }
+            else if ([item[@"key"] isEqualToString:@"category_appearance"])
+            {
+                cell.leftIconView.layer.cornerRadius = cell.leftIconView.frame.size.height / 2;
+                cell.leftIconView.backgroundColor = item[@"appearanceColor"];
+            }
             else
             {
                 [cell leftIconVisibility:NO];
             }
-            
+
             cell.valueLabel.text = item[@"value"];
             cell.valueLabel.textColor = [UIColor colorNamed:ACColorNameTextColorSecondary];
         }
@@ -614,6 +622,15 @@
         _colorController = [[OAEditColorViewController alloc] initWithColor:favCol.color];
         _colorController.delegate = self;
         [self showViewController:_colorController];
+        [self.view endEditing:YES];
+    }
+    else if ([item[@"key"] isEqualToString:@"category_appearance"])
+    {
+        _appearanceController = [[OAQuickActionAppearanceViewController alloc] initWithColor:item[@"appearanceColor"]
+                                                                                       iconName:item[@"appearanceIcon"]
+                                                                             backgroundIconName:item[@"appearanceBackgroundIcon"]];
+        _appearanceController.delegate = self;
+        [self showViewController:_appearanceController];
         [self.view endEditing:YES];
     }
     else if ([item[@"key"] isEqualToString:@"key_category"])
@@ -1093,6 +1110,60 @@
     }
     [_data setObject:[NSArray arrayWithArray:newItems] forKey:key];
     [self.tableView reloadData];
+}
+
+#pragma mark - OAEditorDelegate
+
+- (void)addNewItemWithName:(nullable NSString *)name
+                   iconName:(NSString *)iconName
+                      color:(UIColor *)color
+         backgroundIconName:(NSString *)backgroundIconName
+{
+    NSString *key = _data.allKeys.lastObject;
+    NSArray *items = _data[key];
+    NSMutableArray *newItems = [NSMutableArray new];
+    for (NSDictionary *item in items)
+    {
+        NSMutableDictionary *mutableItem = [NSMutableDictionary dictionaryWithDictionary:item];
+        if ([item[@"key"] isEqualToString:@"category_appearance"])
+        {
+            [mutableItem setObject:color forKey:@"appearanceColor"];
+            [mutableItem setObject:iconName ?: @"" forKey:@"appearanceIcon"];
+            [mutableItem setObject:backgroundIconName ?: @"" forKey:@"appearanceBackgroundIcon"];
+        }
+        else if ([item[@"key"] isEqualToString:@"category_name"])
+        {
+            NSInteger nearestIndex = [[OADefaultFavorite builtinColors] indexOfObject:[OADefaultFavorite nearestFavColor:color]];
+            [mutableItem setObject:@(nearestIndex) forKey:@"color"];
+        }
+        [newItems addObject:[NSDictionary dictionaryWithDictionary:mutableItem]];
+    }
+    [_data setObject:[NSArray arrayWithArray:newItems] forKey:key];
+    [self.tableView reloadData];
+}
+
+- (void)selectColorItem:(OASPaletteItemSolid *)colorItem
+{
+}
+
+- (nullable OASPaletteItemSolid *)addAndGetNewColorItem:(UIColor *)color
+{
+    return [[OAGPXAppearanceCollection sharedInstance] addNewSelectedColor:color] ?: [[OAGPXAppearanceCollection sharedInstance] defaultPointColorItem];
+}
+
+- (void)changeColorItem:(OASPaletteItemSolid *)colorItem withColor:(UIColor *)color
+{
+    [[OAGPXAppearanceCollection sharedInstance] changeColor:colorItem newColor:color];
+}
+
+- (nullable OASPaletteItemSolid *)duplicateColorItem:(OASPaletteItemSolid *)colorItem
+{
+    return [[OAGPXAppearanceCollection sharedInstance] duplicateColor:colorItem] ?: colorItem;
+}
+
+- (void)deleteColorItem:(OASPaletteItemSolid *)colorItem
+{
+    [[OAGPXAppearanceCollection sharedInstance] deleteColor:colorItem];
 }
 
 #pragma mark - OAAddCategoryDelegate

--- a/Sources/Controllers/TargetMenu/OAEditPointViewController.mm
+++ b/Sources/Controllers/TargetMenu/OAEditPointViewController.mm
@@ -364,9 +364,17 @@
     _appearanceCollection = [OAGPXAppearanceCollection sharedInstance];
     UIColor *selectedColor;
     if (_isNewItemAdding && _editPointType == EOAEditPointTypeFavorite)
+    {
+        // Follow the destination group's existing appearance if it already has one;
+        // otherwise fall through to the color the caller (e.g. a Quick Action) pre-selected.
         selectedColor = [OAFavoritesHelper groupByTrimmedName:[OAFavoriteGroup convertDisplayNameToGroupIdName:self.groupTitle]].color;
+        if (!selectedColor)
+            selectedColor = [_pointHandler getColor];
+    }
     else
+    {
         selectedColor = [_pointHandler getColor];
+    }
     if (!selectedColor)
         selectedColor = [OADefaultFavorite getDefaultColor];
     

--- a/Sources/Controllers/TargetMenu/OAEditPointViewController.mm
+++ b/Sources/Controllers/TargetMenu/OAEditPointViewController.mm
@@ -365,9 +365,12 @@
     UIColor *selectedColor;
     if (_isNewItemAdding && _editPointType == EOAEditPointTypeFavorite)
     {
-        // Follow the destination group's existing appearance if it already has one;
-        // otherwise fall through to the color the caller (e.g. a Quick Action) pre-selected.
-        selectedColor = [OAFavoritesHelper groupByTrimmedName:[OAFavoriteGroup convertDisplayNameToGroupIdName:self.groupTitle]].color;
+        // Follow the destination group's existing appearance only once it actually holds
+        // favorites - a freshly created (still-empty) group only carries a structural
+        // default color, which must not override the color the caller (e.g. a Quick
+        // Action) pre-selected.
+        OAFavoriteGroup *existingGroup = [OAFavoritesHelper groupByTrimmedName:[OAFavoriteGroup convertDisplayNameToGroupIdName:self.groupTitle]];
+        selectedColor = existingGroup.points.count > 0 ? existingGroup.color : nil;
         if (!selectedColor)
             selectedColor = [_pointHandler getColor];
     }

--- a/Sources/Controllers/TargetMenu/PointEditing/OAFavoriteEditingHandler.mm
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAFavoriteEditingHandler.mm
@@ -50,7 +50,16 @@
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         NSString *groupName = [userDefaults objectForKey:kFavoriteDefaultGroupKey] ? [userDefaults stringForKey:kFavoriteDefaultGroupKey] : @"";
 
-        OAFavoriteColor *favCol = [OADefaultFavorite builtinColors].firstObject;
+        OAFavoriteColor *favCol;
+        if ([userDefaults objectForKey:kFavoriteDefaultColorKey])
+        {
+            NSInteger colorIndex = [OADefaultFavorite getValidBuiltInColorNumber:[userDefaults integerForKey:kFavoriteDefaultColorKey]];
+            favCol = [OADefaultFavorite builtinColors][colorIndex];
+        }
+        else
+        {
+            favCol = [OADefaultFavorite builtinColors].firstObject;
+        }
         _favorite = [[OAFavoriteItem alloc] initWithLat:location.latitude
                                                     lon:location.longitude
                                                    name:formattedTitle

--- a/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAGpxWptEditingHandler.mm
@@ -58,7 +58,33 @@
     {
         _gpxFileName = gpxFileName;
         _gpxDocument = gpxFile;
-        UIColor *color = [OADefaultFavorite getDefaultColor];
+        [self commonInit];
+
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        NSString *groupName = [userDefaults objectForKey:kWptDefaultGroupKey] ? [userDefaults stringForKey:kWptDefaultGroupKey] : @"";
+
+        UIColor *color;
+        NSString *iconName = nil;
+        NSString *backgroundType = nil;
+
+        OASGpxUtilitiesPointsGroup *existingGroup = _gpxDocument.pointsGroups[groupName];
+        if (existingGroup)
+        {
+            // Follow the target track's already-defined folder appearance, if present
+            color = UIColorFromARGB(existingGroup.color);
+            iconName = existingGroup.iconName;
+            backgroundType = existingGroup.backgroundType;
+        }
+        else if ([userDefaults objectForKey:kWptDefaultColorKey])
+        {
+            color = UIColorFromARGB((int32_t)[userDefaults integerForKey:kWptDefaultColorKey]);
+            iconName = [userDefaults stringForKey:kWptDefaultIconKey];
+            backgroundType = [userDefaults stringForKey:kWptDefaultBackgroundKey];
+        }
+        else
+        {
+            color = [OADefaultFavorite getDefaultColor];
+        }
 
         OAGpxWptItem *wpt = [[OAGpxWptItem alloc] init];
         OASWptPt* p = [[OASWptPt alloc] init];
@@ -66,22 +92,23 @@
         p.lat = location.latitude;
         p.lon = location.longitude;
         p.time = (long)([[NSDate date] timeIntervalSince1970] * 1000.0);
+        p.category = groupName.length > 0 ? groupName : nil;
         OASInt *colorToSave = [[OASInt alloc] initWithInt:[color toARGBNumber]];
-        
+
         [p setColorColor:colorToSave];
         p.desc = @"";
-        
-        _iconName = nil;
+
+        _iconName = iconName;
         NSString *poiIconName = [self.class getPoiIconName:poi];
         if (poiIconName && poiIconName.length > 0)
             _iconName = poiIconName;
-        
+
         [p setIconNameIconName:_iconName];
-        [p setBackgroundTypeBackType:DEFAULT_ICON_SHAPE_KEY];
+        [p setBackgroundTypeBackType:backgroundType.length > 0 ? backgroundType : DEFAULT_ICON_SHAPE_KEY];
         [p setAddressAddress:address];
         NSDictionary<NSString *, NSString *> *extensions = [poi toTagValue:AMENITY_PREFIX osmPrefix:OSM_PREFIX_KEY];
         [[p getExtensionsToWrite] addEntriesFromDictionary:extensions];
-        
+
         NSString *originName = poi.toStringEn;
         if (originName.length > 0)
             [p setAmenityOriginNameOriginName:originName];
@@ -90,8 +117,6 @@
         wpt.point = p;
 
         _gpxWpt = wpt;
-
-        [self commonInit];
     }
     return self;
 }

--- a/Sources/Controllers/TargetMenu/PointEditing/OAQuickActionAppearanceViewController.h
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAQuickActionAppearanceViewController.h
@@ -1,0 +1,23 @@
+//
+//  OAQuickActionAppearanceViewController.h
+//  OsmAnd Maps
+//
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+#import "OAGroupEditorViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Transient "pick a color/icon/shape" screen reusing the same editor used for
+// Favorite folder "Change / Default appearance", without persisting anything to
+// real storage - used to configure a Quick Action's predefined waypoint appearance.
+@interface OAQuickActionAppearanceViewController : OAGroupEditorViewController
+
+- (nullable instancetype)initWithColor:(UIColor *)color
+                               iconName:(nullable NSString *)iconName
+                     backgroundIconName:(nullable NSString *)backgroundIconName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Controllers/TargetMenu/PointEditing/OAQuickActionAppearanceViewController.mm
+++ b/Sources/Controllers/TargetMenu/PointEditing/OAQuickActionAppearanceViewController.mm
@@ -1,0 +1,69 @@
+//
+//  OAQuickActionAppearanceViewController.mm
+//  OsmAnd Maps
+//
+//  Copyright (c) 2026 OsmAnd. All rights reserved.
+//
+
+#import "OAQuickActionAppearanceViewController.h"
+#import "OsmAndSharedWrapper.h"
+#import "Localization.h"
+#import "OsmAnd_Maps-Swift.h"
+
+@interface OAQuickActionAppearanceViewController ()
+
+@property (nonatomic, readwrite) BOOL isNewItem;
+
+@end
+
+@implementation OAQuickActionAppearanceViewController
+
+@synthesize isNewItem = _isNewItem;
+
+- (nullable instancetype)initWithColor:(UIColor *)color
+                               iconName:(nullable NSString *)iconName
+                     backgroundIconName:(nullable NSString *)backgroundIconName
+{
+    OASGpxUtilitiesPointsGroup *group = [[OASGpxUtilitiesPointsGroup alloc] initWithName:@""
+                                                                                  iconName:iconName
+                                                                            backgroundType:backgroundIconName
+                                                                                     color:(int32_t) [color toARGBNumber]];
+    self = [super initWithGroup:group];
+    if (self)
+        self.isNewItem = YES;
+    return self;
+}
+
+- (NSString *)getTitle
+{
+    return OALocalizedString(@"shared_string_appearance");
+}
+
+- (void)generateDescriptionSection
+{
+    // The Quick Action config screen already has a dedicated "Group" row for the folder name;
+    // this screen only edits color / icon / shape.
+}
+
+- (BOOL)isValidText
+{
+    // There's no name field on this screen (see generateDescriptionSection above), so the
+    // base class's name-validity gate on the Done button doesn't apply here.
+    return YES;
+}
+
+- (void)onRightNavbarButtonPressed
+{
+    [[self getPoiIconCollectionHandler] addIconToLastUsed:self.editIconName];
+    NSString *iconName = self.editIconName;
+    UIColor *color = self.editColor;
+    NSString *backgroundIconName = self.editBackgroundIconName;
+    id<OAEditorDelegate> delegate = self.delegate;
+    [self dismissViewController];
+    [delegate addNewItemWithName:nil
+                         iconName:iconName
+                            color:color
+               backgroundIconName:backgroundIconName];
+}
+
+@end

--- a/Sources/Helpers/OADefaultFavorite.h
+++ b/Sources/Helpers/OADefaultFavorite.h
@@ -16,6 +16,8 @@
 
 #define kWptDefaultColorKey @"WptDefaultColorKey"
 #define kWptDefaultGroupKey @"WptDefaultGroupKey"
+#define kWptDefaultIconKey @"WptDefaultIconKey"
+#define kWptDefaultBackgroundKey @"WptDefaultBackgroundKey"
 
 @interface OAFavoriteColor : NSObject
 

--- a/Sources/QuickAction/Actions/OAGPXAction.mm
+++ b/Sources/QuickAction/Actions/OAGPXAction.mm
@@ -23,11 +23,19 @@
 #import "OAFavoritesHelper.h"
 #import "OrderedDictionary.h"
 #import "Localization.h"
+#import "OAUtilities.h"
 #import "OsmAnd_Maps-Swift.h"
 
 static NSString * const kName = @"name";
 static NSString * const kCategoryName = @"category_name";
 static NSString * const kCategoryColor =  @"category_color";
+static NSString * const kCategoryIcon = @"category_icon";
+static NSString * const kCategoryBackgroundIcon = @"category_background_icon";
+// Full ARGB color chosen via the "Appearance" editor - takes priority over the legacy
+// kCategoryColor (a builtin-palette index) when present, so existing configured buttons
+// keep working while new ones get full custom-color support.
+static NSString * const kCategoryColorArgb = @"category_color_argb";
+static NSString * const kCategoryAppearance = @"category_appearance";
 
 static QuickActionType *TYPE;
 
@@ -78,12 +86,33 @@ static QuickActionType *TYPE;
         [self addWaypointWithDialog:lat lon:lon title:title];
 }
 
+- (UIColor *)resolvedCategoryColor
+{
+    if (self.getParams[kCategoryColorArgb])
+        return UIColorFromARGB([self.getParams[kCategoryColorArgb] intValue]);
+    if (self.getParams[kCategoryColor])
+    {
+        NSInteger defaultColor = [OADefaultFavorite getValidBuiltInColorNumber:[self.getParams[kCategoryColor] integerValue]];
+        OAFavoriteColor *favCol = [OADefaultFavorite builtinColors][defaultColor];
+        return favCol.color;
+    }
+    return [OADefaultFavorite getDefaultColor];
+}
+
 - (void)addWaypointWithDialog:(double)lat lon:(double)lon title:(NSString *)title
 {
-    if (self.getParams[kCategoryColor])
-        [[NSUserDefaults standardUserDefaults] setInteger:[self.getParams[kCategoryColor] integerValue] forKey:kFavoriteDefaultColorKey];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setInteger:(int32_t)[[self resolvedCategoryColor] toARGBNumber] forKey:kWptDefaultColorKey];
     if (self.getParams[kCategoryName])
-        [[NSUserDefaults standardUserDefaults] setObject:self.getParams[kCategoryName] forKey:kFavoriteDefaultGroupKey];
+        [userDefaults setObject:self.getParams[kCategoryName] forKey:kWptDefaultGroupKey];
+    if (self.getParams[kCategoryIcon])
+        [userDefaults setObject:self.getParams[kCategoryIcon] forKey:kWptDefaultIconKey];
+    else
+        [userDefaults removeObjectForKey:kWptDefaultIconKey];
+    if (self.getParams[kCategoryBackgroundIcon])
+        [userDefaults setObject:self.getParams[kCategoryBackgroundIcon] forKey:kWptDefaultBackgroundKey];
+    else
+        [userDefaults removeObjectForKey:kWptDefaultBackgroundKey];
     OAMapPanelViewController *mapPanel = [OARootViewController instance].mapPanel;
     CLLocationCoordinate2D point = CLLocationCoordinate2DMake(lat, lon);
     if ([OAFavoritesHelper hasFavoriteAt:point])
@@ -101,19 +130,8 @@ static QuickActionType *TYPE;
 - (void) addWaypointSilent:(double)lat lon:(double)lon title:(NSString *)title
 {
     NSString *groupName = self.getParams[kCategoryName];
-    UIColor* color;
-    if (self.getParams[kCategoryColor])
-    {
-        NSInteger defaultColor = [OADefaultFavorite getValidBuiltInColorNumber:[self.getParams[kCategoryColor] integerValue]];
-        OAFavoriteColor *favCol = [OADefaultFavorite builtinColors][defaultColor];
-        color = favCol.color;
-    }
-    else
-    {
-        OAFavoriteColor *favCol = [OADefaultFavorite builtinColors].firstObject;
-        color = favCol.color;
-    }
-    
+    UIColor *color = [self resolvedCategoryColor];
+
     OAGpxWptItem* wpt = [[OAGpxWptItem alloc] init];
     OASWptPt *p = [[OASWptPt alloc] init];
     p.name = title;
@@ -121,6 +139,9 @@ static QuickActionType *TYPE;
     p.lon = lon;
     p.category = groupName;
     p.time = (long)([[NSDate date] timeIntervalSince1970] * 1000.0);
+    [p setIconNameIconName:self.getParams[kCategoryIcon]];
+    NSString *backgroundIcon = self.getParams[kCategoryBackgroundIcon];
+    [p setBackgroundTypeBackType:backgroundIcon.length > 0 ? backgroundIcon : DEFAULT_ICON_SHAPE_KEY];
     wpt.point = p;
     wpt.color = color;
     OAMapPanelViewController *mapPanel = [OARootViewController instance].mapPanel;
@@ -180,9 +201,9 @@ static QuickActionType *TYPE;
                           }
                       ] forKey:kSectionNoName];
     
-    NSInteger defaultColor = [OADefaultFavorite getValidBuiltInColorNumber:[self.getParams[kCategoryColor] integerValue]];
-    OAFavoriteColor *color = [OADefaultFavorite builtinColors][defaultColor];
-    
+    UIColor *appearanceColor = [self resolvedCategoryColor];
+    NSInteger defaultColor = [[OADefaultFavorite builtinColors] indexOfObject:[OADefaultFavorite nearestFavColor:appearanceColor]];
+
     [data setObject:@[@{
                           @"type" : [OAValueTableViewCell getCellIdentifier],
                           @"key" : kCategoryName,
@@ -193,10 +214,11 @@ static QuickActionType *TYPE;
                           },
                       @{
                           @"type" : [OAValueTableViewCell getCellIdentifier],
-                          @"key" : kCategoryColor,
-                          @"title" : OALocalizedString(@"shared_string_color"),
-                          @"value" : color ? color.name : @"",
-                          @"color" : @(defaultColor)
+                          @"key" : kCategoryAppearance,
+                          @"title" : OALocalizedString(@"shared_string_appearance"),
+                          @"appearanceColor" : appearanceColor,
+                          @"appearanceIcon" : self.getParams[kCategoryIcon] ?: @"",
+                          @"appearanceBackgroundIcon" : self.getParams[kCategoryBackgroundIcon] ?: @""
                           },
                       @{
                           @"footer" : OALocalizedString(@"quick_action_select_group")
@@ -221,6 +243,14 @@ static QuickActionType *TYPE;
             {
                 [params setValue:item[@"value"] forKey:kCategoryName];
                 [params setValue:item[@"color"] forKey:kCategoryColor];
+            }
+            else if ([item[@"key"] isEqualToString:kCategoryAppearance])
+            {
+                UIColor *appearanceColor = item[@"appearanceColor"];
+                if (appearanceColor)
+                    [params setValue:@((int32_t)[appearanceColor toARGBNumber]) forKey:kCategoryColorArgb];
+                [params setValue:item[@"appearanceIcon"] forKey:kCategoryIcon];
+                [params setValue:item[@"appearanceBackgroundIcon"] forKey:kCategoryBackgroundIcon];
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes #5646: custom "Add track waypoint" / "Add Favourite" Quick Action buttons stored their configured group/color in `NSUserDefaults`, but the point-editing handlers never read them back, so the interim dialog always fell back to the default group and yellow color.
- Fixes a related bug: when adding a new Favorite, `setupColors` preferred an existing group's stored color over the handler's resolved color. This misfired even for a brand-new, still-empty group (which only carries a structural default color, not a user-chosen one), silently discarding the Quick Action's configured color.
- Implements Dmitry's follow-up request on #5646: the "Add track waypoint" Quick Action config screen now offers a full Appearance editor (icon/color/shape) via a new `OAQuickActionAppearanceViewController`, reusing the existing Favorites group appearance editor. Waypoints added into a track group that already has its own established appearance now follow that group's appearance instead of the Quick Action's configured one.

## Test plan
- [x] Build for iOS Simulator, verify no crashes on launch
- [x] Configure "Add — Favourite" Quick Action with group "Group2" (new, empty) + color Red; confirm interim dialog now opens with Red pre-selected (was Yellow) — recorded before/after video
- [x] Configure "Add — Track waypoint" Quick Action; verify new "Appearance" row opens icon/color/shape picker and saves back correctly
- [x] Manual test: Add Track waypoint into an existing track group that already has waypoints/appearance set, confirm the group's appearance is followed instead of the Quick Action's configured one

🤖 Generated with [Claude Code](https://claude.com/claude-code)