### PR TITLE
Fix Favorites auto-merge upload races and visibility

### DIFF
--- a/Sources/Backup/OAFavoritesBackupMerger.mm
+++ b/Sources/Backup/OAFavoritesBackupMerger.mm
@@ -9,6 +9,7 @@
 
 #import "OABackupHelper.h"
 #import "OABackupInfo.h"
+#import "OAExportSettingsType.h"
 #import "OAFavoritesHelper.h"
 #import "OAFavoritesSettingsItem.h"
 #import "OAFavoriteItem.h"
@@ -47,6 +48,11 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
             continue;
 
         OAFavoritesSettingsItem *localItem = (OAFavoritesSettingsItem *)localFile.item;
+        // Merging downloads the remote file, so skip types the backup would filter out anyway.
+        OAExportSettingsType *exportType = [OAExportSettingsType findBySettingsItem:localItem];
+        if (exportType == nil || ![[BackupUtils getBackupTypePref:exportType] get])
+            continue;
+
         OAFavoriteGroup *localGroup = localItem.items.count == 1 ? localItem.items.firstObject : nil;
         if (!localGroup || localGroup.isPersonal)
             continue;

--- a/Sources/Backup/OAFavoritesBackupMerger.mm
+++ b/Sources/Backup/OAFavoritesBackupMerger.mm
@@ -14,6 +14,7 @@
 #import "OAFavoriteItem.h"
 #import "OALocalFile.h"
 #import "OARemoteFile.h"
+#import "OASettingsItemType.h"
 #import "OAUtilities.h"
 #import "OsmAndApp.h"
 #import "OsmAnd_Maps-Swift.h"
@@ -25,7 +26,8 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
 - (instancetype)initWithBaseItem:(OAFavoritesSettingsItem *)baseItem
                        localGroup:(OAFavoriteGroup *)localGroup
                       mergedGroup:(OAFavoriteGroup *)mergedGroup
-               sourceModifiedTime:(long)sourceModifiedTime;
+               sourceModifiedTime:(long)sourceModifiedTime
+                     baseSyncTime:(long)baseSyncTime;
 - (void)finishUpload:(NSString *)fileName uploadTime:(long)uploadTime;
 
 @end
@@ -58,7 +60,8 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
         localFile.item = [[OAMergedFavoritesSettingsItem alloc] initWithBaseItem:localItem
                                                                      localGroup:localGroup
                                                                     mergedGroup:mergedGroup
-                                                             sourceModifiedTime:localFile.localModifiedTime];
+                                                             sourceModifiedTime:localFile.localModifiedTime
+                                                                   baseSyncTime:localFile.uploadTime];
         [info.filesToUpload addObject:localFile];
         [info.filesToMerge removeObject:pair];
     }
@@ -74,7 +77,11 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
     OAFavoritesSettingsItem *favoritesItem = (OAFavoritesSettingsItem *)item;
     if ([favoritesItem isKindOfClass:OAMergedFavoritesSettingsItem.class])
     {
-        [(OAMergedFavoritesSettingsItem *)favoritesItem finishUpload:fileName uploadTime:uploadTime];
+        // Upload callbacks run in parallel, while applying a group mutates shared Favorites state.
+        @synchronized (self)
+        {
+            [(OAMergedFavoritesSettingsItem *)favoritesItem finishUpload:fileName uploadTime:uploadTime];
+        }
     }
     else if (favoritesItem.localModifiedTime == favoritesItem.lastModifiedTime)
     {
@@ -370,7 +377,9 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
 {
     std::shared_ptr<OsmAnd::IFavoriteLocation> favorite =
         [OAFavoritesHelper getFavoritesCollection]->copyFavoriteLocation(point.favorite);
-    return [[OAFavoriteItem alloc] initWithFavorite:favorite];
+    OAFavoriteItem *copy = [[OAFavoriteItem alloc] initWithFavorite:favorite];
+    [copy setVisible:point.isVisible];
+    return copy;
 }
 
 + (OAFavoriteGroup *)copyGroup:(OAFavoriteGroup *)group
@@ -393,12 +402,14 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
     OAFavoriteGroup *_localGroup;
     OAFavoriteGroup *_mergedGroup;
     long _sourceModifiedTime;
+    long _baseSyncTime;
 }
 
 - (instancetype)initWithBaseItem:(OAFavoritesSettingsItem *)baseItem
                        localGroup:(OAFavoriteGroup *)localGroup
                       mergedGroup:(OAFavoriteGroup *)mergedGroup
                sourceModifiedTime:(long)sourceModifiedTime
+                     baseSyncTime:(long)baseSyncTime
 {
     self = [super initWithItems:@[mergedGroup] baseItem:baseItem];
     if (self)
@@ -406,6 +417,7 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
         _localGroup = [OAFavoritesBackupMerger copyGroup:localGroup];
         _mergedGroup = mergedGroup;
         _sourceModifiedTime = sourceModifiedTime;
+        _baseSyncTime = baseSyncTime;
     }
     return self;
 }
@@ -435,7 +447,13 @@ static NSString * const kFavoritesSnapshotDirectory = @"favorites_sync";
     else
     {
         if (current)
+        {
+            // Preserve the old common base so the next preparation keeps both sides in conflict.
+            [OABackupHelper.sharedInstance updateFileUploadTime:[OASettingsItemType typeName:self.type]
+                                                       fileName:fileName
+                                                     uploadTime:_baseSyncTime];
             self.localModifiedTime = MAX((long)(NSDate.date.timeIntervalSince1970 * 1000.0), uploadTime + 1);
+        }
     }
 }
 


### PR DESCRIPTION
### Summary

Fixes three post-merge correctness issues in the Favorites auto-merge flow introduced by #5688.

- Preserves conflict state when a Favorites group changes locally while its prepared merge is being uploaded.
- Serializes merged-upload completion so parallel uploads cannot concurrently mutate shared Favorites state.
- Preserves point visibility when copying groups for snapshots and merged payloads.

Related to #5177.

### Implementation

The prepared merge now retains the timestamp of its common base. If the live group changes before upload completion, the previous per-file upload timestamp is restored and the existing snapshot is retained. The next backup preparation therefore sees both the local group and cloud group as changed and keeps them in conflict instead of allowing the local state to overwrite the uploaded merge.

Merged upload completion is synchronized because Favorites uploads run concurrently while applying a group deletes, adds, saves, and reloads shared Favorites state.

The core favorite-location copy does not preserve the hidden flag, so copyPoint now explicitly restores the source point visibility.

All changes are isolated in OAFavoritesBackupMerger.

### Test plan

- Prepare an automatic merge, edit the same local group while its upload is in progress, and verify the next preparation reports a conflict without losing cloud changes.
- Auto-merge two different Favorites groups in one sync and verify both merged results remain present locally and in the cloud.
- Hide a Favorites group, add different points on two devices, and verify it auto-merges while remaining hidden.
- Recheck the existing independent-addition, edit, move, rename, and deletion merge scenarios.

Automated tests were not run because build execution was not permitted for this task. Static validation with git diff --check passed.

## AI disclaimer

Produced with Codex (GPT-5).

Prompts used (summarised):
1. Analyse the new post-merge review comments on #5688 and determine which should be fixed.
2. Implement the three correctness fixes concerning in-flight local edits, concurrent merged-upload completion, and copied point visibility.
3. Commit the changes and create a pull request.

Decided by the agent, not requested explicitly: preserved the original common-base timestamp to force safe conflict detection after an in-flight edit, synchronized the complete merged-upload completion path, restored visibility after copying a core favorite location, and kept the preparation-performance suggestion outside this PR.