### PR TITLE
Automate localized App Store release notes with fastlane

### DIFF
--- a/.github/workflows/appstore-release-notes.yml
+++ b/.github/workflows/appstore-release-notes.yml
@@ -1,0 +1,53 @@
+name: App Store release notes
+
+# Pushes the localized release notes to App Store Connect without building anything.
+# The text is the in-app "What's new" string ios_release_<major>_<minor> from
+# Resources/Localizations/*/Localizable.strings, so re-running this after Weblate has
+# delivered more translations is the way to fill in the languages that were missing.
+on:
+  workflow_dispatch:
+    inputs:
+      releaseversion:
+        description: 'Release Version (selects the ios_release_X_Y notes)'
+        required: true
+        default: '5.4.0'
+      submit_for_review:
+        description: 'Submit the version for review after uploading'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  metadata:
+    runs-on: self-hosted
+    steps:
+    - name: Checkout ios
+      uses: actions/checkout@v4
+      with:
+        ref: refs/heads/master
+        repository: osmandapp/OsmAnd-iOS
+        path: ios
+        clean: true
+
+    - name: Setup fastlane
+      run: |
+        command -v fastlane >/dev/null 2>&1 || brew install fastlane
+        fastlane --version
+
+    - name: Upload release notes
+      working-directory: ios
+      env:
+        LANG: "en_US.UTF-8"
+        RELEASE_IOS_VERSION: ${{ github.event.inputs.releaseversion }}
+        ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+        ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
+        FASTLANE_USER: ${{ secrets.APPLEID_USERNAME }}
+        FASTLANE_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
+      run: fastlane release submit_for_review:${{ github.event.inputs.submit_for_review }}
+
+    - name: Upload generated release notes
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-notes-${{ github.event.inputs.releaseversion }}
+        path: ios/fastlane/metadata

--- a/.github/workflows/publish-testflight.yml
+++ b/.github/workflows/publish-testflight.yml
@@ -1,0 +1,56 @@
+name: Publish TestFlight (self hosted)
+
+# Publishes an IPA that a previous "Build OsmAndMaps (self hosted)" run already produced,
+# so a build can be checked first and uploaded later without rebuilding it.
+# Release notes are taken from the in-app "What's new" strings, see fastlane/Fastfile.
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Run ID of the build to publish (the number in the build run URL)'
+        required: true
+      releaseversion:
+        description: 'Release Version (selects the ios_release_X_Y notes)'
+        required: true
+        default: '5.4.0'
+
+jobs:
+  publish:
+    runs-on: self-hosted
+    permissions:
+      actions: read
+    steps:
+    - name: Checkout ios
+      uses: actions/checkout@v4
+      with:
+        ref: refs/heads/master
+        repository: osmandapp/OsmAnd-iOS
+        path: ios
+        clean: true
+
+    - name: Download IPA from build run
+      uses: actions/download-artifact@v4
+      with:
+        pattern: '*.ipa'
+        merge-multiple: true
+        path: ipa
+        run-id: ${{ github.event.inputs.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup fastlane
+      run: |
+        command -v fastlane >/dev/null 2>&1 || brew install fastlane
+        fastlane --version
+
+    - name: Publish TestFlight
+      working-directory: ios
+      env:
+        LANG: "en_US.UTF-8"
+        RELEASE_IOS_VERSION: ${{ github.event.inputs.releaseversion }}
+        IPA_PATH: ${{ github.workspace }}/ipa/OsmAnd Maps.ipa
+        ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+        ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
+        FASTLANE_USER: ${{ secrets.APPLEID_USERNAME }}
+        FASTLANE_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
+      run: fastlane beta

--- a/.github/workflows/xcode-local-build.yml
+++ b/.github/workflows/xcode-local-build.yml
@@ -15,6 +15,16 @@ on:
         description: 'Release Version'
         required: true
         default: '5.5.0'
+      run_tests:
+        description: 'Run unit and UI tests before archiving (+4 min)'
+        type: boolean
+        required: false
+        default: false
+      publish_testflight:
+        description: 'Upload to TestFlight when the build succeeds'
+        type: boolean
+        required: false
+        default: true
 jobs:
   build:
     runs-on: self-hosted
@@ -128,6 +138,7 @@ jobs:
       run: 'xcodebuild -project OsmAnd_projects.xcodeproj -target OsmAndCore_static_standalone -sdk iphoneos -configuration Release'
       working-directory: baked/fat-ios-clang.xcode
     - name: Build iOS tests
+      if: ${{ inputs.run_tests }}
       env:
         LANG: "en_US.UTF-8"
       run: |
@@ -152,6 +163,7 @@ jobs:
           -testRegion US \
           | xcpretty
     - name: Run iOS UI tests
+      if: ${{ inputs.run_tests }}
       env:
         LANG: "en_US.UTF-8"
       run: |
@@ -195,6 +207,9 @@ jobs:
           -archivePath OsmAndMaps.xcarchive \
           CURRENT_PROJECT_VERSION="${BUILD_IOS_VERSION}" \
           MARKETING_VERSION="${RELEASE_IOS_VERSION}" \
+          COMPILER_INDEX_STORE_ENABLE=NO \
+          -skipPackagePluginValidation \
+          -skipMacroValidation \
           archive | xcpretty
     - name: Zip iOS archive
       env:
@@ -217,14 +232,29 @@ jobs:
             -exportPath . 
             -allowProvisioningUpdates 
             -exportArchive' 
-    # - name: Upload maps archive
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: OsmAndMaps-${{ github.event.inputs.releaseversion }}.${{ github.event.inputs.buildversion }}.ipa
-    #     path: 'OsmAnd Maps.ipa'
+    ### Keep the IPA around so "Publish TestFlight (self hosted)" can upload it later
+    ### without rebuilding, using this run's ID.
+    - name: Upload maps ipa
+      uses: actions/upload-artifact@v4
+      with:
+        name: OsmAndMaps-${{ github.event.inputs.releaseversion }}.${{ github.event.inputs.buildversion }}.ipa
+        path: 'OsmAnd Maps.ipa'
+    - name: Setup fastlane
+      if: ${{ inputs.publish_testflight }}
+      run: |
+        command -v fastlane >/dev/null 2>&1 || brew install fastlane
+        fastlane --version
+    ### Uploads the build and sets "What to Test" from the localized ios_release_X_Y strings.
     - name: Publish TestFlight
+      if: ${{ inputs.publish_testflight }}
+      working-directory: ios
       env:
         LANG: "en_US.UTF-8"
-        APPLEID_USERNAME: ${{ secrets.APPLEID_USERNAME }}
-        APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
-      run: 'xcrun altool --upload-app -t ios -f "OsmAnd Maps.ipa" -u "$APPLEID_USERNAME" -p "$APPLEID_PASSWORD" --verbose'
+        RELEASE_IOS_VERSION: ${{ github.event.inputs.releaseversion }}
+        IPA_PATH: ${{ github.workspace }}/OsmAnd Maps.ipa
+        ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+        ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
+        FASTLANE_USER: ${{ secrets.APPLEID_USERNAME }}
+        FASTLANE_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
+      run: fastlane beta

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/Scripts/generate_release_notes.rb
+++ b/Scripts/generate_release_notes.rb
@@ -1,0 +1,135 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Generates App Store Connect release notes from the in-app "What's new" strings.
+#
+# Release notes are already written and translated in Resources/Localizations/<lang>.lproj/
+# Localizable.strings under the key "ios_release_<major>_<minor>" (the same text the
+# What's new bottom sheet shows). This script maps every .lproj to its App Store Connect
+# locale and writes fastlane/metadata/<locale>/release_notes.txt, so nothing has to be
+# pasted into App Store Connect by hand.
+#
+# Usage: Scripts/generate_release_notes.rb <marketing version> [output dir]
+#   Scripts/generate_release_notes.rb 5.4.0
+#   Scripts/generate_release_notes.rb 5.4.0 fastlane/metadata
+
+require 'json'
+require 'fileutils'
+
+# .lproj directory -> App Store Connect locale.
+# Only locales App Store Connect actually accepts are listed; the rest are skipped.
+LOCALE_MAP = {
+  'ar' => 'ar-SA',
+  'ca' => 'ca',
+  'cs' => 'cs',
+  'da' => 'da',
+  'de' => 'de-DE',
+  'el' => 'el',
+  'en' => 'en-US',
+  'en-GB' => 'en-GB',
+  'es' => 'es-ES',
+  'es-US' => 'es-MX',
+  'fi' => 'fi',
+  'fr' => 'fr-FR',
+  'he' => 'he',
+  'hi' => 'hi',
+  'hr' => 'hr',
+  'hu' => 'hu',
+  'id' => 'id',
+  'it' => 'it',
+  'ja' => 'ja',
+  'ko' => 'ko',
+  'nb' => 'no',
+  'nl' => 'nl-NL',
+  'pl' => 'pl',
+  'pt' => 'pt-PT',
+  'pt-BR' => 'pt-BR',
+  'ro-RO' => 'ro',
+  'ru' => 'ru',
+  'sk' => 'sk',
+  'sv' => 'sv',
+  'tr' => 'tr',
+  'uk' => 'uk',
+  'vi' => 'vi',
+  'zh-Hans' => 'zh-Hans',
+  'zh-Hant' => 'zh-Hant'
+}.freeze
+
+# App Store Connect rejects release notes longer than this.
+MAX_LENGTH = 4000
+
+# en-US is mandatory: it is the fallback App Store shows for every locale we do not upload.
+FALLBACK_LOCALE = 'en-US'
+
+def die(message)
+  warn "error: #{message}"
+  exit 1
+end
+
+# "5.4.0" / "5.4" / "5.4.0.5433" -> "ios_release_5_4"
+def release_key(version)
+  parts = version.strip.split('.')
+  die("cannot parse version '#{version}'") if parts.size < 2
+  "ios_release_#{parts[0]}_#{parts[1]}"
+end
+
+# Localizable.strings is an old-style plist, so plutil parses it including all escapes.
+def read_strings(path)
+  json = `plutil -convert json -o - "#{path}" 2>/dev/null`
+  return nil unless $?.success?
+
+  JSON.parse(json)
+rescue JSON::ParserError
+  nil
+end
+
+def clean(text)
+  # Normalise the bullet lines and drop the trailing newline the in-app string carries.
+  text.gsub("\r\n", "\n").split("\n").map(&:strip).reject(&:empty?).join("\n")
+end
+
+version = ARGV[0]
+die('usage: generate_release_notes.rb <marketing version> [output dir]') if version.nil? || version.empty?
+
+root = File.expand_path('..', __dir__)
+localizations = File.join(root, 'Resources', 'Localizations')
+out_dir = ARGV[1] ? File.expand_path(ARGV[1]) : File.join(root, 'fastlane', 'metadata')
+key = release_key(version)
+
+written = []
+skipped = []
+
+LOCALE_MAP.each do |lproj, locale|
+  strings_path = File.join(localizations, "#{lproj}.lproj", 'Localizable.strings')
+  next unless File.exist?(strings_path)
+
+  strings = read_strings(strings_path)
+  if strings.nil?
+    warn "warning: could not parse #{lproj}.lproj/Localizable.strings, skipping"
+    next
+  end
+
+  notes = strings[key]
+  if notes.nil? || notes.strip.empty?
+    skipped << locale
+    next
+  end
+
+  notes = clean(notes)
+  if notes.length > MAX_LENGTH
+    warn "warning: #{locale} release notes are #{notes.length} chars, truncating to #{MAX_LENGTH}"
+    notes = notes[0, MAX_LENGTH]
+  end
+
+  locale_dir = File.join(out_dir, locale)
+  FileUtils.mkdir_p(locale_dir)
+  File.write(File.join(locale_dir, 'release_notes.txt'), notes + "\n")
+  written << locale
+end
+
+if written.include?(FALLBACK_LOCALE)
+  puts "Generated release notes for #{key} in #{written.size} locale(s): #{written.sort.join(', ')}"
+  puts "Not translated yet (App Store falls back to #{FALLBACK_LOCALE}): #{skipped.sort.join(', ')}" unless skipped.empty?
+else
+  die("#{key} is missing from en.lproj/Localizable.strings - add the English release notes first")
+end

--- a/fastlane/.gitignore
+++ b/fastlane/.gitignore
@@ -1,0 +1,4 @@
+# Release notes are generated from Resources/Localizations by Scripts/generate_release_notes.rb
+metadata/
+report.xml
+README.md

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+app_identifier("net.osmand.maps")
+team_id("LM67P5MQ23")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,104 @@
+# OsmAnd Maps – App Store Connect automation.
+#
+# The build itself stays in xcodebuild (see .github/workflows). Fastlane is used only for
+# what altool cannot do: uploading localized release notes together with the build.
+#
+# Release notes are not written here – they are the in-app "What's new" strings
+# (ios_release_<major>_<minor> in Resources/Localizations/*/Localizable.strings), already
+# translated by the community. Scripts/generate_release_notes.rb converts them into the
+# fastlane/metadata layout deliver expects.
+#
+# Authentication: an App Store Connect API key (ASC_KEY_ID / ASC_ISSUER_ID / ASC_KEY_P8) is
+# used when present. Otherwise it falls back to the Apple ID + app-specific password already
+# stored in the repository secrets (FASTLANE_USER / FASTLANE_PASSWORD).
+
+require 'shellwords'
+
+default_platform(:ios)
+
+DEFAULT_IPA = "OsmAnd Maps.ipa"
+
+# The repository root, whatever directory fastlane was started from.
+def repo_root
+  folder = FastlaneCore::FastlaneFolder.path
+  folder ? File.expand_path('..', folder) : Dir.pwd
+end
+
+def resolve_ipa(options)
+  path = options[:ipa] || ENV['IPA_PATH'] || File.join(repo_root, DEFAULT_IPA)
+  path = File.expand_path(path, repo_root)
+  UI.user_error!("IPA not found at #{path}") unless File.exist?(path)
+  path
+end
+
+def resolve_version(options)
+  version = options[:version] || ENV['RELEASE_IOS_VERSION']
+  UI.user_error!('Pass version:5.4.0 or set RELEASE_IOS_VERSION') if version.to_s.strip.empty?
+  version.to_s.strip
+end
+
+# Uses the API key when the secrets are configured; pilot/deliver fall back to
+# FASTLANE_USER / FASTLANE_PASSWORD otherwise.
+def authenticate
+  return nil if ENV['ASC_KEY_ID'].to_s.empty?
+
+  app_store_connect_api_key(
+    key_id: ENV['ASC_KEY_ID'],
+    issuer_id: ENV['ASC_ISSUER_ID'],
+    key_content: ENV['ASC_KEY_P8'],
+    is_key_content_base64: true,
+    in_house: false
+  )
+end
+
+platform :ios do
+  desc 'Generate localized release notes from the in-app "What\'s new" strings'
+  lane :release_notes do |options|
+    version = resolve_version(options)
+    sh("cd #{repo_root.shellescape} && Scripts/generate_release_notes.rb #{version.shellescape} fastlane/metadata")
+  end
+
+  desc 'Upload the IPA to TestFlight with the release notes as "What to Test"'
+  lane :beta do |options|
+    version = resolve_version(options)
+    ipa = resolve_ipa(options)
+    api_key = authenticate
+    release_notes(version: version)
+
+    changelog = File.read(File.join(repo_root, 'fastlane', 'metadata', 'en-US', 'release_notes.txt'))
+
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: ipa,
+      app_identifier: 'net.osmand.maps',
+      changelog: changelog,
+      # Setting "What to Test" requires the build to finish processing first.
+      skip_waiting_for_build_processing: false,
+      distribute_external: false,
+      notify_external_testers: false
+    )
+  end
+
+  desc 'Push localized release notes for a version to App Store Connect (no binary upload)'
+  lane :release do |options|
+    version = resolve_version(options)
+    api_key = authenticate
+    release_notes(version: version)
+
+    upload_to_app_store(
+      api_key: api_key,
+      app_identifier: 'net.osmand.maps',
+      app_version: version,
+      metadata_path: File.join(repo_root, 'fastlane', 'metadata'),
+      # Only release notes are managed here; everything else stays as it is in App Store Connect.
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      skip_app_version_update: false,
+      overwrite_screenshots: false,
+      submit_for_review: options[:submit_for_review].to_s == 'true',
+      automatic_release: false,
+      precheck_include_in_app_purchases: false,
+      force: true
+    )
+  end
+end

--- a/fastlane/RELEASE.md
+++ b/fastlane/RELEASE.md
@@ -1,0 +1,52 @@
+# Release automation
+
+The build stays in `xcodebuild` (see `.github/workflows/xcode-local-build.yml`). Fastlane is
+used only for App Store Connect, because `altool` can upload a binary but cannot set release
+notes.
+
+## Where release notes come from
+
+They are not written for the store separately. The App Store text **is** the in-app
+"What's new" string:
+
+```
+Resources/Localizations/<lang>.lproj/Localizable.strings
+"ios_release_5_4" = "• Added \"Terrain shadows\" visualization type\n…";
+```
+
+`Scripts/generate_release_notes.rb 5.4.0` reads that key from every `.lproj`, maps the
+language to its App Store Connect locale and writes
+`fastlane/metadata/<locale>/release_notes.txt`. Languages that are not translated yet are
+simply skipped — the App Store falls back to `en-US` for them. Re-running the
+**App Store release notes** workflow after Weblate delivers more translations fills them in.
+
+`fastlane/metadata/` is generated, so it is not committed.
+
+## Workflows
+
+| Workflow | What it does |
+| --- | --- |
+| **Build OsmAndMaps (self hosted)** | Builds, archives, exports the IPA and — if *Upload to TestFlight* is checked — uploads it with "What to Test" set. Always keeps the IPA as an artifact. |
+| **Publish TestFlight (self hosted)** | Uploads an IPA an earlier build run produced. Takes that run's ID, so a build can be checked first and shipped later without rebuilding. |
+| **App Store release notes** | Pushes the localized release notes for a version to App Store Connect. No build, no binary upload. |
+
+## Lanes
+
+```sh
+fastlane release_notes version:5.4.0                  # generate fastlane/metadata only
+fastlane beta version:5.4.0                           # TestFlight upload + "What to Test"
+fastlane release version:5.4.0                        # localized release notes -> App Store
+fastlane release version:5.4.0 submit_for_review:true # and submit the version for review
+```
+
+## Credentials
+
+An App Store Connect API key is used when these secrets exist, and is the recommended setup —
+it does not expire and is not tied to a personal Apple ID with 2FA:
+
+- `ASC_KEY_ID` — the key ID
+- `ASC_ISSUER_ID` — the issuer ID from App Store Connect → Users and Access → Integrations
+- `ASC_KEY_P8` — the `.p8` private key, base64 encoded (`base64 -i AuthKey_XXXX.p8 | pbcopy`)
+
+Without them fastlane falls back to the Apple ID and app-specific password already stored as
+`APPLEID_USERNAME` / `APPLEID_PASSWORD`.


### PR DESCRIPTION
## Problem

App Store release notes are retyped by hand, per language, for every release — while the exact same text already lives in this repository and is already translated:

```
Resources/Localizations/<lang>.lproj/Localizable.strings
"ios_release_5_4" = "• Added \"Terrain shadows\" visualization type\n…";
```

That is the string the What's new bottom sheet shows. `altool` cannot upload metadata, which is why the store side stayed manual.

## What this adds

**`Scripts/generate_release_notes.rb <version>`** reads `ios_release_<major>_<minor>` from every `.lproj`, maps the language to its App Store Connect locale and writes `fastlane/metadata/<locale>/release_notes.txt`. Locales that are not translated yet are skipped — the App Store falls back to `en-US` for them. Truncates at the 4000 character limit Apple enforces.

For 5.4 it currently produces 9 locales:

```
$ Scripts/generate_release_notes.rb 5.4.0
Generated release notes for ios_release_5_4 in 9 locale(s): cs, da, en-US, fr-FR, hu, id, it, pt-BR, zh-Hant
Not translated yet (App Store falls back to en-US): ar-SA, ca, de-DE, el, en-GB, es-ES, es-MX, fi, he, hi,
hr, ja, ko, nl-NL, no, pl, pt-PT, ro, ru, sk, sv, tr, uk, vi, zh-Hans
```

Re-running the metadata workflow later, after Weblate delivers more translations, fills the rest in.

**Fastlane** (`fastlane/Fastfile`) — used only for App Store Connect, the build stays in `xcodebuild`:

| lane | |
| --- | --- |
| `release_notes version:5.4.0` | generate `fastlane/metadata` only |
| `beta version:5.4.0` | TestFlight upload, sets "What to Test" |
| `release version:5.4.0` | localized release notes → App Store, no binary upload |

**Three workflow entry points**, which answers "build now, publish later":

| Workflow | |
| --- | --- |
| **Build OsmAndMaps (self hosted)** | new checkboxes *Run unit and UI tests* (default off) and *Upload to TestFlight* (default on); always uploads the IPA as an artifact |
| **Publish TestFlight (self hosted)** | takes the run ID of an earlier build and uploads that IPA — no rebuild |
| **App Store release notes** | pushes localized notes for a version, builds nothing (~1 min) |

## Build time

Measured on run `33764044853` (17 min total): archive 534 s, unit tests 183 s, UI tests 75 s, prepare 71 s, core 38 s, TestFlight upload 66 s.

Tests are now off by default in the release path — they are worth ~258 s there and belong on pull requests instead. The archive additionally sets `COMPILER_INDEX_STORE_ENABLE=NO` and skips package plugin / macro validation, none of which are useful in CI.

Not done here, worth a follow-up: `prepare.sh` deletes `Pods` and `Podfile.lock` on every run, which costs a full `pod install` each build and means release builds resolve pod versions non-reproducibly.

## Credentials

Fastlane uses an App Store Connect API key when `ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_KEY_P8` (base64 `.p8`) are configured, and otherwise falls back to the existing `APPLEID_USERNAME` / `APPLEID_PASSWORD` secrets — so this merges and works before the key exists. The API key is still the recommended setup: it does not expire and is not tied to a personal Apple ID with 2FA.

The runner needs `fastlane` available; the workflows `brew install fastlane` if it is missing.

## Notes for review

- `fastlane/metadata/` is generated and deliberately not committed.
- The `release` lane sets `skip_binary_upload: true` and only manages release notes — description, keywords and screenshots in App Store Connect are left untouched.
- `sr` and `sr-Latn` are translated for 5.4 but App Store Connect has no Serbian locale, so they are not uploaded.
- The unused `xcode-build.yml` (hosted runner, pinned to Xcode 15.0.1, no runs in the retention window) is left alone here, but it should probably be deleted.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. How do we speed up the iOS build — we have GitHub Actions but need release notes and fastlane, what would you do?
2. Open a pull request for 5.4 right away and implement the release notes; should building and publishing be separate jobs, or a checkbox — look at the self-hosted actions.
3. Automating the insertion of translations is what interests us most, and the rest too.

Decided by the agent, not requested explicitly:
- Sourcing App Store release notes from the existing `ios_release_X_Y` strings instead of introducing a new file format for them.
- The `.lproj` → App Store Connect locale mapping, including `es-US` → `es-MX` and `nb` → `no`, and dropping languages App Store Connect does not support.
- Keeping `xcodebuild` for the build and using fastlane only for upload and metadata, rather than migrating to `gym`/`match`.
- Falling back to the existing Apple ID secrets when no App Store Connect API key is configured, so the change is mergeable today.
- Splitting into three workflows and adding the two checkboxes, plus turning tests off by default in the release path.
- The build-time changes (`COMPILER_INDEX_STORE_ENABLE=NO`, skipping plugin/macro validation).
