### PR TITLE
Read the nearest settlement from the address index

### DIFF
--- a/Sources/Helpers/OAGPXUIHelper.h
+++ b/Sources/Helpers/OAGPXUIHelper.h
@@ -44,6 +44,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable OAPOI *)searchNearestCity:(CLLocationCoordinate2D)latLon;
 
+/// Nearest settlement name. Reads the address index, falling back to the POI search only where
+/// there is no address data.
++ (NSString *)searchNearestCityName:(CLLocationCoordinate2D)latLon;
+
 - (void) openExportForTrack:(nullable OASGpxDataItem *)gpx
                      gpxDoc:(nullable id)gpxDoc
              isCurrentTrack:(BOOL)isCurrentTrack

--- a/Sources/Helpers/OAGPXUIHelper.mm
+++ b/Sources/Helpers/OAGPXUIHelper.mm
@@ -31,6 +31,12 @@
 #import "OAResourcesInstaller.h"
 
 #include <OsmAndCore/Utilities.h>
+#include <OsmAndCore/QuadTree.h>
+#include <OsmAndCore/ResourcesManager.h>
+#include <OsmAndCore/IObfsCollection.h>
+#include <OsmAndCore/ObfDataInterface.h>
+#include <OsmAndCore/Data/StreetGroup.h>
+#include <OsmAndCore/Data/ObfAddressSectionInfo.h>
 #include <exception>
 
 #define SECOND_IN_MILLIS 1000L
@@ -124,6 +130,7 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
 
 + (NSArray<OAPOI *> *)findCityCandidatesAroundLat:(double)lat lon:(double)lon radiusMeters:(int)radiusMeters;
 + (NSArray<OAPOI *> *)filterCityCandidates:(NSArray<OAPOI *> *)candidates radiusMeters:(int)radiusMeters ofLat:(double)lat lon:(double)lon;
++ (NSString *)nearestCityNameFromAddressIndex:(CLLocationCoordinate2D)latLon;
 
 @end
 
@@ -421,6 +428,175 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
 
     if (gpxItem.gradientPaletteName && gpxItem.gradientPaletteName.length > 0)
         [gpxFile setGradientColorPaletteGradientColorPaletteName:gpxItem.gradientPaletteName];
+}
+
+// Settlements are read out of the address section once per map and kept in a quadtree for the
+// session, so every later lookup is an in-memory box query.
+
+static const int kNearestCityAddressRadiusMeters = 50 * 1000;
+
+typedef OsmAnd::QuadTree<std::shared_ptr<const OsmAnd::StreetGroup>, OsmAnd::AreaI::CoordType> OAGPXCityQuadTreeType;
+
+static NSLock *OAGPXNearestCityAddressLock()
+{
+    static NSLock *lock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        lock = [NSLock new];
+    });
+    return lock;
+}
+
+static std::shared_ptr<OAGPXCityQuadTreeType> &OAGPXCityQuadTree()
+{
+    static std::shared_ptr<OAGPXCityQuadTreeType> tree =
+        std::make_shared<OAGPXCityQuadTreeType>(OsmAnd::AreaI::largestPositive(), 12u);
+    return tree;
+}
+
+static NSMutableSet<NSString *> *OAGPXLoadedCityResourceIds()
+{
+    static NSMutableSet<NSString *> *loaded;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        loaded = [NSMutableSet set];
+        [[NSNotificationCenter defaultCenter] addObserverForName:OAResourceInstalledNotification
+                                                         object:nil
+                                                          queue:nil
+                                                     usingBlock:^(NSNotification * _Nonnull note) {
+            NSLock *lock = OAGPXNearestCityAddressLock();
+            [lock lock];
+            [loaded removeAllObjects];
+            OAGPXCityQuadTree() = std::make_shared<OAGPXCityQuadTreeType>(OsmAnd::AreaI::largestPositive(), 12u);
+            [lock unlock];
+        }];
+    });
+    return loaded;
+}
+
++ (NSString *)searchNearestCityName:(CLLocationCoordinate2D)latLon
+{
+    NSString *fromAddress = [self nearestCityNameFromAddressIndex:latLon];
+    if (fromAddress)
+        return fromAddress;
+
+    OAPOI *poi = [self searchNearestCity:latLon];
+    return poi.name ?: @"";
+}
+
+/// nil = no map here carries address data, caller falls back to POI. @"" = read, nothing in range.
++ (NSString *)nearestCityNameFromAddressIndex:(CLLocationCoordinate2D)latLon
+{
+    OsmAndAppInstance app = [OsmAndApp instance];
+    OsmAnd::PointI point31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(latLon.latitude, latLon.longitude));
+    const OsmAnd::AreaI bbox31 = (OsmAnd::AreaI) OsmAnd::Utilities::boundingBox31FromAreaInMeters(
+        kNearestCityAddressRadiusMeters, point31);
+
+    QList<std::shared_ptr<const OsmAnd::StreetGroup>> cities;
+    BOOL covered = NO;
+
+    NSLock *lock = OAGPXNearestCityAddressLock();
+    [lock lock];
+    @try
+    {
+        try
+        {
+            NSMutableSet<NSString *> *loaded = OAGPXLoadedCityResourceIds();
+            const auto &obfsCollection = app.resourcesManager->obfsCollection;
+            for (const auto &resource : app.resourcesManager->getLocalResources())
+            {
+                // Other resource kinds carry a different Metadata subclass; casting those
+                // statically yields a bogus pointer that crashes on dereference.
+                if (resource->type != OsmAnd::ResourcesManager::ResourceType::MapRegion
+                    && resource->type != OsmAnd::ResourcesManager::ResourceType::RoadMapRegion)
+                    continue;
+
+                const auto obfMetadata = std::dynamic_pointer_cast<const OsmAnd::ResourcesManager::ObfMetadata>(resource->metadata);
+                if (!obfMetadata || !obfMetadata->obfFile || !obfMetadata->obfFile->obfInfo)
+                    continue;
+
+                OsmAnd::AreaI queryBbox31 = bbox31;
+                // As in OASearchPhrase.getOfflineIndexes: the address flag is not set on every
+                // map, so coverage is probed with the POI mask.
+                if (!obfMetadata->obfFile->obfInfo->containsDataFor(&queryBbox31,
+                                                                   OsmAnd::MinZoomLevel,
+                                                                   OsmAnd::MaxZoomLevel,
+                                                                   OsmAnd::ObfDataTypesMask().set(OsmAnd::ObfDataType::POI)))
+                    continue;
+
+                covered = YES;
+                NSString *resourceId = resource->id.toNSString();
+                if ([loaded containsObject:resourceId])
+                    continue;
+
+                [loaded addObject:resourceId];
+                const auto dataInterface = obfsCollection->obtainDataInterface({resource});
+                QList<std::shared_ptr<const OsmAnd::StreetGroup>> groups;
+                dataInterface->loadStreetGroups(&groups, nullptr,
+                    OsmAnd::ObfAddressStreetGroupTypesMask().set(OsmAnd::ObfAddressStreetGroupType::CityOrTown));
+
+                for (const auto &group : groups)
+                {
+                    // bbox31 is optional on a street group.
+                    OsmAnd::AreaI area(group->position31.y, group->position31.x, group->position31.y, group->position31.x);
+                    if (group->bbox31.size() >= 4)
+                    {
+                        // bbox31[left,top,right,bottom] => AreaI(top,left,bottom,right)
+                        area = OsmAnd::AreaI(group->bbox31.at(1), group->bbox31.at(0), group->bbox31.at(3), group->bbox31.at(2));
+                    }
+                    OAGPXCityQuadTree()->insert(group, area);
+                }
+            }
+
+            if (covered)
+            {
+                OsmAnd::AreaI queryBbox31 = bbox31;
+                OAGPXCityQuadTree()->query(queryBbox31, cities);
+            }
+        }
+        catch (const std::exception &ex)
+        {
+            NSLog(@"[ERROR] -> OAGPXUIHelper -> nearestCityNameFromAddressIndex failed: %s", ex.what());
+        }
+        catch (...)
+        {
+            NSLog(@"[ERROR] -> OAGPXUIHelper -> nearestCityNameFromAddressIndex failed: unknown C++ exception");
+        }
+    }
+    @catch (NSException *exception)
+    {
+        NSLog(@"[ERROR] -> OAGPXUIHelper -> nearestCityNameFromAddressIndex failed: %@ %@", exception.name, exception.reason);
+    }
+    @finally
+    {
+        [lock unlock];
+    }
+
+    if (covered)
+
+    if (!covered)
+        return nil;
+    if (cities.isEmpty())
+        return @"";
+
+    // Distance weighted by the settlement's own radius.
+    std::shared_ptr<const OsmAnd::StreetGroup> nearest;
+    double nearestWeight = 0;
+    for (const auto &city : cities)
+    {
+        OsmAnd::LatLon cityLatLon = OsmAnd::Utilities::convert31ToLatLon(city->position31);
+        CGFloat radius = [OACity getRadius:[OACity getTypeStr:(EOACityType) city->type]];
+        if (radius <= 0)
+            radius = 1000.;
+        double weight = OsmAnd::Utilities::distance(cityLatLon.longitude, cityLatLon.latitude,
+                                                    latLon.longitude, latLon.latitude) / radius;
+        if (!nearest || weight < nearestWeight)
+        {
+            nearest = city;
+            nearestWeight = weight;
+        }
+    }
+    return nearest ? nearest->nativeName.toNSString() : @"";
 }
 
 + (OAPOI *)searchNearestCity:(CLLocationCoordinate2D)latLon

--- a/Sources/Helpers/OAOsmAndContextImpl.mm
+++ b/Sources/Helpers/OAOsmAndContextImpl.mm
@@ -245,8 +245,7 @@ static NSString * const kGpxImportDir = @"import";
 - (void)searchNearestCityNameLatLon:(OASKLatLon *)latLon callback:(void (^)(NSString * _Nonnull))callback
 {
     @autoreleasepool {
-        OAPOI *nearestCityPOI = [OAGPXUIHelper searchNearestCity:CLLocationCoordinate2DMake(latLon.latitude, latLon.longitude)];
-        callback(nearestCityPOI ? nearestCityPOI.name : @"");
+        callback([OAGPXUIHelper searchNearestCityName:CLLocationCoordinate2DMake(latLon.latitude, latLon.longitude)]);
     }
 }
 


### PR DESCRIPTION
## Related issue / task

Follows the GPX indexing work in #5737 (osmandapp/OsmAnd-iOS#4095). Independent of #5737 itself — this is about where the nearest-city name comes from.

## Problem

Every track indexed by `GpxReader` ends in `setupNearestCityName`, which reaches `+[OAGPXUIHelper searchNearestCity:]`. That ran a POI amenity search over a 120 km box with no category filter, so the core decoded every amenity in the area — shops, benches, stops — and the accept block rejected them one by one.

Measured on a simulator with 836 tracks and an empty GPX database:

| | |
| --- | --- |
| one search | ~1050 ms |
| cache miss rate | ~55% (0.5° cells, `NSCache`, evicted under the memory pressure of indexing) |
| total for 100 tracks | 54.4 s of searching, all of it serialised behind one `NSLock` |

That is the single-threaded stretch users see behind "Tracks stats are being calculated...".

## Change

Settlements now come from the OBF address section instead:

* `loadStreetGroups(CityOrTown)` once per map resource, guarded by a set of already-loaded resource ids;
* the groups go into an `OsmAnd::QuadTree` that lives for the session, so every later track is an in-memory box query over a 50 km rect;
* ranking is distance weighted by the settlement's own radius;
* the POI search stays as the fallback for areas whose maps carry no address data, and the rest of its callers are untouched.

`OAGPXUIHelper.searchNearestCityName:` is the new entry point and the only one `OAOsmAndContextImpl` uses. The eight other callers of `searchNearestCity:` (track menu, travel guides, astro card, resource installer) keep the POI path.

The machinery is the same one the search UI already uses in `OASearchCoreFactory.OATownCitiesCache`; that class keeps its quadtree private to the .mm, so this is a separate instance rather than a refactor of search code.

## Testing

Simulator, 836 tracks, empty GPX database, instrumented build:

```
calls=300 covered=300 | avg ms: load=0.151 query=0.0042 | avg cities=11
                      | total s: load=0.045 query=0.0013
```

* address coverage on every call, so the POI fallback was never entered;
* loading plateaus at 45 ms for the whole session — after ~200 tracks no new region is read;
* ~4 us per track for the query.

Against ~1 s per miss before, the stage stops being measurable.

Also verified: the metadata of non-map resources (voice packs, styles, tiles, weather) is not `ObfMetadata`, so the resource loop filters on `MapRegion`/`RoadMapRegion` and uses `dynamic_pointer_cast`. A `static_pointer_cast` here returns a bogus non-null pointer and crashes on the first dereference — that is what an earlier revision of this branch did.

**Not verified:** the returned names have not been compared against the previous POI-derived ones on a real corpus. The source changed from a POI name to the address section's `nativeName`, which is where Android reads it from, but it is worth a look before merge.

## Notes

Behaviour where there is no address index is unchanged: `nearestCityNameFromAddressIndex:` returns nil and the caller falls back. An empty string means the address index was read and holds no settlement in range, which matches what the POI path returned in that case.
