### PR TITLE
Fix Plan Route tests target membership

### DIFF
--- a/OsmAnd.xcodeproj/project.pbxproj
+++ b/OsmAnd.xcodeproj/project.pbxproj
@@ -1755,6 +1755,8 @@
 		D1C573510000000000000001 /* PlanRouteTrackSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C573510000000000000003 /* PlanRouteTrackSource.swift */; };
 		D1C573510000000000000002 /* PlanRouteTrackSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C573510000000000000003 /* PlanRouteTrackSource.swift */; };
 		D1C573510000000000000004 /* PlanRouteTrackSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C573510000000000000005 /* PlanRouteTrackSourceTests.swift */; };
+		D1C573520000000000000001 /* PlanRoutePresentationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C573520000000000000003 /* PlanRoutePresentationContext.swift */; };
+		D1C573520000000000000002 /* PlanRoutePresentationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C573520000000000000003 /* PlanRoutePresentationContext.swift */; };
 		D1C571200000000000000007 /* ContextMenuPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571200000000000000003 /* ContextMenuPresentationCoordinator.swift */; };
 		D1C571210000000000000001 /* ContextMenuPresentationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */; };
 		D71B9A8C2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71B9A8B2FC95D8500FBB0F3 /* OrganizeTracksByViewController.swift */; };
@@ -5938,6 +5940,7 @@
 		D1C573500000000000000002 /* OAPlanRouteEditingBridgeTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OAPlanRouteEditingBridgeTest.mm; sourceTree = "<group>"; };
 		D1C573510000000000000003 /* PlanRouteTrackSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteTrackSource.swift; sourceTree = "<group>"; };
 		D1C573510000000000000005 /* PlanRouteTrackSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRouteTrackSourceTests.swift; sourceTree = "<group>"; };
+		D1C573520000000000000003 /* PlanRoutePresentationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRoutePresentationContext.swift; sourceTree = "<group>"; };
 		D1C571210000000000000002 /* ContextMenuPresentationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPresentationUITests.swift; sourceTree = "<group>"; };
 		D1C571210000000000000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D1C571210000000000000004 /* OsmAnd MapsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OsmAnd MapsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -11265,6 +11268,7 @@
 				D7210159301B768C003CECB8 /* PlanRouteEditingContextDataProvider.swift */,
 				D721015A301B768C003CECB8 /* PlanRouteEditingModels.swift */,
 				D721015B301B768C003CECB8 /* PlanRouteModels.swift */,
+				D1C573520000000000000003 /* PlanRoutePresentationContext.swift */,
 				D1C573510000000000000003 /* PlanRouteTrackSource.swift */,
 				D721015C301B768C003CECB8 /* PlanRoutePointMenuViewController.swift */,
 				D721015D301B768C003CECB8 /* PlanRoutePoiState.swift */,
@@ -18298,6 +18302,7 @@
 				D7210182301B768C003CECB8 /* PlanRouteEditingContextDataProvider.swift in Sources */,
 				D7210183301B768C003CECB8 /* PlanRouteEditingModels.swift in Sources */,
 				D7210184301B768C003CECB8 /* PlanRouteModels.swift in Sources */,
+				D1C573520000000000000001 /* PlanRoutePresentationContext.swift in Sources */,
 				D1C573510000000000000001 /* PlanRouteTrackSource.swift in Sources */,
 				D7210185301B768C003CECB8 /* PlanRoutePointMenuViewController.swift in Sources */,
 				D7210186301B768C003CECB8 /* PlanRoutePoiState.swift in Sources */,
@@ -19642,6 +19647,7 @@
 				DA72AB952508F44900851313 /* SearchUICoreTest.mm in Sources */,
 				D1C571200000000000000007 /* ContextMenuPresentationCoordinator.swift in Sources */,
 				D1C573500000000000000001 /* OAPlanRouteEditingBridgeTest.mm in Sources */,
+				D1C573520000000000000002 /* PlanRoutePresentationContext.swift in Sources */,
 				D1C573510000000000000002 /* PlanRouteTrackSource.swift in Sources */,
 				D1C573510000000000000004 /* PlanRouteTrackSourceTests.swift in Sources */,
 				D1C571200000000000000002 /* ContextMenuPresentationCoordinatorTest.swift in Sources */,

--- a/Sources/Controllers/PlanRoute/PlanRouteModels.swift
+++ b/Sources/Controllers/PlanRoute/PlanRouteModels.swift
@@ -30,22 +30,6 @@ enum PlanRouteMode {
     }
 }
 
-struct PlanRoutePresentationContext {
-    static let standard = PlanRoutePresentationContext(followTrackMode: false,
-                                                        showSnapWarning: false,
-                                                        appliesApproximationToNavigation: false)
-
-    let followTrackMode: Bool
-    let showSnapWarning: Bool
-    let appliesApproximationToNavigation: Bool
-
-    static func followTrack(attachToRoads: Bool) -> PlanRoutePresentationContext {
-        PlanRoutePresentationContext(followTrackMode: true,
-                                     showSnapWarning: attachToRoads,
-                                     appliesApproximationToNavigation: attachToRoads)
-    }
-}
-
 enum PlanRouteTab: Int, CaseIterable {
     case poi
     case analyze

--- a/Sources/Controllers/PlanRoute/PlanRoutePresentationContext.swift
+++ b/Sources/Controllers/PlanRoute/PlanRoutePresentationContext.swift
@@ -1,0 +1,16 @@
+struct PlanRoutePresentationContext {
+
+    static let standard = PlanRoutePresentationContext(followTrackMode: false,
+                                                        showSnapWarning: false,
+                                                        appliesApproximationToNavigation: false)
+
+    let followTrackMode: Bool
+    let showSnapWarning: Bool
+    let appliesApproximationToNavigation: Bool
+
+    static func followTrack(attachToRoads: Bool) -> PlanRoutePresentationContext {
+        PlanRoutePresentationContext(followTrackMode: true,
+                                     showSnapWarning: attachToRoads,
+                                     appliesApproximationToNavigation: attachToRoads)
+    }
+}


### PR DESCRIPTION

Moved `PlanRoutePresentationContext` to a dedicated source file and added it to both the app and unit-test targets. This fixes the `cannot find 'PlanRoutePresentationContext' in scope` compilation error from the `Build iOS tests` job.

### Verification

- `PlanRoutePresentationContextTests`: 2 passed
- `PlanRouteTrackSourceTests`: 6 passed
- Total: 8 tests, 0 failures
- Result: `TEST SUCCEEDED