### PR TITLE
Follow up analyze tab

### DIFF
--- a/Sources/Controllers/PlanRoute/GetElevationDataViewController.swift
+++ b/Sources/Controllers/PlanRoute/GetElevationDataViewController.swift
@@ -8,6 +8,18 @@
 
 import UIKit
 
+private enum GetElevationDataSheetLayout {
+    static let panelWidth: CGFloat = 393
+    static let horizontalInset: CGFloat = 16
+    static let phoneTopInset: CGFloat = 20
+    static let padTopInset: CGFloat = 8
+    static let verticalInset: CGFloat = 16
+    static let minimumMapWidth: CGFloat = 252
+    static let cornerRadius: CGFloat = 20
+    static let animationDuration: TimeInterval = 0.3
+    static let dimmingAlpha: CGFloat = 0.2
+}
+
 final class GetElevationDataViewController: UIViewController {
 
     var onSelectMethod: ((Bool) -> Void)?
@@ -16,10 +28,13 @@ final class GetElevationDataViewController: UIViewController {
     private let titleLabel = UILabel()
     private let descriptionLabel = UILabel()
     private let separatorView = SeparatorView()
+    private let sheetTransitioningDelegate = GetElevationDataSheetTransitioningDelegate()
 
     init(isTerrainMapsAvailable: Bool) {
         self.isTerrainMapsAvailable = isTerrainMapsAvailable
         super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .custom
+        transitioningDelegate = sheetTransitioningDelegate
     }
 
     required init?(coder: NSCoder) {
@@ -87,20 +102,22 @@ final class GetElevationDataViewController: UIViewController {
             optionsCard.addSubview($0)
         }
 
+        let safeArea = view.safeAreaLayoutGuide
         NSLayoutConstraint.activate([
-            closeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 16),
-            closeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            closeButton.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 16),
+            closeButton.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 16),
 
             titleLabel.centerYAnchor.constraint(equalTo: closeButton.centerYAnchor),
-            titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            titleLabel.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
 
             descriptionLabel.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 16),
-            descriptionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
-            descriptionLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            descriptionLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 32),
+            descriptionLabel.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -16),
 
             optionsCard.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 16),
-            optionsCard.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            optionsCard.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            optionsCard.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 16),
+            optionsCard.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -16),
+            optionsCard.bottomAnchor.constraint(lessThanOrEqualTo: safeArea.bottomAnchor, constant: -16),
 
             nearbyRoadsRow.topAnchor.constraint(equalTo: optionsCard.topAnchor),
             nearbyRoadsRow.leadingAnchor.constraint(equalTo: optionsCard.leadingAnchor),
@@ -200,12 +217,201 @@ final class GetElevationDataViewController: UIViewController {
 
     @objc private func onTerrainMaps() {
         guard OAIAPHelper.isOsmAndProAvailable() else {
-            guard let navigationController else { return }
-            OAChoosePlanHelper.showChoosePlanScreen(with: OAFeature.terrain(), navController: navigationController)
+            let choosePlanViewController = OAChoosePlanViewController(feature: OAFeature.terrain())
+            let navController = UINavigationController(rootViewController: choosePlanViewController)
+            navController.isNavigationBarHidden = true
+            navController.edgesForExtendedLayout = []
+            present(navController, animated: true)
             return
         }
         dismiss(animated: true) { [weak self] in
             self?.onSelectMethod?(false)
         }
+    }
+}
+
+final class GetElevationDataSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
+
+    func presentationController(forPresented presented: UIViewController,
+                               presenting: UIViewController?,
+                               source: UIViewController) -> UIPresentationController? {
+        GetElevationDataSheetPresentationController(presentedViewController: presented, presenting: presenting)
+    }
+
+    func animationController(forPresented presented: UIViewController,
+                            presenting: UIViewController,
+                            source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        GetElevationDataSheetAnimator(isPresenting: true)
+    }
+
+    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        GetElevationDataSheetAnimator(isPresenting: false)
+    }
+}
+
+final class GetElevationDataSheetPresentationController: UIPresentationController {
+
+    private lazy var dimmingView: UIView = {
+        let dimming = UIView()
+        dimming.backgroundColor = UIColor.black.withAlphaComponent(GetElevationDataSheetLayout.dimmingAlpha)
+        dimming.alpha = 0
+        dimming.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onDimmingTapped)))
+        return dimming
+    }()
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView else { return .zero }
+        return frame(for: containerView.bounds.size, safeArea: containerView.safeAreaInsets)
+    }
+
+    override func presentationTransitionWillBegin() {
+        super.presentationTransitionWillBegin()
+        guard let containerView else { return }
+        dimmingView.frame = containerView.bounds
+        dimmingView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        containerView.addSubview(dimmingView)
+        if let presentedView {
+            presentedView.layer.cornerRadius = GetElevationDataSheetLayout.cornerRadius
+            presentedView.layer.masksToBounds = true
+        }
+        applyCornerMask(for: containerView.bounds.size)
+        presentedViewController.transitionCoordinator?.animate { [weak self] _ in
+            self?.dimmingView.alpha = 1
+        }
+    }
+
+    override func dismissalTransitionWillBegin() {
+        super.dismissalTransitionWillBegin()
+        presentedViewController.transitionCoordinator?.animate { [weak self] _ in
+            self?.dimmingView.alpha = 0
+        }
+    }
+
+    override func containerViewWillLayoutSubviews() {
+        super.containerViewWillLayoutSubviews()
+        guard let containerView else { return }
+        dimmingView.frame = containerView.bounds
+        applyCornerMask(for: containerView.bounds.size)
+        if presentedViewController.transitionCoordinator == nil {
+            presentedView?.frame = frameOfPresentedViewInContainerView
+        }
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate { [weak self] _ in
+            guard let self, let containerView else { return }
+            presentedView?.frame = frame(for: size, safeArea: containerView.safeAreaInsets)
+            applyCornerMask(for: size)
+        } completion: { [weak self] _ in
+            guard let self, let containerView else { return }
+            presentedView?.frame = frameOfPresentedViewInContainerView
+            applyCornerMask(for: containerView.bounds.size)
+        }
+    }
+
+    @objc private func onDimmingTapped() {
+        presentingViewController.dismiss(animated: true)
+    }
+
+    private func isPhoneLandscape(_ size: CGSize) -> Bool {
+        !OAUtilities.isIPad() && !OAUtilities.isiOSAppOnMac() && size.width > size.height
+    }
+
+    private func isSidePanel(for size: CGSize, safeArea: UIEdgeInsets) -> Bool {
+        guard OAUtilities.isIPad() || OAUtilities.isiOSAppOnMac() || size.width > size.height else { return false }
+        let leftInset = max(GetElevationDataSheetLayout.horizontalInset, safeArea.left)
+        let visibleMapWidth = size.width - leftInset - GetElevationDataSheetLayout.panelWidth - safeArea.right
+        return visibleMapWidth >= GetElevationDataSheetLayout.minimumMapWidth
+    }
+
+    private func frame(for size: CGSize, safeArea: UIEdgeInsets) -> CGRect {
+        if isSidePanel(for: size, safeArea: safeArea) {
+            let left = max(GetElevationDataSheetLayout.horizontalInset, safeArea.left)
+            let top = isPhoneLandscape(size)
+                ? max(GetElevationDataSheetLayout.phoneTopInset, safeArea.top)
+                : safeArea.top + GetElevationDataSheetLayout.padTopInset
+            let bottom = isPhoneLandscape(size)
+                ? 0
+                : max(GetElevationDataSheetLayout.verticalInset, safeArea.bottom)
+            return CGRect(x: left,
+                          y: top,
+                          width: GetElevationDataSheetLayout.panelWidth,
+                          height: max(0, size.height - top - bottom))
+        }
+        let contentHeight = measuredContentHeight(forWidth: size.width)
+        let maxHeight = size.height - safeArea.top - 24
+        let height = min(contentHeight + safeArea.bottom, maxHeight)
+        return CGRect(x: 0, y: size.height - height, width: size.width, height: height)
+    }
+
+    private func measuredContentHeight(forWidth width: CGFloat) -> CGFloat {
+        guard width > 0, let contentView = presentedViewController.view else { return 320 }
+        let target = CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
+        let fitting = contentView.systemLayoutSizeFitting(target,
+                                                          withHorizontalFittingPriority: .required,
+                                                          verticalFittingPriority: .fittingSizeLevel)
+        let insets = contentView.safeAreaInsets
+        return max(160, ceil(fitting.height - insets.top - insets.bottom))
+    }
+
+    private func applyCornerMask(for size: CGSize) {
+        guard let presentedView else { return }
+        let roundsAllCorners = isSidePanel(for: size, safeArea: containerView?.safeAreaInsets ?? .zero)
+            && !isPhoneLandscape(size)
+        presentedView.layer.maskedCorners = roundsAllCorners
+            ? [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+            : [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    }
+}
+
+final class GetElevationDataSheetAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+
+    private let isPresenting: Bool
+
+    init(isPresenting: Bool) {
+        self.isPresenting = isPresenting
+        super.init()
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        GetElevationDataSheetLayout.animationDuration
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        let container = transitionContext.containerView
+        let duration = transitionDuration(using: transitionContext)
+        if isPresenting {
+            guard let toViewController = transitionContext.viewController(forKey: .to),
+                  let toView = transitionContext.view(forKey: .to) else {
+                transitionContext.completeTransition(false)
+                return
+            }
+            let finalFrame = transitionContext.finalFrame(for: toViewController)
+            toView.frame = finalFrame
+            toView.transform = offscreenTransform(for: finalFrame, in: container)
+            container.addSubview(toView)
+            UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseOut], animations: {
+                toView.transform = .identity
+            }, completion: { _ in
+                transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+            })
+        } else {
+            guard let fromView = transitionContext.view(forKey: .from) else {
+                transitionContext.completeTransition(false)
+                return
+            }
+            let targetTransform = offscreenTransform(for: fromView.frame, in: container)
+            UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseIn], animations: {
+                fromView.transform = targetTransform
+            }, completion: { _ in
+                fromView.removeFromSuperview()
+                transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+            })
+        }
+    }
+
+    private func offscreenTransform(for frame: CGRect, in container: UIView) -> CGAffineTransform {
+        CGAffineTransform(translationX: 0, y: container.bounds.height - frame.minY)
     }
 }

--- a/Sources/Controllers/PlanRoute/GetElevationDataViewController.swift
+++ b/Sources/Controllers/PlanRoute/GetElevationDataViewController.swift
@@ -46,11 +46,6 @@ final class GetElevationDataViewController: UIViewController {
         setupView()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: animated)
-    }
-
     private func setupView() {
         view.backgroundColor = .viewBg
 
@@ -230,7 +225,7 @@ final class GetElevationDataViewController: UIViewController {
     }
 }
 
-final class GetElevationDataSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
+private final class GetElevationDataSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
 
     func presentationController(forPresented presented: UIViewController,
                                presenting: UIViewController?,
@@ -249,7 +244,7 @@ final class GetElevationDataSheetTransitioningDelegate: NSObject, UIViewControll
     }
 }
 
-final class GetElevationDataSheetPresentationController: UIPresentationController {
+private final class GetElevationDataSheetPresentationController: UIPresentationController {
 
     private lazy var dimmingView: UIView = {
         let dimming = UIView()
@@ -267,6 +262,7 @@ final class GetElevationDataSheetPresentationController: UIPresentationControlle
     override func presentationTransitionWillBegin() {
         super.presentationTransitionWillBegin()
         guard let containerView else { return }
+        containerView.accessibilityViewIsModal = true
         dimmingView.frame = containerView.bounds
         dimmingView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         containerView.addSubview(dimmingView)
@@ -365,7 +361,7 @@ final class GetElevationDataSheetPresentationController: UIPresentationControlle
     }
 }
 
-final class GetElevationDataSheetAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+private final class GetElevationDataSheetAnimator: NSObject, UIViewControllerAnimatedTransitioning {
 
     private let isPresenting: Bool
 

--- a/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteScrollableViewController.swift
@@ -1156,8 +1156,7 @@ final class PlanRouteScrollableViewController: OABaseScrollableHudViewController
         case .analyze:
             let analyzeViewController = PlanRouteAnalyzeViewController(dataSource: dataProvider)
             analyzeViewController.onAttachToRoadsRequested = { [weak self] in
-                guard let self, dataProvider.isApproximationNeeded else { return }
-                presentApproximationWarning(force: true)
+                self?.presentApproximationWarning(force: true)
             }
             return analyzeViewController
         case .route:

--- a/Sources/Controllers/PlanRoute/PlanRouteToolbarsView.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteToolbarsView.swift
@@ -91,6 +91,8 @@ final class PlanRouteTopToolbarView: TouchesPassView {
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
+        saveButton.tintAdjustmentMode = .normal
+        
         let trailingStack = UIStackView(arrangedSubviews: [optionsButton, saveButton])
         trailingStack.spacing = Self.buttonSpacing
         trailingStack.alignment = .center

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
@@ -70,6 +70,8 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
     ]
     private var selectedXAxisType: GPXDataSetAxisType = .distance
     private var expandedStatIndexes: Set<Int> = []
+    private var measuredRowHeights: [String: CGFloat] = [:]
+    private var lastLayoutWidth: CGFloat = 0
     private var allowsTerrainFallbackSteepness = false
     private var wasCalculatingElevation = false
     private var hasCompletedElevationCalculation = false
@@ -151,6 +153,16 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         reloadData()
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        let width = tableView.bounds.width
+        guard width > 0, width != lastLayoutWidth else { return }
+        lastLayoutWidth = width
+        guard !measuredRowHeights.isEmpty else { return }
+        measuredRowHeights.removeAll()
+        tableView.reloadData()
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         hideChartLocation()
@@ -188,6 +200,7 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         tableView.separatorStyle = .none
         tableView.canCancelContentTouches = true
         tableView.sectionHeaderTopPadding = 0
+        tableView.estimatedRowHeight = Self.fallbackEstimatedRowHeight
         tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 72, right: 0)
         tableView.delegate = self
         tableView.dataSource = self
@@ -481,12 +494,14 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         let previousState = lastRenderState
         lastRenderState = renderState
         guard let previousState else {
+            measuredRowHeights.removeAll()
             tableView.reloadData()
             return
         }
         guard previousState.state == renderState.state,
               previousState.hasOverviewData == renderState.hasOverviewData,
               previousState.sectionCount == renderState.sectionCount else {
+            measuredRowHeights.removeAll()
             tableView.reloadData()
             return
         }
@@ -513,6 +528,7 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         }
 
         guard !changedSections.isEmpty else { return }
+        measuredRowHeights.removeAll()
         tableView.reloadSections(changedSections, with: .none)
     }
 }
@@ -533,6 +549,9 @@ private extension PlanRouteAnalyzeViewController {
     static let statsSection = 1
     static let roadAttributesBase = 2
     static let cardHorizontalInset: CGFloat = 16
+    static let roadAttrCardChartTopInset: CGFloat = 20
+    static let roadAttrCardChartHeight: CGFloat = 54
+    static let fallbackEstimatedRowHeight: CGFloat = 160
     static let compactLegendBorderWidth: CGFloat = 1
     static let compactLegendMarkerSize: CGFloat = 16
     static let compactLegendInnerSpacing: CGFloat = 6
@@ -903,10 +922,10 @@ extension PlanRouteAnalyzeViewController: UITableViewDataSource {
         addRoadAttrLegend(legendView, to: card, below: barChart)
 
         NSLayoutConstraint.activate([
-            barChart.topAnchor.constraint(equalTo: card.topAnchor, constant: 20),
+            barChart.topAnchor.constraint(equalTo: card.topAnchor, constant: Self.roadAttrCardChartTopInset),
             barChart.leadingAnchor.constraint(equalTo: card.leadingAnchor),
             barChart.trailingAnchor.constraint(equalTo: card.trailingAnchor),
-            barChart.heightAnchor.constraint(equalToConstant: 54)
+            barChart.heightAnchor.constraint(equalToConstant: Self.roadAttrCardChartHeight)
         ])
 
         return cell
@@ -1231,7 +1250,11 @@ extension PlanRouteAnalyzeViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        UITableView.automaticDimension
+        exactRoadAttrRowHeight(for: indexPath) ?? UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        exactRoadAttrRowHeight(for: indexPath) ?? Self.fallbackEstimatedRowHeight
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -1375,6 +1398,41 @@ private extension PlanRouteAnalyzeViewController {
         return roadAttributeStatistics[statIndex]
     }
 
+    private func roadAttrHeightKey(name: String?, isExpanded: Bool) -> String {
+        "\(name ?? "")|\(isExpanded ? "expanded" : "collapsed")"
+    }
+
+    private func exactRoadAttrRowHeight(for indexPath: IndexPath) -> CGFloat? {
+        guard case .hasData = currentState,
+              indexPath.section >= roadAttributesSectionStart,
+              let stat = roadAttributeStatistic(for: indexPath.section) else {
+            return nil
+        }
+        let isExpanded = expandedStatIndexes.contains(indexPath.section - roadAttributesSectionStart)
+        let key = roadAttrHeightKey(name: stat.name, isExpanded: isExpanded)
+        if let cached = measuredRowHeights[key] {
+            return cached
+        }
+        guard let computed = roadAttrRowHeight(for: stat, isExpanded: isExpanded) else {
+            return nil
+        }
+        measuredRowHeights[key] = computed
+        return computed
+    }
+
+    private func roadAttrRowHeight(for stat: OARouteStatistics, isExpanded: Bool) -> CGFloat? {
+        let width = tableView.bounds.width - Self.cardHorizontalInset * 2
+        guard width > 0 else { return nil }
+        let legend = isExpanded ? makeExpandedRoadAttrLegend(stat: stat) : makeCompactRoadAttrLegend(stat: stat)
+        legend.translatesAutoresizingMaskIntoConstraints = false
+        let legendHeight = legend.systemLayoutSizeFitting(
+            CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        return Self.roadAttrCardChartTopInset + Self.roadAttrCardChartHeight + legendHeight
+    }
+
     private func roadAttributeTitle(for stat: OARouteStatistics) -> String {
         if stat.name == Self.roadClassAttributeName {
             return localizedString("routeInfo_road_types_name")
@@ -1477,8 +1535,6 @@ private extension PlanRouteAnalyzeViewController {
     }
 
     private func toggleRoadAttribute(at index: Int) {
-        let expandedLegendFadeDelay = Self.expandedLegendFadeDelay
-        let expandedLegendFadeDuration = Self.expandedLegendFadeDuration
         guard roadAttributeStatistics.indices.contains(index) else { return }
         if expandedStatIndexes.contains(index) {
             expandedStatIndexes.remove(index)
@@ -1487,25 +1543,35 @@ private extension PlanRouteAnalyzeViewController {
         }
 
         let section = index + roadAttributesSectionStart
-        let indexPath = IndexPath(row: 0, section: section)
-        let stat = roadAttributeStatistics[index]
         let isExpanded = expandedStatIndexes.contains(index)
+        let stat = roadAttributeStatistics[index]
         (tableView.headerView(forSection: section) as? AnalyzeRouteAttributeHeaderView)?.setExpanded(isExpanded)
 
+        if let height = roadAttrRowHeight(for: stat, isExpanded: isExpanded) {
+            measuredRowHeights[roadAttrHeightKey(name: stat.name, isExpanded: isExpanded)] = height
+        }
+
+        let indexPath = IndexPath(row: 0, section: section)
         guard let cell = tableView.cellForRow(at: indexPath) as? AnalyzeCardCell,
-              let barChart = cell.cardView.subviews.first(where: { $0 is HorizontalBarChartView }) else { return }
+              let barChart = cell.cardView.subviews.first(where: { $0 is HorizontalBarChartView }) else {
+            tableView.beginUpdates()
+            tableView.endUpdates()
+            return
+        }
 
         let legendView = isExpanded ? makeExpandedRoadAttrLegend(stat: stat) : makeCompactRoadAttrLegend(stat: stat)
         legendView.alpha = isExpanded ? 0 : 1
 
         cell.cardView.subviews.filter { $0 !== barChart }.forEach { $0.removeFromSuperview() }
         addRoadAttrLegend(legendView, to: cell.cardView, below: barChart)
-        tableView.performBatchUpdates(nil)
+
+        tableView.beginUpdates()
+        tableView.endUpdates()
 
         guard isExpanded else { return }
         UIView.animate(
-            withDuration: expandedLegendFadeDuration,
-            delay: expandedLegendFadeDelay,
+            withDuration: Self.expandedLegendFadeDuration,
+            delay: Self.expandedLegendFadeDelay,
             options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseIn],
             animations: { legendView.alpha = 1 }
         )

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
@@ -163,6 +163,15 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
         tableView.reloadData()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard isViewLoaded, previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory else { return }
+        measuredRowHeights.removeAll()
+        DispatchQueue.main.async { [weak self] in
+            self?.tableView.reloadData()
+        }
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         hideChartLocation()

--- a/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
+++ b/Sources/Controllers/PlanRoute/Tabs/PlanRouteAnalyzeViewController.swift
@@ -218,7 +218,7 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
     }
 
     private func showGetElevationSheet() {
-        let presenter = parent ?? self
+        let host = parent ?? self
         let sheet = GetElevationDataViewController(isTerrainMapsAvailable: dataSource?.isTerrainElevationAvailable ?? false)
         sheet.onSelectMethod = { [weak self] useNearbyRoads in
             guard let self else { return }
@@ -230,7 +230,7 @@ final class PlanRouteAnalyzeViewController: UIViewController, PlanRouteTabConten
             reloadData()
             dataSource?.startElevationCalculation(useNearbyRoads: false)
         }
-        presenter.showMediumSheetViewController(viewController: sheet, isLargeAvailable: false)
+        (host.navigationController ?? host).present(sheet, animated: true)
     }
 
     private func showAxisPicker(startingOnYAxis: Bool) {


### PR DESCRIPTION
## Related issue / task

Fixes https://github.com/osmandapp/OsmAnd-iOS/issues/5674

## Summary

Two changes on this branch.

### 1. Get elevation data screen — adaptive presentation

Replaces the `UISheetPresentationController` medium sheet with a custom
`UIPresentationController`:

- **Landscape:** renders as a left-side panel (393pt, full height) using the
  same geometry as the Plan Route panel — identical left/top/bottom insets,
  the same `visibleMapWidth >= 252` gate, and the same "always a side panel"
  behavior on iPad / Mac Catalyst.
- **Portrait:** bottom sheet sized to its content height
  (`systemLayoutSizeFitting`, safe-area-independent so the measurement is
  idempotent) + bottom safe area.
- Both orientations slide in/out vertically (from the bottom).
- Content constraints moved from raw `view` edges to `safeAreaLayoutGuide`,
  which fixes the reported bug: title / description / option rows were
  clipped under the Dynamic Island in landscape.
- `containerView.accessibilityViewIsModal = true` — a custom presentation
  does not get VoiceOver modal isolation for free the way `.pageSheet` did.
- Non-Pro "Use Terrain maps" now opens the Choose Plan screen directly
  (there is no navigation controller wrapper anymore); this mirrors what
  `OAChoosePlanHelper` does internally.

Everything lives in `GetElevationDataViewController.swift` (no new file, to
avoid a manual `project.pbxproj` edit).

### 2. Plan Route → Analyze tab — road-attribute section jitter (iteration 3)

Road-attribute rows (Surface / Smoothness / Steepness / Road types) now get
exact, synchronous heights from a content-keyed cache instead of
`automaticDimension`. Expand/collapse and the following scroll no longer
jerk `contentOffset` (worst when the section header is pinned at the top).
The section-header structure and its floating behavior are unchanged.

- `measuredRowHeights` cache keyed by `"<stat.name>|expanded|collapsed"`.
- `roadAttrRowHeight` = `chartTopInset(20) + chartHeight(54) + measured
  legend height`; verified to match the real card constraints and
  `AnalyzeCardCell` (card fills the cell vertically, 16pt horizontal inset).
- `heightForRowAt` / `estimatedHeightForRowAt` return the exact height for
  road-attribute rows, `automaticDimension` / a fixed estimate for the
  chart / stats / status rows.
- `toggleRoadAttribute` pre-warms the new-state height, swaps the legend in
  place (keeps the bar chart), then `beginUpdates()/endUpdates()`.
- Cache invalidated on every reload path in `applyRenderState` and on a
  table-width change in `viewDidLayoutSubviews`.

## Testing

**Tested on:**

- Device: iPhone 11
- iOS: 26.5

### Scenarios

**Get elevation data**

- Portrait: bottom sheet. Landscape: left panel, clear of the notch. Slides
  up from the bottom.
- Rotate while open — nothing clipped or stuck.
- Close with ✕ and by tapping the dimmed area.
- "Use nearby roads" / "Use Terrain maps" (Pro) — close and run the action.
- "Use Terrain maps" (no Pro) — Choose Plan opens, back returns here.
- iPad — left panel in both orientations.
- VoiceOver stays inside the screen; light / dark.

**Analyze tab**

- Expand / collapse each section, including with the header pinned — no jump.
- Scroll right after a toggle — no jitter.
- Toggle an off-screen section, then scroll to it — correct height.
- Track with and without elevation data.

## Relevant checks

- [x] Portrait / Landscape tested
- [x] Light / Dark mode tested
- [ ] Different profiles tested
- [ ] Localization / RTL checked
- [ ] VoiceOver / Accessibility checked
- [ ] CarPlay checked
- [ ] Android parity checked
- [ ] Performance impact checked

## AI disclaimer

**Implementation:**

- Tool / Agent: Claude Code
- Model: Claude Sonnet 5 (`claude-sonnet-5`)

**Prompts used (summarised):**

1. Check whether that screen can open as a left-side panel like the Plan
   Route panel; first implemented by embedding it in the Plan Route panel,
   then reverted after a janky resize animation.
2. Explore an alternative — tuning `sheetPresentationController` vs a custom
   `UIPresentationController`; implement the custom presentation controller
   (adaptive side panel / bottom sheet).
3. In landscape, slide in from the bottom instead of from the side.
4. Run a code review of the branch; apply the safe findings.
5. (Earlier sessions) Iterate the Analyze-tab road-attribute jitter fix to
   iteration 3 (exact synchronous row heights + cache).

**Decided by the agent, not requested explicitly:**

- Side-panel geometry constants (393pt width, insets, `minimumMapWidth`,
  the side-panel eligibility check) copied from
  `PlanRouteScrollableViewController` rather than derived or shared.
- A 0.2 black dimming overlay with tap-to-dismiss (carried over from the
  medium sheet's behavior).
- Corner radius kept at 20 (the old medium sheet value), not the Plan Route
  panel's 28.
- Portrait sheet height derived from content, no scroll view.
- Moving content constraints to `safeAreaLayoutGuide` (also resolves the
  original landscape report).
- Non-Pro terrain path: replicate `OAChoosePlanHelper.showImpl` inline
  because the helper needs a `UINavigationController` that no longer exists.
- Keep everything in one file to avoid a manual `project.pbxproj` change.

**Final review:**

- Tool / Agent: Claude Code
- Model: Claude Sonnet 5 (`claude-sonnet-5`)
- [x] Final diff reviewed (static review only — not built or run)

**Significant findings:**

- Get elevation data: missing VoiceOver modal isolation with the custom
  presentation — fixed (`accessibilityViewIsModal`).
