### PR TITLE
Search: stop re-normalizing strings on every collator comparison

### DIFF
--- a/Sources/Common/OACollatorStringMatcher.m
+++ b/Sources/Common/OACollatorStringMatcher.m
@@ -63,7 +63,7 @@ static NSCharacterSet * _APOSTROPHES;
 
 + (BOOL) cmatches:(NSString *)fullName part:(NSString *)part alignPart:(BOOL)alignPart  mode:(StringMatcherMode)mode
 {
-    if (fullName != nil && [self.class containsHyphen:fullName])
+    if (fullName != nil && [fullName rangeOfString:@"-"].location != NSNotFound)
     {
         NSString *stringWithoutHyphen = [self replaceHyphen:fullName replacement:@("")];
         if ([self.class cmatches:stringWithoutHyphen part:part mode:mode])
@@ -221,19 +221,7 @@ static NSCharacterSet * _APOSTROPHES;
 
 + (BOOL) isSpace:(unichar) c
 {
-    // Called per character of every compared name: avoid re-fetching the shared
-    // NSCharacterSets and short-circuit the ASCII range.
-    if (c < 0x80)
-        return !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'));
-
-    static NSCharacterSet *letters;
-    static NSCharacterSet *digits;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        letters = [NSCharacterSet letterCharacterSet];
-        digits = [NSCharacterSet decimalDigitCharacterSet];
-    });
-    return ![letters characterIsMember:c] && ![digits characterIsMember:c];
+    return ![[NSCharacterSet letterCharacterSet] characterIsMember:c] && ![[NSCharacterSet decimalDigitCharacterSet] characterIsMember:c];
 }
 
 + (BOOL)isWordStart:(NSString *)searchIn index:(int)index part:(NSString *)part
@@ -248,53 +236,16 @@ static NSCharacterSet * _APOSTROPHES;
     {
         return YES;
     }
-    if (current != '-' || part.length <= 1 || [part characterAtIndex:0] != '-')
-        return NO;
-    const unichar second = [part characterAtIndex:1];
-    if (second < 0x80)
-        return second >= '0' && second <= '9';
-    return [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:second];
+    return (current == '-' && part.length > 1 &&
+            [part characterAtIndex:0] == '-' &&
+            [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[part characterAtIndex:1]]);
 }
 
 + (NSString *) lowercaseAndAlignChars:(NSString *)fullText
 {
-    return [self alignChars:[self lowerCaseIfNeeded:fullText]];
-}
-
-// -lowerCase resolves +[NSLocale currentLocale] and runs a locale-aware fold on every
-// call. It runs on every compared name, so skip it when the text holds no character
-// that lowercasing could possibly change.
-+ (NSString *) lowerCaseIfNeeded:(NSString *)text
-{
-    const CFIndex length = text.length;
-    if (length == 0) // also covers a nil string, which callers do pass
-        return text;
-
-    CFStringInlineBuffer buffer;
-    CFStringInitInlineBuffer((__bridge CFStringRef) text, &buffer, CFRangeMake(0, length));
-    for (CFIndex i = 0; i < length; i++)
-    {
-        const UniChar c = CFStringGetCharacterFromInlineBuffer(&buffer, i);
-        if (c >= 0x80 || (c >= 'A' && c <= 'Z'))
-            return text.lowerCase;
-    }
-    return text;
-}
-
-+ (BOOL) containsHyphen:(NSString *)text
-{
-    const CFIndex length = text.length;
-    if (length == 0) // also covers a nil string, which callers do pass
-        return NO;
-
-    CFStringInlineBuffer buffer;
-    CFStringInitInlineBuffer((__bridge CFStringRef) text, &buffer, CFRangeMake(0, length));
-    for (CFIndex i = 0; i < length; i++)
-    {
-        if (CFStringGetCharacterFromInlineBuffer(&buffer, i) == '-')
-            return YES;
-    }
-    return NO;
+    fullText = fullText.lowerCase;
+    fullText = [self alignChars:fullText];
+    return fullText;
 }
 
 + (NSString *) alignChars:(NSString *)fullText
@@ -304,9 +255,6 @@ static NSCharacterSet * _APOSTROPHES;
 
 + (NSString *) replaceHyphen:(NSString *)text replacement:(NSString *)replacement
 {
-    // Avoid allocating a copy when there is nothing to replace
-    if (![self containsHyphen:text])
-        return text;
     return [text stringByReplacingOccurrencesOfString:@"-" withString:replacement];
 }
 

--- a/Sources/Common/OACollatorStringMatcher.m
+++ b/Sources/Common/OACollatorStringMatcher.m
@@ -63,7 +63,7 @@ static NSCharacterSet * _APOSTROPHES;
 
 + (BOOL) cmatches:(NSString *)fullName part:(NSString *)part alignPart:(BOOL)alignPart  mode:(StringMatcherMode)mode
 {
-    if (fullName != nil && [fullName rangeOfString:@"-"].location != NSNotFound)
+    if (fullName != nil && [self.class containsHyphen:fullName])
     {
         NSString *stringWithoutHyphen = [self replaceHyphen:fullName replacement:@("")];
         if ([self.class cmatches:stringWithoutHyphen part:part mode:mode])
@@ -148,6 +148,9 @@ static NSCharacterSet * _APOSTROPHES;
  * Checks if string starts with another string.
  * Special check try to find as well in the middle of name
  *
+ * Both arguments must already be lowercased and aligned (see +lowercaseAndAlignChars:);
+ * +cmatches: is the only caller and does that once for both strings.
+ *
  * @param fullTextP
  * @param theStart
  * @param fullText
@@ -155,12 +158,10 @@ static NSCharacterSet * _APOSTROPHES;
  */
 + (BOOL) cstartsWith:(NSString *)fullTextP theStart:(NSString *)theStart checkBeginning:(BOOL)checkBeginning checkSpaces:(BOOL)checkSpaces equals:(BOOL)equals
 {
-    // FUTURE: This is not effective code, it runs on each comparision
-    // It would be more efficient to normalize all strings in file and normalize search string before collator
-    theStart = [self alignChars:theStart];
+    // Both strings arrive normalized from +cmatches: (as in the Java original, where
+    // cstartsWith() does no normalization of its own), so only hyphens are folded here.
     theStart = [self replaceHyphen:theStart replacement:@(" ")];
-    NSString *searchIn = [self lowercaseAndAlignChars:fullTextP];
-    searchIn = [self replaceHyphen:searchIn replacement:@(" ")];
+    NSString *searchIn = [self replaceHyphen:fullTextP replacement:@(" ")];
     NSInteger searchInLength = searchIn.length;
     
     NSInteger startLength = theStart.length;
@@ -220,7 +221,19 @@ static NSCharacterSet * _APOSTROPHES;
 
 + (BOOL) isSpace:(unichar) c
 {
-    return ![[NSCharacterSet letterCharacterSet] characterIsMember:c] && ![[NSCharacterSet decimalDigitCharacterSet] characterIsMember:c];
+    // Called per character of every compared name: avoid re-fetching the shared
+    // NSCharacterSets and short-circuit the ASCII range.
+    if (c < 0x80)
+        return !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'));
+
+    static NSCharacterSet *letters;
+    static NSCharacterSet *digits;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        letters = [NSCharacterSet letterCharacterSet];
+        digits = [NSCharacterSet decimalDigitCharacterSet];
+    });
+    return ![letters characterIsMember:c] && ![digits characterIsMember:c];
 }
 
 + (BOOL)isWordStart:(NSString *)searchIn index:(int)index part:(NSString *)part
@@ -235,16 +248,53 @@ static NSCharacterSet * _APOSTROPHES;
     {
         return YES;
     }
-    return (current == '-' && part.length > 1 &&
-            [part characterAtIndex:0] == '-' &&
-            [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[part characterAtIndex:1]]);
+    if (current != '-' || part.length <= 1 || [part characterAtIndex:0] != '-')
+        return NO;
+    const unichar second = [part characterAtIndex:1];
+    if (second < 0x80)
+        return second >= '0' && second <= '9';
+    return [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:second];
 }
 
 + (NSString *) lowercaseAndAlignChars:(NSString *)fullText
 {
-    fullText = fullText.lowerCase;
-    fullText = [self alignChars:fullText];
-    return fullText;
+    return [self alignChars:[self lowerCaseIfNeeded:fullText]];
+}
+
+// -lowerCase resolves +[NSLocale currentLocale] and runs a locale-aware fold on every
+// call. It runs on every compared name, so skip it when the text holds no character
+// that lowercasing could possibly change.
++ (NSString *) lowerCaseIfNeeded:(NSString *)text
+{
+    const CFIndex length = text.length;
+    if (length == 0) // also covers a nil string, which callers do pass
+        return text;
+
+    CFStringInlineBuffer buffer;
+    CFStringInitInlineBuffer((__bridge CFStringRef) text, &buffer, CFRangeMake(0, length));
+    for (CFIndex i = 0; i < length; i++)
+    {
+        const UniChar c = CFStringGetCharacterFromInlineBuffer(&buffer, i);
+        if (c >= 0x80 || (c >= 'A' && c <= 'Z'))
+            return text.lowerCase;
+    }
+    return text;
+}
+
++ (BOOL) containsHyphen:(NSString *)text
+{
+    const CFIndex length = text.length;
+    if (length == 0) // also covers a nil string, which callers do pass
+        return NO;
+
+    CFStringInlineBuffer buffer;
+    CFStringInitInlineBuffer((__bridge CFStringRef) text, &buffer, CFRangeMake(0, length));
+    for (CFIndex i = 0; i < length; i++)
+    {
+        if (CFStringGetCharacterFromInlineBuffer(&buffer, i) == '-')
+            return YES;
+    }
+    return NO;
 }
 
 + (NSString *) alignChars:(NSString *)fullText
@@ -254,6 +304,9 @@ static NSCharacterSet * _APOSTROPHES;
 
 + (NSString *) replaceHyphen:(NSString *)text replacement:(NSString *)replacement
 {
+    // Avoid allocating a copy when there is nothing to replace
+    if (![self containsHyphen:text])
+        return text;
     return [text stringByReplacingOccurrencesOfString:@"-" withString:replacement];
 }
 

--- a/Sources/Common/OASearchAlgorithms.mm
+++ b/Sources/Common/OASearchAlgorithms.mm
@@ -102,11 +102,6 @@
     return [result copy];
 }
 
-// alignChars() is the identity for pure-ASCII text without apostrophe-like characters:
-// removeApostrophes / replaceGermanSS / removeQuotes / stripDiacritics and the Arabic
-// normalization all only touch non-ASCII, ' and `. Detecting that here avoids the
-// NSString -> QString -> NSString round trip, which the search hot path repeats for
-// every compared name.
 + (BOOL)needsAlignChars:(NSString *)text
 {
     const CFIndex length = text.length;

--- a/Sources/Common/OASearchAlgorithms.mm
+++ b/Sources/Common/OASearchAlgorithms.mm
@@ -102,8 +102,32 @@
     return [result copy];
 }
 
+// alignChars() is the identity for pure-ASCII text without apostrophe-like characters:
+// removeApostrophes / replaceGermanSS / removeQuotes / stripDiacritics and the Arabic
+// normalization all only touch non-ASCII, ' and `. Detecting that here avoids the
+// NSString -> QString -> NSString round trip, which the search hot path repeats for
+// every compared name.
++ (BOOL)needsAlignChars:(NSString *)text
+{
+    const CFIndex length = text.length;
+    if (length == 0) // also covers a nil string, which callers do pass
+        return NO;
+
+    CFStringInlineBuffer buffer;
+    CFStringInitInlineBuffer((__bridge CFStringRef) text, &buffer, CFRangeMake(0, length));
+    for (CFIndex i = 0; i < length; i++)
+    {
+        const UniChar c = CFStringGetCharacterFromInlineBuffer(&buffer, i);
+        if (c >= 0x80 || c == 0x0027 /* ' */ || c == 0x0060 /* ` */)
+            return YES;
+    }
+    return NO;
+}
+
 + (NSString *)alignChars:(NSString *)fullText
 {
+    if (![self needsAlignChars:fullText])
+        return fullText;
     return OsmAnd::SearchAlgorithms::alignChars(QString::fromNSString(fullText)).toNSString();
 }
 


### PR DESCRIPTION
## Related issue / task

Part of osmandapp/OsmAnd#24943 (search performance on iOS).

## Summary

The shared `SearchUICoreTest` corpus (60 cases / 143 phrases, `resources/test-resources/search`) runs on both platforms, so it is a direct A/B against Android. On the same corpus:

| | Time |
|---|---|
| Android (`OsmAnd-java`) | 6.4 s |
| iOS Release, master | 23.1 s |
| **iOS Release, this PR** | **13.8 s (-40%)** |
| iOS Debug, master → this PR | 48.7 s → 27.1 s |

Profiling a **Release** build showed the search was not spending its time comparing strings but preparing them. On Android 54% of the run is the actual `RuleBasedCollator` comparison and 12% is `alignChars`; on iOS only **1.1%** was the actual `compare:options:` and **33%** was `alignChars`.

The cause is redundant per-comparison work in `OACollatorStringMatcher`, none of which the Java original does:

* `+cstartsWith:` lowercased and aligned the full name that `+cmatches:` had **already** normalized, and re-aligned a part that `-initWithPart:` had already aligned. Java's `cstartsWith()` takes normalized strings and does no normalization at all. So `alignChars` ran 3x per `matches:` (7x when the name contains a hyphen) instead of once — and every call crosses the `NSString -> QString -> C++ -> QString -> NSString` bridge into `SearchAlgorithms::alignChars`.
* `+alignChars:` always crossed that bridge even though it is the identity for pure-ASCII text without apostrophe-like characters — which is most POI type names. `removeApostrophes` / `replaceGermanSS` / `removeQuotes` / `stripDiacritics` / the Arabic normalization only touch non-ASCII, `'` and `` ` ``, so the ASCII fast path is exact.
* `+isSpace:` re-fetched `[NSCharacterSet letterCharacterSet]` and `decimalDigitCharacterSet` **for every character** of every compared name.
* `+replaceHyphen:` allocated a copy even with no hyphen, and `-lowerCase` resolved `+[NSLocale currentLocale]` even for text with nothing to lowercase.

No behaviour change is intended: same algorithm, same comparisons, same results.

Note for reviewers: `+cstartsWith:` and `+ccontains:` are declared in the header but have no callers outside this class; `+cstartsWith:` now documents that it expects already-normalized input, matching the Java contract.

### Not the cause (measured, so nobody has to re-check)

`ICU::stripDiacritics` was a suspect — it is **0.19 s of a 14.1 s Release run (1.4%)** and already early-outs on text with no combining marks.

### Still open after this PR (Release profile of the remaining 14.1 s)

Filed here so the numbers are not lost; not addressed in this PR:

1. **`ObfsCollectionProxy::obtainDataInterface` — 7% (1.0 s, of which 0.6 s is raw `open()` syscalls).** It constructs a fresh `ObfReader` and re-opens the `.obf` file on *every* call, and search calls it per sub-search (street, building, city) per index in radius. Android keeps `BinaryMapIndexReader`s open in `ResourceManager`. This scales with the number of installed maps and is the prime suspect for the QA report that ~200 installed maps push iOS search to minutes.
2. **POI type enumeration — 27% (3.8 s).** ~5k types x 4 name fields x 2 calls per query, re-normalized on every query although the names are constants. The right fix is normalize-once storage on the type, not a cache in the matcher (a memoizing `NSCache` was measured at only -4% and is deliberately not included here).
3. **Result sort/dedup — 11% (1.6 s) against Android's 0.22 s.** A 7x gap that deserves its own look.

## Testing

**Tested on:**

- Device / Simulator: iPhone 17 Simulator (arm64), Release configuration
- iOS: 26.5

### Scenarios

- `xcodebuild test -only-testing:"OsmAnd MapsTests/SearchUICoreTest"` — 60/60 cases pass (0 failures) both before and after, in Debug and in Release.
- Each of the five changes was applied and timed separately (Debug baseline 48.7 s): drop the double normalization in `cstartsWith` 35.7 s → guard `replaceHyphen` 34.1 s → ASCII fast path in `alignChars` 29.2 s → fast `isSpace:` 28.0 s → skip `lowerCase` when nothing can change 27.1 s.
- Release measurements were taken with a Release build of `OsmAndCore_static_standalone` for the simulator, not the checked-in 2024 binaries.

## Relevant checks

- [ ] Portrait / Landscape tested
- [ ] Light / Dark mode tested
- [ ] Different profiles tested
- [ ] Localization / RTL checked
- [ ] VoiceOver / Accessibility checked
- [ ] CarPlay checked
- [x] Android parity checked
- [x] Performance impact checked

## AI disclaimer

**Implementation:**

- Tool / Agent: Claude Code
- Model: Opus 5

**Prompts used (summarised):**

1. Run the iOS search tests, measure their performance and compare with the Android tests; Android is much faster, work out why and where iOS is slow, given that C++ should be the faster side.
2. Try to build a Release build for the tests — the fix has to be made against Release, otherwise we may fix the collator while something else is the real bottleneck in Release.
3. Maybe `stripDiacritics` is the slow part — measure both platforms in Release in seconds for the whole run, give your own hypothesis and fix, and apply it.
4. Open a draft pull request.

**Decided by the agent, not requested explicitly:**

- Which five micro-optimisations to make, and measuring each one separately rather than as one batch.
- Deliberately excluding a memoising `NSCache` for `lowercaseAndAlignChars:` that was implemented and measured at only -4%, because the normalization belongs at the source (POI types) rather than in a global cache.
- Documenting the new "input must already be normalized" contract of `+cstartsWith:` in the header/implementation comments.
- Listing the three remaining hot spots above instead of silently dropping the measurements.

**Final review:**

- Tool / Agent: Claude Code
- Model: Opus 5
- [x] Final diff reviewed

**Significant findings:** A first version of this change crashed the test suite in `CFStringInitInlineBuffer` because the refactored character scans dropped the empty/nil-string guard (callers do pass nil, e.g. `nameSynonyms`). Fixed and re-verified before pushing.
