### PR TITLE
Hotfix incorrect 1-char region search (port Java fix)

### DIFF
--- a/Sources/Search/OAQuickSearchHelper.mm
+++ b/Sources/Search/OAQuickSearchHelper.mm
@@ -262,10 +262,6 @@ static NSString * const GPX_TEMP_FOLDER_NAME = @"Temp";
 
 - (BOOL)isMatch:(OASearchPhrase *)phrase text:(NSString *)text
 {
-    if ([phrase getFullSearchPhrase].length <= 1 && [phrase isNoSelectedType])
-    {
-        return YES;
-    }
     OANameStringMatcher *matcher = [[OANameStringMatcher alloc] initWithNamePart:[phrase getFullSearchPhrase] mode:CHECK_EQUALS_FROM_SPACE];
     return [matcher matches:text];
 }


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/issues/25485 (part of the Issue)

https://github.com/osmandapp/OsmAnd/pull/25818/changes (part of Java PR)

## AI disclaimer

Produced with Codex (GPT-6).

Prompts used (summarised):
1. Analyze Android PR #25818 and check whether the same bugs exist in iOS.
2. Fix the one-character query matching bypass in iOS.
3. Review callers of the modified method and assess effects beyond map-name search.
4. Generate an AI disclaimer following the Android repository rules, excluding local workflow details.

Decided by the agent, not requested explicitly: None.

**Before**
<img width="1024" height="800" alt="osmand-search-0-before" src="https://github.com/user-attachments/assets/dc3a39a4-9d43-4464-a935-79fbfd575c85" />

**After**
<img width="1024" height="800" alt="osmand-search-0-fixed" src="https://github.com/user-attachments/assets/591e1847-7261-45c1-80a7-467061270622" />
