### PR TITLE
Fix list ordering in import/export and incomplete Select all in Tracks

### DIFF
--- a/Sources/Backup/LocalBackup/OASettingsHelper.mm
+++ b/Sources/Backup/LocalBackup/OASettingsHelper.mm
@@ -571,14 +571,21 @@ NSInteger const kSettingsHelperErrorCodeEmptyJson = 5;
     MutableOrderedDictionary<OAExportSettingsType *, NSArray *> *myPlacesItems = [MutableOrderedDictionary new];
     MutableOrderedDictionary<OAExportSettingsType *, NSArray *> *resourcesItems = [MutableOrderedDictionary new];
 
-    [settingsToOperate enumerateKeysAndObjectsUsingBlock:^(OAExportSettingsType * _Nonnull type, NSArray * _Nonnull obj, BOOL * _Nonnull stop) {
+    // Follow the declared order of the types: enumerating settingsToOperate would give hash order,
+    // which differs from run to run
+    for (OAExportSettingsType *type in OAExportSettingsType.getAllValues)
+    {
+        NSArray *typeItems = settingsToOperate[type];
+        if (!typeItems)
+            continue;
+
         if (type.isSettingsCategory)
-            settingsItems[type] = obj;
+            settingsItems[type] = typeItems;
         else if (type.isMyPlacesCategory)
-            myPlacesItems[type] = obj;
+            myPlacesItems[type] = typeItems;
         else if (type.isResourcesCategory)
-            resourcesItems[type] = obj;
-    }];
+            resourcesItems[type] = typeItems;
+    }
 
     MutableOrderedDictionary<OAExportSettingsCategory *, OASettingsCategoryItems *> *exportMap = [MutableOrderedDictionary new];
     if (settingsItems.count > 0 || addEmptyItems)

--- a/Sources/Controllers/MyPlaces/TracksViewController.swift
+++ b/Sources/Controllers/MyPlaces/TracksViewController.swift
@@ -1723,11 +1723,9 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
                     let allFolders = currentFolder.getSubFolders()
                     selectedFolders = allFolders.map { $0.getDirName(includingSubdirs: false) }
                     selectedTracks = currentFolder.getTrackItems().compactMap({ $0.dataItem }).filter { track in
-                        !selectedFolders.contains(where: { folderName in
-                            track.gpxFilePath.contains(folderName)
-                        })
+                        !isTrack(track, insideSelectedFolderOf: currentFolder)
                     }
-                    
+
                     for row in 0..<tableView.numberOfRows(inSection: 0) {
                         tableView.selectRow(at: IndexPath(row: row, section: 0), animated: true, scrollPosition: .none)
                     }
@@ -2396,6 +2394,16 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
         settings.saveTracksSortModes(updatedSortModes)
     }
    
+    // Whole path components only: a plain substring test also matched folder names occurring
+    // inside a track's own file name, which left those tracks out of "Select all"
+    private func isTrack(_ track: GpxDataItem, insideSelectedFolderOf currentFolder: TrackFolder) -> Bool {
+        let trackPath = track.gpxFilePath.deletingLastPathComponent()
+        return selectedFolders.contains { folderName in
+            let folderPath = currentFolder.relativePath.appendingPathComponent(folderName)
+            return trackPath == folderPath || trackPath.hasPrefix(folderPath + "/")
+        }
+    }
+
     private func areAllItemsSelected() -> Bool {
         if isSelectionModeInSearch {
             if let allTracks = baseFiltersResult?.values {
@@ -2410,15 +2418,7 @@ final class TracksViewController: UITableViewController, OATrackSavingHelperUpda
             let allDisplayedTracks = currentFolder.getTrackItems().compactMap { $0.dataItem }
             let allDisplayedFolders = currentFolder.getSubFolders()
             let allTracksSelected = allDisplayedTracks.allSatisfy { track in
-                if selectedTracks.contains(track) {
-                    return true
-                }
-                
-                return selectedFolders.contains { folderName -> Bool in
-                    let folderPath = currentFolder.relativePath.appendingPathComponent(folderName)
-                    let trackPath = track.gpxFilePath.deletingLastPathComponent()
-                    return trackPath.hasPrefix(folderPath)
-                }
+                selectedTracks.contains(track) || isTrack(track, insideSelectedFolderOf: currentFolder)
             }
             
             let allFoldersSelected = allDisplayedFolders.allSatisfy { folder in


### PR DESCRIPTION
Two independent list bugs in the same area.

---

## 1. Import and export type lists come out in a different order every run

On the import selection screen (and the export screen) the data types inside a category are arranged differently each time: `Tracks, Navigation history, Search history, Favourites, OSM Edits, Markers history, Map markers` one run, something else the next.

`+[OASettingsHelper getSettingsToOperateByCategory:addEmptyItems:]` fills the per-category `MutableOrderedDictionary` by enumerating `settingsToOperate`, which is a plain `NSDictionary` — so insertion happens in hash order, and `OASettingsCategoryItems.getTypes` (`allKeys` of the ordered dictionary) hands that order straight to the table.

**Fix:** walk `OAExportSettingsType.getAllValues` and pick the types that are present. That is the canonical order the rest of the export/import code already uses, and it matches Android, where `SettingsHelper.collectExportData` iterates `ExportType.availableValuesOf(category)` into a `LinkedHashMap`.

My Places now reads:

```
Favourites
Tracks
OSM Edits            (plus OSM Notes when the plugin is on)
Map markers
Markers history
Search history
Navigation history
```

Notes:
- Fixes both screens at once — the import picker and the export picker take their data from this method.
- Category order (Settings / My Places / Resources) was never affected; those are inserted explicitly.
- "Import complete" is unaffected; it builds its rows in a hardcoded sequence already.
- All 21 types `getSettingsToOperate:` can produce are present in `getAllValues`, so nothing is dropped.
- `MutableOrderedDictionary.allKeys` returns `[_keys array]`, i.e. insertion order, so fixing insertion is enough.

---

## 2. "Select all" in Tracks does not select everything

Selecting all in a track folder leaves tracks unselected, so deleting or sharing has to be repeated. Observed on a folder of 782 tracks: `Select all` covered 653 of them.

`onSelectDeselectAllButtonClicked` selects every subfolder, then adds the tracks of the current folder minus the ones considered to live inside a selected subfolder:

```swift
track.gpxFilePath.contains(folderName)
```

That is a substring test over the whole path, file name included. A root track called `test1.gpx` matches the folder `test`; anything with `color` in its name matches the folder `color`. Those tracks are silently dropped from the selection. The exclusion is not even needed in principle — `TrackFolder.getTrackItems()` is not recursive, so a direct child can never be inside a subfolder.

**Fix:** compare whole path components, and share one `isTrack(_:insideSelectedFolderOf:)` helper with `areAllItemsSelected()`, which already did the path comparison properly. The helper also requires a separator after the prefix, so folder `test` no longer matches a track sitting in `test2`.