### PR TITLE
Speed up the nearest-city lookup during GPX indexing

### DIFF
--- a/Sources/Helpers/OAAmenitySearcher.mm
+++ b/Sources/Helpers/OAAmenitySearcher.mm
@@ -1457,6 +1457,33 @@ static std::shared_ptr<const OsmAnd::Amenity> OAGetAmenityFromSearchResult(const
         OsmAnd::PointI topLeftPoint31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(topLatitude, leftLongitude));
         OsmAnd::PointI bottomRightPoint31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(bottomLatitude, rightLongitude));
         searchCriteria->bbox31 = OsmAnd::AreaI(topLeftPoint31, bottomRightPoint31);
+
+        // Without a category filter the core decodes every amenity in the bbox and the accept
+        // block rejects almost all of them one by one.
+        NSMapTable<OAPOICategory *, NSMutableSet<NSString *> *> *acceptedTypes = [filter getAcceptedTypes];
+        if (acceptedTypes.count > 0)
+        {
+            auto categoriesFilter = QHash<QString, QStringList>();
+            for (OAPOICategory *category in acceptedTypes.keyEnumerator)
+            {
+                NSMutableSet<NSString *> *subcategories = [acceptedTypes objectForKey:category];
+                QString categoryName = QString::fromNSString(category.name);
+                if (subcategories != [OAPOIBaseType nullSet] && subcategories.count > 0)
+                {
+                    QStringList subcatList;
+                    for (NSString *subcategory in subcategories)
+                        subcatList.push_back(QString::fromNSString(subcategory));
+
+                    categoriesFilter.insert(categoryName, subcatList);
+                }
+                else
+                {
+                    categoriesFilter.insert(categoryName, QStringList());
+                }
+            }
+            searchCriteria->categoriesFilter = categoriesFilter;
+        }
+
         NSMutableSet<NSString *> *deduplicateTypeIdSet = [NSMutableSet set];
         const auto search = std::shared_ptr<const OsmAnd::AmenitiesInAreaSearch>(new OsmAnd::AmenitiesInAreaSearch(obfsCollection));
         search->performSearch(*searchCriteria,

--- a/Sources/Helpers/OAGPXUIHelper.h
+++ b/Sources/Helpers/OAGPXUIHelper.h
@@ -44,6 +44,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable OAPOI *)searchNearestCity:(CLLocationCoordinate2D)latLon;
 
+/// Nearest settlement name. Reads the address index, falling back to the POI search only where
+/// there is no address data.
++ (NSString *)searchNearestCityName:(CLLocationCoordinate2D)latLon;
+
 - (void) openExportForTrack:(nullable OASGpxDataItem *)gpx
                      gpxDoc:(nullable id)gpxDoc
              isCurrentTrack:(BOOL)isCurrentTrack

--- a/Sources/Helpers/OAGPXUIHelper.mm
+++ b/Sources/Helpers/OAGPXUIHelper.mm
@@ -31,6 +31,12 @@
 #import "OAResourcesInstaller.h"
 
 #include <OsmAndCore/Utilities.h>
+#include <OsmAndCore/QuadTree.h>
+#include <OsmAndCore/ResourcesManager.h>
+#include <OsmAndCore/IObfsCollection.h>
+#include <OsmAndCore/ObfDataInterface.h>
+#include <OsmAndCore/Data/StreetGroup.h>
+#include <OsmAndCore/Data/ObfAddressSectionInfo.h>
 #include <exception>
 
 #define SECOND_IN_MILLIS 1000L
@@ -120,10 +126,69 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
 @end
 
 
+// Settlements are read out of the address section once per map and kept in a quadtree for the
+// session, so every later lookup is an in-memory box query.
+
+static const int kNearestCityAddressRadiusMeters = 50 * 1000;
+
+typedef OsmAnd::QuadTree<std::shared_ptr<const OsmAnd::StreetGroup>, OsmAnd::AreaI::CoordType> OAGPXCityQuadTreeType;
+
+static NSLock *OAGPXNearestCityAddressLock()
+{
+    static NSLock *lock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        lock = [NSLock new];
+    });
+    return lock;
+}
+
+static std::shared_ptr<OAGPXCityQuadTreeType> &OAGPXCityQuadTree()
+{
+    static std::shared_ptr<OAGPXCityQuadTreeType> tree =
+        std::make_shared<OAGPXCityQuadTreeType>(OsmAnd::AreaI::largestPositive(), 12u);
+    return tree;
+}
+
+// Resources whose address section has already been read into the quadtree.
+static NSMutableSet<NSString *> *OAGPXLoadedCityResourceIds()
+{
+    static NSMutableSet<NSString *> *loaded;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        loaded = [NSMutableSet set];
+    });
+    return loaded;
+}
+
+// Of those, the ones that turned out to carry settlements at all.
+static NSMutableSet<NSString *> *OAGPXCityResourceIdsWithAddressData()
+{
+    static NSMutableSet<NSString *> *withAddressData;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        withAddressData = [NSMutableSet set];
+        [[NSNotificationCenter defaultCenter] addObserverForName:OAResourceInstalledNotification
+                                                         object:nil
+                                                          queue:nil
+                                                     usingBlock:^(NSNotification * _Nonnull note) {
+            NSLock *lock = OAGPXNearestCityAddressLock();
+            [lock lock];
+            [OAGPXLoadedCityResourceIds() removeAllObjects];
+            [withAddressData removeAllObjects];
+            OAGPXCityQuadTree() = std::make_shared<OAGPXCityQuadTreeType>(OsmAnd::AreaI::largestPositive(), 12u);
+            [lock unlock];
+        }];
+    });
+    return withAddressData;
+}
+
 @interface OAGPXUIHelper() <UIDocumentInteractionControllerDelegate, OASaveTrackViewControllerDelegate>
 
 + (NSArray<OAPOI *> *)findCityCandidatesAroundLat:(double)lat lon:(double)lon radiusMeters:(int)radiusMeters;
 + (NSArray<OAPOI *> *)filterCityCandidates:(NSArray<OAPOI *> *)candidates radiusMeters:(int)radiusMeters ofLat:(double)lat lon:(double)lon;
++ (NSString *)nearestCityNameFromAddressIndex:(CLLocationCoordinate2D)latLon;
++ (NSArray<OAPOI *> *)cityCandidatesForCellAt:(CLLocationCoordinate2D)latLon;
 
 @end
 
@@ -423,40 +488,191 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
         [gpxFile setGradientColorPaletteGradientColorPaletteName:gpxItem.gradientPaletteName];
 }
 
-+ (OAPOI *)searchNearestCity:(CLLocationCoordinate2D)latLon
++ (NSString *)searchNearestCityName:(CLLocationCoordinate2D)latLon
 {
-    OAPOI *nearestCity = nil;
-    NSLock *lock = OAGPXNearestCitySearchLock();
+    NSString *fromAddress = [self nearestCityNameFromAddressIndex:latLon];
+    if (fromAddress)
+        return fromAddress;
+
+    OAPOI *poi = [self searchNearestCity:latLon];
+    return poi.name ?: @"";
+}
+
+/// nil = no map here carries address data, caller falls back to POI. @"" = read, nothing in range.
++ (NSString *)nearestCityNameFromAddressIndex:(CLLocationCoordinate2D)latLon
+{
+    OsmAndAppInstance app = [OsmAndApp instance];
+    OsmAnd::PointI point31 = OsmAnd::Utilities::convertLatLonTo31(OsmAnd::LatLon(latLon.latitude, latLon.longitude));
+    const OsmAnd::AreaI bbox31 = (OsmAnd::AreaI) OsmAnd::Utilities::boundingBox31FromAreaInMeters(
+        kNearestCityAddressRadiusMeters, point31);
+
+    QList<std::shared_ptr<const OsmAnd::StreetGroup>> cities;
+    BOOL covered = NO;
+
+    NSLock *lock = OAGPXNearestCityAddressLock();
     [lock lock];
     @try
     {
         try
         {
-            NSCache<NSString *, NSArray<OAPOI *> *> *cache = OAGPXNearestCityCandidatesCache();
-            NSString *cellKey = OAGPXNearestCityCellKey(latLon);
-            NSArray<OAPOI *> *regionCandidates = [cache objectForKey:cellKey];
-            if (!regionCandidates)
+            NSMutableSet<NSString *> *loaded = OAGPXLoadedCityResourceIds();
+            NSMutableSet<NSString *> *withAddressData = OAGPXCityResourceIdsWithAddressData();
+            const auto &obfsCollection = app.resourcesManager->obfsCollection;
+            for (const auto &resource : app.resourcesManager->getLocalResources())
             {
-                CLLocationCoordinate2D cellCenter = OAGPXNearestCityCellCenter(latLon);
-                regionCandidates = [self findCityCandidatesAroundLat:cellCenter.latitude
-                                                                 lon:cellCenter.longitude
-                                                        radiusMeters:kNearestCityRegionRadiusMeters];
-                [cache setObject:regionCandidates forKey:cellKey];
+                // Other resource kinds carry a different Metadata subclass; casting those
+                // statically yields a bogus pointer that crashes on dereference.
+                if (resource->type != OsmAnd::ResourcesManager::ResourceType::MapRegion
+                    && resource->type != OsmAnd::ResourcesManager::ResourceType::RoadMapRegion)
+                    continue;
+
+                const auto obfMetadata = std::dynamic_pointer_cast<const OsmAnd::ResourcesManager::ObfMetadata>(resource->metadata);
+                if (!obfMetadata || !obfMetadata->obfFile || !obfMetadata->obfFile->obfInfo)
+                    continue;
+
+                OsmAnd::AreaI queryBbox31 = bbox31;
+                // As in OASearchPhrase.getOfflineIndexes: the address flag is not set on every
+                // map, so coverage is probed with the POI mask.
+                if (!obfMetadata->obfFile->obfInfo->containsDataFor(&queryBbox31,
+                                                                   OsmAnd::MinZoomLevel,
+                                                                   OsmAnd::MaxZoomLevel,
+                                                                   OsmAnd::ObfDataTypesMask().set(OsmAnd::ObfDataType::POI)))
+                    continue;
+
+                NSString *resourceId = resource->id.toNSString();
+                if (![loaded containsObject:resourceId])
+                {
+                    [loaded addObject:resourceId];
+                    const auto dataInterface = obfsCollection->obtainDataInterface({resource});
+                    QList<std::shared_ptr<const OsmAnd::StreetGroup>> groups;
+                    dataInterface->loadStreetGroups(&groups, nullptr,
+                        OsmAnd::ObfAddressStreetGroupTypesMask().set(OsmAnd::ObfAddressStreetGroupType::CityOrTown));
+
+                    if (!groups.isEmpty())
+                        [withAddressData addObject:resourceId];
+
+                    for (const auto &group : groups)
+                    {
+                        // bbox31 is optional on a street group.
+                        OsmAnd::AreaI area(group->position31.y, group->position31.x, group->position31.y, group->position31.x);
+                        if (group->bbox31.size() >= 4)
+                        {
+                            // bbox31[left,top,right,bottom] => AreaI(top,left,bottom,right)
+                            area = OsmAnd::AreaI(group->bbox31.at(1), group->bbox31.at(0), group->bbox31.at(3), group->bbox31.at(2));
+                        }
+                        OAGPXCityQuadTree()->insert(group, area);
+                    }
+                }
+
+                // Probing coverage with the POI mask only says a map is here, not that it has an
+                // address section. Without this the POI fallback could never run and a track in
+                // such an area would silently get an empty name.
+                if ([withAddressData containsObject:resourceId])
+                    covered = YES;
             }
-            NSArray<OAPOI *> *inRange = [self filterCityCandidates:regionCandidates
-                                                     radiusMeters:kNearestCityQueryRadiusMeters
-                                                            ofLat:latLon.latitude
-                                                              lon:latLon.longitude];
-            if (inRange.count > 0)
-                nearestCity = [self sortAmenities:inRange cityTypes:OAGPXNearestCitySubTypes() latLon:latLon].firstObject;
+
+            if (covered)
+            {
+                OsmAnd::AreaI queryBbox31 = bbox31;
+                OAGPXCityQuadTree()->query(queryBbox31, cities);
+            }
         }
         catch (const std::exception &ex)
         {
-            NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: %s", ex.what());
+            NSLog(@"[ERROR] -> OAGPXUIHelper -> nearestCityNameFromAddressIndex failed: %s", ex.what());
         }
         catch (...)
         {
-            NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: unknown C++ exception");
+            NSLog(@"[ERROR] -> OAGPXUIHelper -> nearestCityNameFromAddressIndex failed: unknown C++ exception");
+        }
+    }
+    @catch (NSException *exception)
+    {
+        NSLog(@"[ERROR] -> OAGPXUIHelper -> nearestCityNameFromAddressIndex failed: %@ %@", exception.name, exception.reason);
+    }
+    @finally
+    {
+        [lock unlock];
+    }
+
+    if (!covered)
+        return nil;
+    if (cities.isEmpty())
+        return @"";
+
+    // Distance weighted by the settlement's own radius.
+    std::shared_ptr<const OsmAnd::StreetGroup> nearest;
+    double nearestWeight = 0;
+    for (const auto &city : cities)
+    {
+        OsmAnd::LatLon cityLatLon = OsmAnd::Utilities::convert31ToLatLon(city->position31);
+        CGFloat radius = [OACity getRadius:[OACity getTypeStr:(EOACityType) city->type]];
+        if (radius <= 0)
+            radius = 1000.;
+        double weight = OsmAnd::Utilities::distance(cityLatLon.longitude, cityLatLon.latitude,
+                                                    latLon.longitude, latLon.latitude) / radius;
+        if (!nearest || weight < nearestWeight)
+        {
+            nearest = city;
+            nearestWeight = weight;
+        }
+    }
+    return nearest ? nearest->nativeName.toNSString() : @"";
+}
+
++ (OAPOI *)searchNearestCity:(CLLocationCoordinate2D)latLon
+{
+    // Only the OBF lookup needs serialising. Filtering and sorting are pure computation over
+    // an immutable array, so they run unlocked.
+    NSArray<OAPOI *> *regionCandidates = [self cityCandidatesForCellAt:latLon];
+    if (regionCandidates.count == 0)
+        return nil;
+
+    NSArray<OAPOI *> *inRange = [self filterCityCandidates:regionCandidates
+                                             radiusMeters:kNearestCityQueryRadiusMeters
+                                                    ofLat:latLon.latitude
+                                                      lon:latLon.longitude];
+    if (inRange.count == 0)
+        return nil;
+
+    return [self sortAmenities:inRange cityTypes:OAGPXNearestCitySubTypes() latLon:latLon].firstObject;
+}
+
++ (NSArray<OAPOI *> *)cityCandidatesForCellAt:(CLLocationCoordinate2D)latLon
+{
+    NSCache<NSString *, NSArray<OAPOI *> *> *cache = OAGPXNearestCityCandidatesCache();
+    NSString *cellKey = OAGPXNearestCityCellKey(latLon);
+
+    // NSCache is thread-safe, so a warm cell never takes the lock.
+    NSArray<OAPOI *> *candidates = [cache objectForKey:cellKey];
+    if (candidates)
+        return candidates;
+
+    NSLock *lock = OAGPXNearestCitySearchLock();
+    [lock lock];
+    @try
+    {
+        // Another thread may have filled the cell while we waited.
+        candidates = [cache objectForKey:cellKey];
+        if (!candidates)
+        {
+            try
+            {
+                CLLocationCoordinate2D cellCenter = OAGPXNearestCityCellCenter(latLon);
+                candidates = [self findCityCandidatesAroundLat:cellCenter.latitude
+                                                          lon:cellCenter.longitude
+                                                 radiusMeters:kNearestCityRegionRadiusMeters];
+                // Only on a normal return, so a failed lookup is retried instead of cached.
+                [cache setObject:candidates forKey:cellKey];
+            }
+            catch (const std::exception &ex)
+            {
+                NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: %s", ex.what());
+            }
+            catch (...)
+            {
+                NSLog(@"[ERROR] -> OAGPXUIHelper -> searchNearestCity failed: unknown C++ exception");
+            }
         }
     }
     @catch (NSException *exception)
@@ -467,7 +683,7 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
     {
         [lock unlock];
     }
-    return nearestCity;
+    return candidates ?: @[];
 }
 
 + (NSArray<OAPOI *> *)findCityCandidatesAroundLat:(double)lat lon:(double)lon radiusMeters:(int)radiusMeters
@@ -481,11 +697,24 @@ static NSArray<NSString *> *OAGPXNearestCitySubTypes()
 
     NSArray<NSString *> *cityTypes = OAGPXNearestCitySubTypes();
 
+    // City subtypes live in the "administrative" category; declaring it lets the core skip the
+    // rest at the OBF index. Subcategories stay empty so the accept block still decides.
     OASearchPoiTypeFilter *filter = [[OASearchPoiTypeFilter alloc] initWithAcceptFunc:^BOOL(OAPOICategory *type, NSString *subcategory) {
         return [cityTypes containsObject:subcategory];
     } emptyFunction:^BOOL{
         return NO;
-    } getTypesFunction:nil];
+    } getTypesFunction:^NSMapTable<OAPOICategory *, NSMutableSet<NSString *> *> *{
+        OAPOIHelper *poiHelper = [OAPOIHelper sharedInstance];
+        OAPOICategory *administrative = [poiHelper getPoiCategoryByName:@"administrative"];
+        // getPoiCategoryByName: falls back to "other" rather than nil, which would silently
+        // narrow the search to the wrong category.
+        if (!administrative || administrative == poiHelper.otherPoiCategory)
+            return nil;
+
+        NSMapTable<OAPOICategory *, NSMutableSet<NSString *> *> *types = [NSMapTable strongToStrongObjectsMapTable];
+        [types setObject:[NSMutableSet set] forKey:administrative];
+        return types;
+    }];
 
     NSArray<OAPOI *> *amenities = [OAAmenitySearcher findPOIsByFilter:filter topLatitude:top leftLongitude:left bottomLatitude:bottom rightLongitude:right matcher:nil];
     return amenities ?: @[];

--- a/Sources/Helpers/OAOsmAndContextImpl.mm
+++ b/Sources/Helpers/OAOsmAndContextImpl.mm
@@ -245,8 +245,7 @@ static NSString * const kGpxImportDir = @"import";
 - (void)searchNearestCityNameLatLon:(OASKLatLon *)latLon callback:(void (^)(NSString * _Nonnull))callback
 {
     @autoreleasepool {
-        OAPOI *nearestCityPOI = [OAGPXUIHelper searchNearestCity:CLLocationCoordinate2DMake(latLon.latitude, latLon.longitude)];
-        callback(nearestCityPOI ? nearestCityPOI.name : @"");
+        callback([OAGPXUIHelper searchNearestCityName:CLLocationCoordinate2DMake(latLon.latitude, latLon.longitude)]);
     }
 }
 


### PR DESCRIPTION
## Related issue / task

Came out of profiling GPX bulk indexing, osmandapp/OsmAnd-iOS#4095.

## Problem

Every track indexed by `GpxReader` ends in `setupNearestCityName`, which reaches `+[OAGPXUIHelper searchNearestCity:]`. Two things made that expensive:

* `+[OAAmenitySearcher findPOIsByFilter:topLatitude:...]` filled only `bbox31` on `AmenitiesInAreaSearch::Criteria` and left `categoriesFilter` empty, so the core decoded **every** amenity in a 120 km box — shops, benches, stops — and the accept block rejected almost all of them one at a time;
* the whole search sat under one process-wide `NSLock`, so the four `GpxReader` threads served it in turn.

Measured on a simulator, 836 tracks, empty GPX database:

| | |
| --- | --- |
| one search | ~1050 ms |
| cache miss rate | ~55% (0.5° cells in an `NSCache`, evicted under the memory pressure of indexing) |
| per 100 tracks | 54.4 s searching, 146.6 s of lock wait |

That is the single-threaded stretch behind "Tracks stats are being calculated...".

## Change

**Settlements come from the address index where one exists.** `loadStreetGroups(CityOrTown)` runs once per map resource, guarded by a set of loaded resource ids; the groups go into an `OsmAnd::QuadTree` that lives for the session, so a later track in that region is an in-memory box query over a 50 km rect, ranked by distance weighted by the settlement's own radius — the same ranking Android uses, with the same radii (`CITY` 10000, `TOWN` 4000, `VILLAGE` 1300, `HAMLET` 1000). `OAGPXUIHelper.searchNearestCityName:` is the new entry point and the only one `OAOsmAndContextImpl` uses.

The machinery is the same one the search UI already has in `OASearchCoreFactory.OATownCitiesCache`; that class keeps its quadtree private to the .mm, so this is a separate instance rather than a refactor of search code.

A map counts as covered only once its address section has actually yielded settlements. Probing coverage by bbox alone would mark a map without an address section as covered, and the empty query result would then be returned as an empty city name instead of falling through.

**The POI scan stays as the fallback**, and it is a main path rather than an edge case: regions served only by the world basemap have POI data but no address section. The eight other callers of `searchNearestCity:` (track menu, travel guides, astro card, resource installer) keep using it. Two fixes there:

* `findPOIsByFilter` now builds `categoriesFilter` from `[filter getAcceptedTypes]`. `OASearchPoiTypeFilter` has carried `getAcceptedTypesFunction` for exactly this since it was written; the method just never asked. Same construction as `OASearchCoreFactory.mm:1778`, `nullSet` check included; filters returning nil keep the previous behaviour. The nearest-city filter declares the `administrative` category with an **empty** subcategory set, so the core only skips non-administrative amenities and the accept block still decides. `getPoiCategoryByName:` returns the "other" category rather than nil for a missing name, so that is checked explicitly.
* The lock is narrowed to the OBF lookup. `filterCityCandidates` and `sortAmenities` are pure computation over an immutable `NSArray` of already-built `OAPOI` objects — `latitude`, `longitude`, `subType` and `name` are plain synthesised properties and nothing in the path writes them — so they run unlocked, and a warm cache cell takes no lock at all since `NSCache` is thread-safe. A failed lookup is no longer cached, so it is retried instead of poisoning the cell.

## Behaviour change: the returned name

Where the address index covers the track, the name now comes from the address section instead of the nearest matching POI. Compared on 40 tracks against the old result:

| track | before | after |
| --- | --- | --- |
| 48.16, 14.01 (and 8 more) | Linz | Enns |
| 48.25, 14.63 | Linz | St. Valentin |
| 48.13, 17.20 | Bratislava | Hainburg an der Donau |
| 49.80, 7.94 | Neu-Bamberg | Bad Kreuznach |
| 50.44, 30.45 | Караваєві Дачі | Київ |

This is Android's answer in each case — same data source, same ranking, same radii. It does change what existing iOS users see, and `NEAREST_CITY_NAME` is persisted, so indexed tracks keep the old name until their analysis is recomputed.

## Testing

Simulator, 836 tracks, empty GPX database, instrumented build.

**Category filter**, per 100 nearest-city calls:

| | before | after |
| --- | --- | --- |
| total search | 54.4 s | 7.68 s |
| per cache miss | ~1050 ms | ~135 ms |
| total lock wait | 146.6 s | 12.7 s |

Filtering and sorting were negligible throughout (0.003 s and 0.10 s per 100 calls), which is why narrowing the lock on its own changed nothing.

**Address index.** Loading the address sections plateaus at 45 ms for the whole session — after ~200 tracks no new region is read — and a covered lookup then costs ~4 us. On this map set 22 of 40 sampled tracks were covered; the other 18 sit in regions served only by the world basemap and take the POI fallback at its improved cost.

**Fallback path** exercised end to end by forcing the coverage verdict to NO: all 40 sampled tracks reported no address data, fell through to the POI search and produced the expected names (Birmingham, Amsterdam, Київ, Linz, Stockholm, Ljubljana), with no crash.

The metadata of non-map resources (voice packs, styles, tiles, weather) is not `ObfMetadata`, so the resource loop filters on `MapRegion`/`RoadMapRegion` and uses `dynamic_pointer_cast`. A `static_pointer_cast` there returns a bogus non-null pointer and crashes on the first dereference.

**Not verified:** behaviour on a device rather than the simulator, and the memory held by the quadtree with a large number of installed maps — it keeps every loaded settlement for the life of the process.
