### PR TITLE
Pass the type filter down to the OBF POI search

### DIFF
--- a/Sources/Helpers/OAAmenitySearcher.mm
+++ b/Sources/Helpers/OAAmenitySearcher.mm
@@ -1457,6 +1457,32 @@ static std::shared_ptr<const OsmAnd::Amenity> OAGetAmenityFromSearchResult(const
         OsmAnd::PointI topLeftPoint31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(topLatitude, leftLongitude));
         OsmAnd::PointI bottomRightPoint31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(bottomLatitude, rightLongitude));
         searchCriteria->bbox31 = OsmAnd::AreaI(topLeftPoint31, bottomRightPoint31);
+        // Without a category filter the core decodes every amenity in the bbox and the accept
+        // block rejects almost all of them one by one.
+        NSMapTable<OAPOICategory *, NSMutableSet<NSString *> *> *acceptedTypes = [filter getAcceptedTypes];
+        if (acceptedTypes.count > 0)
+        {
+            auto categoriesFilter = QHash<QString, QStringList>();
+            for (OAPOICategory *category in acceptedTypes.keyEnumerator)
+            {
+                NSMutableSet<NSString *> *subcategories = [acceptedTypes objectForKey:category];
+                QString categoryName = QString::fromNSString(category.name);
+                if (subcategories != [OAPOIBaseType nullSet] && subcategories.count > 0)
+                {
+                    QStringList subcatList;
+                    for (NSString *subcategory in subcategories)
+                        subcatList.push_back(QString::fromNSString(subcategory));
+
+                    categoriesFilter.insert(categoryName, subcatList);
+                }
+                else
+                {
+                    categoriesFilter.insert(categoryName, QStringList());
+                }
+            }
+            searchCriteria->categoriesFilter = categoriesFilter;
+        }
+
         NSMutableSet<NSString *> *deduplicateTypeIdSet = [NSMutableSet set];
         const auto search = std::shared_ptr<const OsmAnd::AmenitiesInAreaSearch>(new OsmAnd::AmenitiesInAreaSearch(obfsCollection));
         search->performSearch(*searchCriteria,

--- a/Sources/Helpers/OAGPXUIHelper.mm
+++ b/Sources/Helpers/OAGPXUIHelper.mm
@@ -124,6 +124,7 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
 
 + (NSArray<OAPOI *> *)findCityCandidatesAroundLat:(double)lat lon:(double)lon radiusMeters:(int)radiusMeters;
 + (NSArray<OAPOI *> *)filterCityCandidates:(NSArray<OAPOI *> *)candidates radiusMeters:(int)radiusMeters ofLat:(double)lat lon:(double)lon;
++ (NSArray<OAPOI *> *)cityCandidatesForCellAt:(CLLocationCoordinate2D)latLon;
 
 @end
 
@@ -425,38 +426,57 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
 
 + (OAPOI *)searchNearestCity:(CLLocationCoordinate2D)latLon
 {
-    OAPOI *nearestCity = nil;
+    // Only the OBF lookup needs serialising. Filtering and sorting are pure computation over
+    // an immutable array, so they run unlocked.
+    NSArray<OAPOI *> *regionCandidates = [self cityCandidatesForCellAt:latLon];
+    if (regionCandidates.count == 0)
+        return nil;
+
+    NSArray<OAPOI *> *inRange = [self filterCityCandidates:regionCandidates
+                                             radiusMeters:kNearestCityQueryRadiusMeters
+                                                    ofLat:latLon.latitude
+                                                      lon:latLon.longitude];
+    if (inRange.count == 0)
+        return nil;
+
+    return [self sortAmenities:inRange cityTypes:OAGPXNearestCitySubTypes() latLon:latLon].firstObject;
+}
+
++ (NSArray<OAPOI *> *)cityCandidatesForCellAt:(CLLocationCoordinate2D)latLon
+{
+    NSCache<NSString *, NSArray<OAPOI *> *> *cache = OAGPXNearestCityCandidatesCache();
+    NSString *cellKey = OAGPXNearestCityCellKey(latLon);
+
+    // NSCache is thread-safe, so a warm cell never takes the lock.
+    NSArray<OAPOI *> *candidates = [cache objectForKey:cellKey];
+    if (candidates)
+        return candidates;
+
     NSLock *lock = OAGPXNearestCitySearchLock();
     [lock lock];
     @try
     {
-        try
+        // Another thread may have filled the cell while we waited.
+        candidates = [cache objectForKey:cellKey];
+        if (!candidates)
         {
-            NSCache<NSString *, NSArray<OAPOI *> *> *cache = OAGPXNearestCityCandidatesCache();
-            NSString *cellKey = OAGPXNearestCityCellKey(latLon);
-            NSArray<OAPOI *> *regionCandidates = [cache objectForKey:cellKey];
-            if (!regionCandidates)
+            try
             {
                 CLLocationCoordinate2D cellCenter = OAGPXNearestCityCellCenter(latLon);
-                regionCandidates = [self findCityCandidatesAroundLat:cellCenter.latitude
-                                                                 lon:cellCenter.longitude
-                                                        radiusMeters:kNearestCityRegionRadiusMeters];
-                [cache setObject:regionCandidates forKey:cellKey];
+                candidates = [self findCityCandidatesAroundLat:cellCenter.latitude
+                                                          lon:cellCenter.longitude
+                                                 radiusMeters:kNearestCityRegionRadiusMeters];
+                // Only on a normal return, so a failed lookup is retried instead of cached.
+                [cache setObject:candidates forKey:cellKey];
             }
-            NSArray<OAPOI *> *inRange = [self filterCityCandidates:regionCandidates
-                                                     radiusMeters:kNearestCityQueryRadiusMeters
-                                                            ofLat:latLon.latitude
-                                                              lon:latLon.longitude];
-            if (inRange.count > 0)
-                nearestCity = [self sortAmenities:inRange cityTypes:OAGPXNearestCitySubTypes() latLon:latLon].firstObject;
-        }
-        catch (const std::exception &ex)
-        {
-            NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: %s", ex.what());
-        }
-        catch (...)
-        {
-            NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: unknown C++ exception");
+            catch (const std::exception &ex)
+            {
+                NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: %s", ex.what());
+            }
+            catch (...)
+            {
+                NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: unknown C++ exception");
+            }
         }
     }
     @catch (NSException *exception)
@@ -467,7 +487,7 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
     {
         [lock unlock];
     }
-    return nearestCity;
+    return candidates ?: @[];
 }
 
 + (NSArray<OAPOI *> *)findCityCandidatesAroundLat:(double)lat lon:(double)lon radiusMeters:(int)radiusMeters
@@ -481,11 +501,24 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
 
     NSArray<NSString *> *cityTypes = OAGPXNearestCitySubTypes();
 
+    // City subtypes live in the "administrative" category; declaring it lets the core skip the
+    // rest at the OBF index. Subcategories stay empty so the accept block still decides.
     OASearchPoiTypeFilter *filter = [[OASearchPoiTypeFilter alloc] initWithAcceptFunc:^BOOL(OAPOICategory *type, NSString *subcategory) {
         return [cityTypes containsObject:subcategory];
     } emptyFunction:^BOOL{
         return NO;
-    } getTypesFunction:nil];
+    } getTypesFunction:^NSMapTable<OAPOICategory *, NSMutableSet<NSString *> *> *{
+        OAPOIHelper *poiHelper = [OAPOIHelper sharedInstance];
+        OAPOICategory *administrative = [poiHelper getPoiCategoryByName:@"administrative"];
+        // getPoiCategoryByName: falls back to "other" rather than nil, which would silently
+        // narrow the search to the wrong category.
+        if (!administrative || administrative == poiHelper.otherPoiCategory)
+            return nil;
+
+        NSMapTable<OAPOICategory *, NSMutableSet<NSString *> *> *types = [NSMapTable strongToStrongObjectsMapTable];
+        [types setObject:[NSMutableSet set] forKey:administrative];
+        return types;
+    }];
 
     NSArray<OAPOI *> *amenities = [OAAmenitySearcher findPOIsByFilter:filter topLatitude:top leftLongitude:left bottomLatitude:bottom rightLongitude:right matcher:nil];
     return amenities ?: @[];


### PR DESCRIPTION
## Related issue / task

Came out of profiling GPX bulk indexing (osmandapp/OsmAnd-iOS#4095). Independent of #5756, which changes where the nearest-city name comes from; this one makes the POI search itself sane and benefits every caller of `findPOIsByFilter`.

## Problem

`+[OAAmenitySearcher findPOIsByFilter:topLatitude:...]` filled only `bbox31` on `AmenitiesInAreaSearch::Criteria` and left `categoriesFilter` empty. The core therefore decoded **every** amenity in the box — shops, benches, stops, trees — and for each one the Obj-C callback bridged the object, built a type-id key, looked it up in an `NSSet`, parsed the POI type, and only then handed it to the accept block, which rejected almost all of them.

`OASearchPoiTypeFilter` has carried `getAcceptedTypesFunction` for exactly this purpose since it was written; this method just never asked.

Measured on a simulator during track indexing, 120 km box, ~1500 accepted out of everything scanned: **~1050 ms per search**.

## Change

**`OAAmenitySearcher`** — `findPOIsByFilter` builds `categoriesFilter` from `[filter getAcceptedTypes]` when the filter provides it. Same construction as `OASearchCoreFactory.mm:1778`, including the `nullSet` check. Filters that return nil keep the previous behaviour exactly.

**`OAGPXUIHelper`** — the nearest-city filter now declares its category. All city subtypes (`city`, `town`, `village`, `hamlet`, `suburb`, `borough`, `neighbourhood`) sit under `administrative` in `poi_types.xml`; `postcode`, `boundary`, `census` and `district` are not POI types at all and never matched. The subcategory set is deliberately left **empty**, so the core only skips non-administrative amenities and the existing accept block still decides — the result is identical even if a type ever moves category.

`getPoiCategoryByName:` returns the "other" category rather than nil when a name is missing, so that case is checked explicitly and falls back to no filter.

**Lock narrowing** — `searchNearestCity` held one process-wide `NSLock` across the whole body. Only the OBF lookup needs it; `filterCityCandidates` and `sortAmenities` are pure computation over an immutable `NSArray` of already-built `OAPOI` objects (`latitude`, `longitude`, `subType`, `name` are plain synthesised properties, nothing in the path writes them), so they now run unlocked, and a warm cache cell takes no lock at all since `NSCache` is thread-safe. A failed lookup is no longer cached, so it is retried rather than poisoning the cell.

## Testing

Simulator, 836 tracks, empty GPX database, instrumented build. Per 100 nearest-city calls:

| | before | after |
| --- | --- | --- |
| total search | 54.4 s | 7.68 s |
| per cache miss | ~1050 ms | ~135 ms |
| total lock wait | 146.6 s | 12.7 s |

Filtering and sorting were already negligible (0.003 s and 0.10 s per 100 calls) — that is why the lock narrowing alone changed nothing, and the category filter is what moved the number.

**Not verified:** other callers of `findPOIsByFilter`. There is only one in the tree today (the nearest-city search), so the new branch is exercised by the numbers above, and filters without `getAcceptedTypesFunction` take the unchanged path.
