### PR TITLE
Fix .osf import silently dropping most of the file

### DIFF
--- a/Sources/Backup/LocalBackup/OASettingsImporter.mm
+++ b/Sources/Backup/LocalBackup/OASettingsImporter.mm
@@ -112,66 +112,102 @@
         return items;
     }
 
+    // Work out what has to come out of the archive before touching it, so that it can then be read
+    // in a single pass. Reopening it per entry made one hiccup cost every entry that came after.
+    QHash<QString, QString> destinationByItemName;
+    NSMutableArray<NSDictionary *> *plannedReads = [NSMutableArray array];
     for (const auto& archiveItem : constOf(archiveItems))
     {
         if (!archiveItem.isValid())
             continue;
-        
-        QString filename = archiveItem.name;
+
+        NSString *fileName = archiveItem.name.toNSString();
         OASettingsItem *item = nil;
         for (OASettingsItem *settingsItem in items)
         {
-            if ([settingsItem applyFileName:filename.toNSString()])
+            if ([settingsItem applyFileName:fileName])
             {
                 item = settingsItem;
                 break;
             }
         }
-        
-        if (item && ((collecting && item.shouldReadOnCollecting) || (!collecting && !item.shouldReadOnCollecting)))
+
+        if (!item || !((collecting && item.shouldReadOnCollecting) || (!collecting && !item.shouldReadOnCollecting)))
+            continue;
+
+        OASettingsItemReader *reader = item.getReader;
+        if (!reader)
+            continue;
+
+        NSString *tmpFileName = [_tmpFilesDir stringByAppendingString:[@"/" stringByAppendingString:fileName]];
+        NSMutableArray<NSString *> *requiredNames = [NSMutableArray array];
+        if ([fileName hasSuffix:@"/"])
         {
-            OASettingsItemReader *reader = item.getReader;
-            NSError *err = nil;
-            if (reader)
+            // Directory item: the reader expects everything below it to be on disk
+            for (const auto& nestedItem : constOf(archiveItems))
             {
-                NSString *fileName = archiveItem.name.toNSString();
-                NSString *tmpFileName = [_tmpFilesDir stringByAppendingString:[@"/" stringByAppendingString:fileName]];
-                BOOL isDir = [fileName hasSuffix:@"/"];
-                if (isDir)
+                NSString *nestedName = nestedItem.name.toNSString();
+                if ([nestedName hasPrefix:fileName] && ![nestedName isEqualToString:fileName])
                 {
-                    // Collect all items for this directory
-                    for (const auto& archiveItem : constOf(archiveItems))
-                    {
-                        NSString *itemName = archiveItem.name.toNSString();
-                        if ([itemName hasPrefix:fileName] && ![itemName isEqualToString:fileName])
-                        {
-                            if (!archive.extractItemToFile(archiveItem.name, QString::fromNSString([_tmpFilesDir stringByAppendingPathComponent:itemName])))
-                            {
-                                NSLog(@"Error processing directory item");
-                                continue;
-                            }
-                        }
-                    }
+                    destinationByItemName[nestedItem.name] =
+                        QString::fromNSString([_tmpFilesDir stringByAppendingPathComponent:nestedName]);
+                    [requiredNames addObject:nestedName];
                 }
-                else
-                {
-                    if (!archive.extractItemToFile(archiveItem.name, QString::fromNSString(tmpFileName)))
-                    {
-                        NSLog(@"Error processing items");
-                        continue;
-                    }
-                }
-                [reader readFromFile:tmpFileName error:&err];
-                [item applyAdditionalParams:tmpFileName];
             }
-            
-            if (err)
-                [item.warnings addObject:[NSString stringWithFormat:OALocalizedString(@"err_profile_import"), item.name]];
         }
+        else
+        {
+            destinationByItemName[archiveItem.name] = QString::fromNSString(tmpFileName);
+            [requiredNames addObject:fileName];
+        }
+
+        [plannedReads addObject:@{ @"item" : item, @"reader" : reader, @"path" : tmpFileName, @"required" : requiredNames }];
     }
-    
+
+    QStringList failedNames;
+    if (!destinationByItemName.isEmpty() && !archive.extractItemsTo(destinationByItemName, &failedNames))
+        NSLog(@"Archive %@ could not be read to the end, some items are missing", file);
+
+    NSMutableSet<NSString *> *failedNameSet = [NSMutableSet set];
+    for (const auto& failedName : OsmAnd::constOf(failedNames))
+        [failedNameSet addObject:failedName.toNSString()];
+
+    NSInteger failedItems = 0;
+    for (NSDictionary *plannedRead in plannedReads)
+    {
+        OASettingsItem *item = plannedRead[@"item"];
+        NSString *tmpFileName = plannedRead[@"path"];
+
+        NSString *missingName = nil;
+        for (NSString *requiredName in (NSArray<NSString *> *) plannedRead[@"required"])
+        {
+            if ([failedNameSet containsObject:requiredName])
+            {
+                missingName = requiredName;
+                break;
+            }
+        }
+        if (missingName)
+        {
+            NSLog(@"Failed to extract %@ from %@", missingName, file);
+            [item.warnings addObject:[NSString stringWithFormat:OALocalizedString(@"err_profile_import"), item.name]];
+            failedItems++;
+            continue;
+        }
+
+        NSError *err = nil;
+        [((OASettingsItemReader *) plannedRead[@"reader"]) readFromFile:tmpFileName error:&err];
+        [item applyAdditionalParams:tmpFileName];
+
+        if (err)
+            [item.warnings addObject:[NSString stringWithFormat:OALocalizedString(@"err_profile_import"), item.name]];
+    }
+
     [fileManager removeItemAtPath:_tmpFilesDir error:nil];
-    
+
+    if (failedItems > 0)
+        NSLog(@"%ld of %lu items failed to extract from %@", (long) failedItems, (unsigned long) plannedReads.count, file);
+
     return items;
 }
 


### PR DESCRIPTION
## Problem

Importing a large `.osf` lands only part of it and reports success. Reproduced on a 940-entry export declaring 782 tracks: **445 tracks were written**, the "Import complete" screen said `Tracks — Added items: 782`.

The loss is not random — it is a contiguous tail. The files on disk were exactly archive entries #3…#447; nothing from #448 on arrived. A second run cut at a different point, which is why it looked random.

Cause: `-processItems:` called `ArchiveReader::extractItemToFile` once per archive entry, and that call reopens the archive and rescans it from the beginning. 940 entries meant 940 opens and O(n²) header reads — and any transient failure at open time was not confined to one entry, because every later entry needed its own reopen of the same archive.

The count on the completion screen is taken from `items.json`, never from what actually landed, so nothing surfaced the loss. The failure path itself was `NSLog(@"Error processing items")` with no file name and no reason.

## Change

`-processItems:` now works in three phases:

1. **Plan** — one pass over the entry list with no I/O. For each entry the matching `OASettingsItem` is found with the same `applyFileName:` in the same order (`OAResourcesSettingsItem` sets `filePath` as a side effect there, so order matters), building a name→temp-path map and an ordered work list. For a directory entry everything beneath it goes into the map.
2. **Extract** — a single `ArchiveReader::extractItemsTo` call.
3. **Read** — walk the work list in the original order: if a required file did not extract, the item gets a warning and is counted as failed; otherwise `readFromFile:` and `applyAdditionalParams:` as before.

Item order is preserved, which matters for `renameFile` when two items resolve to the same destination. Peak temp usage is unchanged — the temp folder was only cleaned at the end before, too. Failures are logged with the entry name, plus a summary line.

## Verification

Same export, tracks folder and GPX database wiped first: **782 of 782 tracks imported**, and the folder contents match `items.json` exactly.

```
declared GPX in items.json : 782
.gpx on disk               : 782
declared but missing       : 0
on disk but not declared   : 0
```

Confirmed on two independent clean runs.

## Note

Depends on osmandapp/OsmAnd-core#1118, which adds `extractItemsTo`. Merge that first.