### PR TITLE
Fix HH map selection for countries published as sub-regions

### DIFF
--- a/Sources/Router/OARouteProvider.mm
+++ b/Sources/Router/OARouteProvider.mm
@@ -1102,31 +1102,34 @@ static NSString *RouteCalculationErrorMessage(const std::exception &exception)
     }
 }
 
+// Download names of the regions of every route point, at all levels of the region hierarchy
+// (Kyiv -> ukraine_kyiv-city_europe, ukraine_kyiv_europe, ukraine_europe). HHRoutePlanner uses
+// them to reject groups of maps which don't belong to the route regions.
+// Regions common to all points must not be used here: countries published only as sub-regions
+// (Ukraine, France, Germany, Poland, ...) have no downloadable map named after the country
+// itself, so for 2 points of different sub-regions the only common region would never match
+// any downloaded file, and the check would always fail.
 - (void) calculateRegionsWithAllRoutePoints:(std::shared_ptr<RoutingContext>)ctx
                                       start:(CLLocation *)start
                                     targets:(NSArray<CLLocation *> *)targets
 {
-    NSMutableDictionary<NSString*, NSNumber*> *regionCounter = [NSMutableDictionary dictionary];
+    NSMutableOrderedSet<NSString *> *regions = [NSMutableOrderedSet orderedSet];
 
-    [self getRegionsOfPoint:start regionCounter:regionCounter];
+    [self collectRegionsOfPoint:start regions:regions];
 
     for (CLLocation *loc in targets) {
-       [self getRegionsOfPoint:loc regionCounter:regionCounter];
+       [self collectRegionsOfPoint:loc regions:regions];
     }
 
-    int allPoints = 1 + (int)targets.count;
-
     std::vector<std::string> result;
-    for (NSString *region in regionCounter) {
-        if ([regionCounter[region] intValue] == allPoints) {
-            result.emplace_back([region UTF8String]);
-        }
+    for (NSString *region in regions) {
+        result.emplace_back([region UTF8String]);
     }
     ctx->regionsCoveringStartAndTargets = std::move(result);
 }
 
-- (void) getRegionsOfPoint:(CLLocation *) ll
-             regionCounter:(NSMutableDictionary<NSString*, NSNumber*> *) regionCounter
+- (void) collectRegionsOfPoint:(CLLocation *) ll
+                       regions:(NSMutableOrderedSet<NSString *> *) regions
 {
     NSArray<OAWorldRegion *> *regionsArray = [_or getWorldRegionsAtWithoutSort:ll.coordinate.latitude longitude:ll.coordinate.longitude];
     for (OAWorldRegion *region in regionsArray)
@@ -1136,7 +1139,10 @@ static NSString *RouteCalculationErrorMessage(const std::exception &exception)
         {
             name = [name substringToIndex:[name length] - 1];
         }
-        regionCounter[name] = @([regionCounter[name] integerValue] + 1);
+        if (name)
+        {
+            [regions addObject:name];
+        }
     }
 }
 


### PR DESCRIPTION
Draft — iOS part of osmandapp/OsmAnd#25841.

`calculateRegionsWithAllRoutePoints` filled `ctx->regionsCoveringStartAndTargets` with the regions covering **all** route points. The HH planner compares that list with the names of the routing sections of the downloaded maps, so for a country published as sub-regions only (Ukraine, France, Germany, Poland, …) it can never match: the single shared region is the country, and no downloadable map is named after it.

Routing Kyiv → Bukovel:

```
Kyiv    -> ukraine_kyiv-city_europe, ukraine_kyiv_europe, ukraine_europe
Bukovel -> ukraine_ivano-frankivsk_europe, ukraine_europe
=> [ukraine_europe]   <- matches no downloaded file
```

`containsStartEnd` is then `false` for the correct group, group ranking degrades to "newest edition wins", and a Moldova or Romania map that merely clips the start/finish bbox takes the whole route.

This lists the regions of **every** route point instead, at all levels of the hierarchy — mirroring the Java change in osmandapp/OsmAnd#25844, where it is covered by a unit test and verified end to end on stock maps. A sub-region map now matches, a country-wide map still matches, a neighbouring country still does not.

Companion C++ ranking safeguard: osmandapp/OsmAnd-core-legacy#348

Not compiled here (no macOS Xcode build run for this change) — please check on CI.

Side note, not changed here: `getWorldRegionsAtWithoutSort` also returns non-downloadable levels (continents), unlike the Java `getRegionsToDownload`. They cannot match a routing section name, so they are harmless, but filtering them would make the two platforms produce identical lists.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. "There seems to be a backend bug — reproduce it in tools MapCreator or Inspector: I was building HH routing in Ukraine and had an old Moldova map (route ~Kyiv → Bukovel), and instead of the Ukrainian maps it wanted to use Romania or Moldova. Reproduce it, and if reproduced, create a GitHub issue."
2. "Maps are in ../maps"; "if you need old maps, download them from https://data.osmand.net/backup-maps/"
3. "Create a draft PR as well, proposing how you'd fix it — Java and C++ — and maybe a simple Java unit test."

Decided by the agent, not requested explicitly: the prompts mentioned Java and C++ only; this iOS change was added because iOS fills the list itself and would otherwise keep the bug. Also the method rename (`getRegionsOfPoint` -> `collectRegionsOfPoint`) and the nil-name guard.
