### PR TITLE
Start GPX filesystem reconciliation on iOS

### DIFF
--- a/Sources/AppHost/OsmAndAppImpl.mm
+++ b/Sources/AppHost/OsmAndAppImpl.mm
@@ -761,6 +761,7 @@
     LogStartup(@"target points cleared");
 
     [[OASGpxDbHelper shared] loadItemsBlocking];
+    [[OASGpxDbHelper shared] startFilesystemReconciliation];
     LogStartup(@"GPX DB helper loaded items blocking");
 
     [OASavingTrackHelper sharedInstance];


### PR DESCRIPTION
## Related issue / task

Related to osmandapp/OsmAnd#24078 and osmandapp/OsmAnd#25784.

## Summary

- Start shared GPX filesystem reconciliation immediately after blocking GPX metadata-cache hydration on iOS.
- Allow queued missing or stale GPX analyses to proceed.
- Align iOS startup with the deferred reconciliation lifecycle in the shared GPX database helper.

## Testing

Not run, per request. Source-only checks:

- `git diff --check`
- Verified the iOS call site against `GpxDbHelper.startFilesystemReconciliation()`.

**Tested on:**

- Device / Simulator: Not run
- iOS: Not run

### Scenarios

- Confirmed startup now hydrates cached GPX metadata before starting filesystem reconciliation.

## Relevant checks

- [ ] Portrait / Landscape tested
- [ ] Light / Dark mode tested
- [ ] Different profiles tested
- [ ] Localization / RTL checked
- [ ] VoiceOver / Accessibility checked
- [ ] CarPlay checked
- [x] Android parity checked
- [ ] Performance impact checked

## AI disclaimer

**Implementation:**

- Tool / Agent: Codex
- Model: GPT-5

**Prompts used (summarised):**

1. Analyze the GPX issue, implement the equivalent iOS startup fix, commit it on a new branch, push, and create a PR.
2. Do not build.

**Decided by the agent, not requested explicitly:**

- Added reconciliation startup directly after blocking GPX metadata hydration.
- Used source-only validation because builds and tests were explicitly disallowed.

**Final review:**

- Tool / Agent: Codex
- Model: GPT-5
- [x] Final diff reviewed

**Significant findings:** iOS loaded the shared GPX database cache but did not start filesystem reconciliation, so stale or missing analyses could remain queued indefinitely.