### PR TITLE
Fix CarPlay search result crashes

### DIFF
--- a/Sources/CarPlay/CarPlayDirectionsControllers/OACarPlayAddressSearchController.mm
+++ b/Sources/CarPlay/CarPlayDirectionsControllers/OACarPlayAddressSearchController.mm
@@ -224,60 +224,60 @@
 - (void) updateSearchResult:(OASearchResultCollection *)res
           completionHandler:(void (^)(NSArray<CPListItem *> *searchResults))completionHandler
 {
-    NSMutableArray<OAQuickSearchListItem *> *searchItems = [NSMutableArray array];
-    NSMutableArray<CPListItem *> *cpItems = [NSMutableArray array];
-
-    if (_searching && _currentSearchPhrase.length > 0)
-        [cpItems addObject:_searchingItem];
-
-    NSInteger maximumItemCount = (NSInteger)CPListTemplate.maximumItemCount - 1;
-    if (res && [res getCurrentSearchResults].count > 0)
-    {
-        NSArray<OASearchResult *> *searchResultItems = [res getCurrentSearchResults];
-        OASearchWord* lastWord = res.phrase.getLastSelectedWord;
-        NSInteger inc = 1;
-        if (lastWord.getType == EOAObjectTypeStreet)
-        {
-            inc = searchResultItems.count / maximumItemCount;
-        }
-        __weak __typeof(self) weakSelf = self;
-        for (NSInteger i = 0; i < searchResultItems.count; i+= inc)
-        {
-            if (cpItems.count >= maximumItemCount)
-                break;
-
-            OASearchResult *sr = searchResultItems[i];
-            NSString *imageName = [OAQuickSearchListItem getIconName:sr] ?: @"";
-            UIImage *image = [UIImage mapSvgImageNamed:imageName] ?: [UIImage imageNamed:imageName];
-            OAQuickSearchListItem *qsItem = [[OAQuickSearchListItem alloc] initWithSearchResult:sr];
-            CPListItem *cpItem = [[CPListItem alloc] initWithText:qsItem.getName
-                                                       detailText:[self generateDescription:qsItem]
-                                                            image:image
-                                                   accessoryImage:[self getAccessoryImageFor:sr.objectType] accessoryType:CPListItemAccessoryTypeDisclosureIndicator];
-            cpItem.userInfo = @{
-                @"index": @(i),
-                @"searchListItem": qsItem
-            };
-            cpItem.handler = ^(id <CPSelectableListItem> item, dispatch_block_t completionBlock) {
-                [weakSelf onItemSelected:item completionHandler:completionHandler];
-                if (completionBlock)
-                    completionBlock();
-            };
-
-            [searchItems addObject:qsItem];
-            [cpItems addObject:cpItem];
-        }
-    }
-    else if (!_searching && _currentSearchPhrase.length > 0)
-    {
-        [cpItems addObject:_emptyItem];
-    }
-
-    _searchItems = searchItems;
-    _cpItems = cpItems;
+    NSArray<OASearchResult *> *searchResultItems = res ? [[res getCurrentSearchResults] copy] : @[];
+    BOOL isStreetResult = res && res.phrase.getLastSelectedWord.getType == EOAObjectTypeStreet;
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [_resultsListTemplate updateSections:@[[[CPListSection alloc] initWithItems:_cpItems]]];
+        NSMutableArray<OAQuickSearchListItem *> *searchItems = [NSMutableArray array];
+        NSMutableArray<CPListItem *> *cpItems = [NSMutableArray array];
+
+        if (_searching && _currentSearchPhrase.length > 0)
+            [cpItems addObject:_searchingItem];
+
+        NSInteger maximumItemCount = (NSInteger)CPListTemplate.maximumItemCount - 1;
+        if (searchResultItems.count > 0)
+        {
+            NSInteger inc = 1;
+            if (isStreetResult)
+                inc = searchResultItems.count / maximumItemCount;
+
+            __weak __typeof(self) weakSelf = self;
+            for (NSInteger i = 0; i < searchResultItems.count; i += inc)
+            {
+                if (cpItems.count >= maximumItemCount)
+                    break;
+
+                OASearchResult *sr = searchResultItems[i];
+                NSString *imageName = [OAQuickSearchListItem getIconName:sr] ?: @"";
+                UIImage *image = [UIImage mapSvgImageNamed:imageName] ?: [UIImage imageNamed:imageName];
+                OAQuickSearchListItem *qsItem = [[OAQuickSearchListItem alloc] initWithSearchResult:sr];
+                CPListItem *cpItem = [[CPListItem alloc] initWithText:qsItem.getName
+                                                           detailText:[self generateDescription:qsItem]
+                                                                image:image
+                                                       accessoryImage:[self getAccessoryImageFor:sr.objectType] accessoryType:CPListItemAccessoryTypeDisclosureIndicator];
+                cpItem.userInfo = @{
+                    @"index": @(i),
+                    @"searchListItem": qsItem
+                };
+                cpItem.handler = ^(id <CPSelectableListItem> item, dispatch_block_t completionBlock) {
+                    [weakSelf onItemSelected:(CPListItem *)item completionHandler:completionHandler];
+                    if (completionBlock)
+                        completionBlock();
+                };
+
+                [searchItems addObject:qsItem];
+                [cpItems addObject:cpItem];
+            }
+        }
+        else if (!_searching && _currentSearchPhrase.length > 0)
+        {
+            [cpItems addObject:_emptyItem];
+        }
+
+        _searchItems = [searchItems copy];
+        _cpItems = [cpItems copy];
+        CPListSection *section = [[CPListSection alloc] initWithItems:_cpItems];
+        [_resultsListTemplate updateSections:@[section]];
         if (completionHandler)
             completionHandler(@[]);
     });

--- a/Sources/Controllers/TargetMenu/Search/OAQuickSearchListItem.mm
+++ b/Sources/Controllers/TargetMenu/Search/OAQuickSearchListItem.mm
@@ -29,6 +29,7 @@
 #import "OAOsmAndFormatter.h"
 #import "OAPOIUIFilter.h"
 #import "OAPOIFiltersHelper.h"
+#import "OATopIndexFilter.h"
 #import "OAFavoriteItem.h"
 #import "OAFavoritesHelper.h"
 #import "OsmAndSharedWrapper.h"
@@ -159,6 +160,11 @@
                     iconName = [OAPOIUIFilter getCustomFilterIconName:filter];
                 return iconName && iconName.length > 0 ? iconName : @"ic_custom_search";
             }
+            else if ([searchResult.object isKindOfClass:OATopIndexFilter.class])
+            {
+                return [((OATopIndexFilter *)searchResult.object) getIconResource];
+            }
+            return @"ic_custom_search";
         }
         case EOAObjectTypePoi:
         {


### PR DESCRIPTION
## Related issue / task

N/A — based on an Xcode Organizer crash report and a reproduced CarPlay search crash.

## Summary

- Snapshot search results before dispatching UI work to the main queue.
- Create `CPListItem` and `CPListSection` objects on the main thread.
- Update CarPlay list sections and the corresponding result arrays on the main thread.
- Keep immutable copies of the published search item arrays.
- Handle `OATopIndexFilter` explicitly when resolving POI type icons.
- Prevent POI type icon handling from falling through and treating a filter as an `OAPOI`.

## Testing

- Build not run (per request).
- Automated tests not run (per request).
- Manual verification after applying the fixes is pending.

## Relevant checks

- [ ] Portrait / Landscape tested
- [ ] Light / Dark mode tested
- [ ] Different profiles tested
- [ ] Localization / RTL checked
- [ ] VoiceOver / Accessibility checked
- [x] CarPlay checked
- [ ] Android parity checked
- [ ] Performance impact checked

## AI disclaimer

**Implementation:**

- Tool / Agent: Codex
- Model: GPT-5

**Prompts used, summarized:**

1. Analyze the Xcode Organizer crash in `CPListSection initWithItems:`.
2. Fix the race between background search callbacks and main-thread CarPlay list updates.
3. Ensure CarPlay list objects are created and used on the main thread.
4. Analyze and fix the `OATopIndexFilter iconName` unrecognized-selector crash.
5. Prepare a pull request targeting `r5.4`.

**Decisions made by the agent:**

- Read and copy the search result collection on its callback queue before crossing the asynchronous boundary.
- Move CarPlay object construction and template updates into one main-queue block.
- Publish immutable arrays and use the same stored item collection for the list section.
- Add explicit top-index filter icon handling and a safe fallback for unknown POI type objects.

**Final review:**

- Tool / Agent: Codex
- Model: GPT-5
- [x] Final diff reviewed
